### PR TITLE
格式化msgspec导入

### DIFF
--- a/src/nonebot_plugin_parser/matchers/rule.py
+++ b/src/nonebot_plugin_parser/matchers/rule.py
@@ -1,7 +1,8 @@
 import re
 from typing import Literal
 
-import msgspec
+from msgspec import Struct, DecodeError
+from msgspec.json import Decoder
 from nonebot import logger
 from nonebot.rule import Rule
 from nonebot.params import Depends
@@ -20,29 +21,29 @@ PSR_SEARCHED_KEY: Literal["psr-searched"] = "psr-searched"
 
 
 # 定义 JSON 卡片的数据结构
-class MetaDetail(msgspec.Struct):
+class MetaDetail(Struct):
     qqdocurl: str | None = None
 
 
-class MetaNews(msgspec.Struct):
+class MetaNews(Struct):
     jumpUrl: str | None = None
 
 
-class MetaMusic(msgspec.Struct):
+class MetaMusic(Struct):
     jumpUrl: str | None = None
 
 
-class Meta(msgspec.Struct):
+class Meta(Struct):
     detail_1: MetaDetail | None = None
     news: MetaNews | None = None
     music: MetaMusic | None = None
 
 
-class RawData(msgspec.Struct):
+class RawData(Struct):
     meta: Meta | None = None
 
 
-raw_decoder = msgspec.json.Decoder(RawData)
+raw_decoder = Decoder(RawData)
 
 
 class SearchResult:
@@ -88,7 +89,7 @@ def _extract_url(hyper: Hyper) -> str | None:
 
     try:
         raw = raw_decoder.decode(raw_str)
-    except msgspec.DecodeError:
+    except DecodeError:
         logger.exception(f"json 卡片解析失败: {raw_str}")
         return None
 

--- a/src/nonebot_plugin_parser/parsers/douyin/video.py
+++ b/src/nonebot_plugin_parser/parsers/douyin/video.py
@@ -1,7 +1,8 @@
 from random import choice
 from typing import Any
 
-from msgspec import Struct, json, field
+from msgspec import Struct, field
+from msgspec.json import Decoder
 
 from ..base import ParseException
 
@@ -142,4 +143,4 @@ class RouterData(Struct):
         )
 
 
-decoder = json.Decoder(RouterData)
+decoder = Decoder(RouterData)

--- a/src/nonebot_plugin_parser/parsers/kuaishou/__init__.py
+++ b/src/nonebot_plugin_parser/parsers/kuaishou/__init__.py
@@ -1,7 +1,7 @@
 import re
 from typing import ClassVar
 
-import msgspec
+from msgspec import convert
 from httpx import AsyncClient
 
 from ..base import BaseParser, PlatformEnum, ParseException, handle
@@ -51,7 +51,7 @@ class KuaiShouParser(BaseParser):
             raise ParseException("failed to parse video JSON info from HTML")
 
         raw = decode_init_state(matched[1].strip())
-        data_map = msgspec.convert(raw, Data)
+        data_map = convert(raw, Data)
 
         photo = data_map.info.photo
         if photo is None:

--- a/src/nonebot_plugin_parser/parsers/weibo/article.py
+++ b/src/nonebot_plugin_parser/parsers/weibo/article.py
@@ -1,4 +1,5 @@
-from msgspec import Struct, json
+from msgspec import Struct
+from msgspec.json import Decoder
 
 
 class UserInfo(Struct):
@@ -20,4 +21,4 @@ class Detail(Struct):
     data: Data
 
 
-decoder = json.Decoder(Detail)
+decoder = Decoder(Detail)

--- a/src/nonebot_plugin_parser/parsers/weibo/common.py
+++ b/src/nonebot_plugin_parser/parsers/weibo/common.py
@@ -1,6 +1,7 @@
 from re import sub
 
-from msgspec import Struct, json
+from msgspec import Struct
+from msgspec.json import Decoder
 
 
 class LargeInPic(Struct):
@@ -103,4 +104,4 @@ class WeiboResponse(Struct):
     data: WeiboData
 
 
-decoder = json.Decoder(WeiboResponse)
+decoder = Decoder(WeiboResponse)

--- a/src/nonebot_plugin_parser/parsers/zhihu/answer.py
+++ b/src/nonebot_plugin_parser/parsers/zhihu/answer.py
@@ -1,4 +1,5 @@
-from msgspec import Struct, json
+from msgspec import Struct
+from msgspec.json import Decoder
 
 
 class Author(Struct):
@@ -82,4 +83,4 @@ class InitState(Struct):
     initialState: InitStateData
 
 
-decoder = json.Decoder(InitState)
+decoder = Decoder(InitState)


### PR DESCRIPTION
## Summary by Sourcery

通过简化导入方式以及统一解码和转换调用，在各个解析器中标准化 msgspec 的使用。

增强内容：
- 将完整限定的 msgspec struct 和 decoder 引用替换为直接使用 Struct、Decoder 和 DecodeError，以保持一致性。
- 更新微博、知乎、抖音和快手解析器，在整个代码中统一使用 msgspec.json.Decoder 和 convert 辅助函数。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Standardize msgspec usage across parsers by simplifying imports and unifying decoder and conversion calls.

Enhancements:
- Replace fully qualified msgspec struct and decoder references with direct Struct, Decoder, and DecodeError usage for consistency.
- Update Weibo, Zhihu, Douyin, and Kuaishou parsers to use unified msgspec.json.Decoder and convert helpers throughout.

</details>