### PR TITLE
feat(parser): 快手解析器添加评论区渲染

### DIFF
--- a/src/nonebot_plugin_parser/constants.py
+++ b/src/nonebot_plugin_parser/constants.py
@@ -38,7 +38,6 @@ class PlatformEnum(str, Enum):
     KUAISHOU = "kuaishou"
     KUGOU = "kugou"
     NETEASE = "netease"
-    NGA = "nga"
     TIKTOK = "tiktok"
     X = "x"
     WEIBO = "weibo"

--- a/src/nonebot_plugin_parser/parsers/__init__.py
+++ b/src/nonebot_plugin_parser/parsers/__init__.py
@@ -1,5 +1,3 @@
-# 导出所有 Parser 类
-from .nga import NGAParser as NGAParser
 from .base import BaseParser as BaseParser
 from .base import handle
 from .data import (
@@ -40,7 +38,6 @@ __all__ = [
     "KuWoParser",
     "KuaiShouParser",
     "NCMParser",
-    "NGAParser",
     "ParseResult",
     "Platform",
     "QSMusicParser",

--- a/src/nonebot_plugin_parser/parsers/base.py
+++ b/src/nonebot_plugin_parser/parsers/base.py
@@ -96,8 +96,8 @@ def handle(keyword: str, pattern: str, max_retries: int = 1):
         key_patterns: KeyPatterns = getattr(func, _KEY_PATTERNS)
         key_patterns.append((keyword, compile(pattern)))
 
-        # 应用重试装饰器，但保留原始函数的_key_patterns属性
-        wrapped_func = retry(max_retries=max_retries)(func)
+        # 应用重试装饰器
+        wrapped_func = func
         # 取消重试，防止死号
         # 复制_key_patterns属性到包装函数
         setattr(wrapped_func, _KEY_PATTERNS, key_patterns)

--- a/src/nonebot_plugin_parser/parsers/data.py
+++ b/src/nonebot_plugin_parser/parsers/data.py
@@ -4,8 +4,6 @@ from datetime import datetime
 from dataclasses import field, dataclass
 from collections.abc import Sequence
 
-from markupsafe import Markup
-
 from ..download.task import DownloadTaskWrapper
 
 

--- a/src/nonebot_plugin_parser/parsers/kuaishou/__init__.py
+++ b/src/nonebot_plugin_parser/parsers/kuaishou/__init__.py
@@ -2,13 +2,20 @@ import re
 from typing import ClassVar
 
 from msgspec import convert
-from httpx import AsyncClient
 
-from ..base import BaseParser, PlatformEnum, ParseException, handle
-from ..data import Platform, MediaContent
+from ..base import (
+    BaseParser,
+    PlatformEnum,
+    ParseException,
+    handle,
+    Comment,
+    Platform,
+    MediaContent,
+)
 from .decode import decode_init_state
-from .states import Data
+from .states import Data, CommentList
 from ...utils import format_num
+from ...browser import BROWSER
 
 
 class KuaiShouParser(BaseParser):
@@ -37,21 +44,24 @@ class KuaiShouParser(BaseParser):
 
         # /fw/long-video/ 返回结果不一样, 统一替换为 /fw/photo/ 请求
         real_url = real_url.replace("/fw/long-video/", "/fw/photo/")
-        async with AsyncClient(
-            headers=self.ios_headers, timeout=self.timeout
-        ) as client:
-            response = await client.get(real_url)
-            response.raise_for_status()
-            response_text = response.text
-
-        pattern = r"window\.INIT_STATE\s*=\s*(.*?)</script>"
-        matched = re.search(pattern, response_text)
-
-        if not matched:
-            raise ParseException("failed to parse video JSON info from HTML")
-
-        raw = decode_init_state(matched[1].strip())
+        tab = BROWSER.new_tab()
+        tab.set.user_agent(
+            "Mozilla/5.0 (iPhone; CPU iPhone OS 16_6 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.6 Mobile/15E148 Safari/604.1 Edg/132.0.0.0",
+            "iPhone",
+        )
+        tab.set.load_mode.none()
+        tab.listen.start("/rest/wd/photo/comment/list")
+        tab.get(real_url)
+        cms = tab.listen.wait()
+        assert cms
+        assert not isinstance(cms, list)
+        tab.listen.stop()
+        tab.stop_loading()
+        data = tab.run_js("window.INIT_STATE", as_expr=True)
+        raw = decode_init_state(data)
+        tab.close()
         data_map = convert(raw, Data)
+        data_map.comments = convert(cms.response.body, CommentList)
 
         photo = data_map.info.photo
         if photo is None:
@@ -72,6 +82,7 @@ class KuaiShouParser(BaseParser):
 
         # 构建作者
         author = self.create_author(name=photo.name, avatar_url=photo.headUrl)
+        comments = self.format_comments(data_map.comments)
 
         return self.result(
             title=photo.caption,
@@ -84,4 +95,40 @@ class KuaiShouParser(BaseParser):
                 share_count=format_num(photo.shareCount),
             ),
             timestamp=photo.timestamp // 1000,
+            comments=comments,
         )
+
+    def format_comments(self, comments: CommentList) -> list[Comment]:
+        """格式化评论"""
+        result: list[Comment] = []
+        parent_comments = comments.rootComments[:5]
+        for rc in parent_comments:
+            rootComment = self.create_comment(
+                author=self.create_author(
+                    name=rc.author_name,
+                    avatar_url=rc.headurl,
+                ),
+                content=[rc.content],
+                timestamp=rc.timestamp // 1000,
+                stats=self.create_stats(
+                    like_count=format_num(rc.likedCount),
+                    comment_count=format_num(rc.subCommentCount),
+                ),
+            )
+
+            for sc in comments.subCommentsMap.get(str(rc.comment_id), [])[:3]:
+                rootComment.replies.append(
+                    self.create_comment(
+                        author=self.create_author(
+                            name=sc.author_name,
+                            avatar_url=sc.headurl,
+                        ),
+                        content=[sc.content],
+                        timestamp=sc.timestamp // 1000,
+                        stats=self.create_stats(
+                            like_count=format_num(sc.likedCount),
+                        ),
+                    )
+                )
+            result.append(rootComment)
+        return result

--- a/src/nonebot_plugin_parser/parsers/kuaishou/states.py
+++ b/src/nonebot_plugin_parser/parsers/kuaishou/states.py
@@ -73,14 +73,51 @@ class Info(Struct):
     photo: Photo | None = None
 
 
-class EmotionConfigList(Struct):
-    emojiCode: str
-    emojiUrlList: list[str]
+# class EmotionConfigList(Struct):
+#     emojiCode: str
+#     emojiUrlList: list[str]
 
 
-class SystemStartup(Struct):
-    emotionConfigList: list[EmotionConfigList]
-    """贴纸映射列表"""
+# class SystemStartup(Struct):
+#     emotionConfigList: list[EmotionConfigList]
+#     """贴纸映射列表(不全)"""
+
+
+class Comment(Struct):
+    content: str
+    timestamp: int
+    likedCount: int
+    authorArea: str
+    """归属地"""
+    comment_id: int
+    """评论id"""
+    headurl: str
+    """头像"""
+    user_sex: str
+    author_name: str
+    subCommentCount: int = 0
+    """子评论数量"""
+
+
+class SubCommentList(Struct):
+    subComments: list[Comment]
+    """子评论列表"""
+
+    def __iter__(self):
+        return iter(self.subComments)
+
+    def __getitem__(self, index):
+        return self.subComments[index]
+
+    def __len__(self):
+        return len(self.subComments)
+
+
+class CommentList(Struct):
+    subCommentsMap: dict[str, SubCommentList]
+    """子评论映射map, {父评论id: 子评论列表}"""
+    rootComments: list[Comment]
+    """父评论列表"""
 
 
 class Data(Struct):
@@ -94,11 +131,12 @@ class Data(Struct):
     - `/rest/wd/user/profile/author` 作者信息
     """
 
-    startup: SystemStartup = field(name="/rest/wd/system/startup")
-    """系统信息"""
+    # startup: SystemStartup = field(name="/rest/wd/system/startup")
+    # """系统信息"""
     info: Info = field(name="/rest/wd/ugH5App/photo/simple/info")
     """视频/图集信息"""
-    comments: dict | None = field(default=None, name="/rest/wd/photo/comment/list")
+    comments: CommentList | None = field(
+        default=None, name="/rest/wd/photo/comment/list"
+    )
     """评论信息，为页面二次加载赋值
-    > TODO: 待完善模型
     """

--- a/src/nonebot_plugin_parser/renders/base.py
+++ b/src/nonebot_plugin_parser/renders/base.py
@@ -43,7 +43,7 @@ class Renderer:
             image_seg = await self.cache_or_render_image(result)
             # 获取图片路径
         except Exception as e:
-            logger.error(f"获取图片路径失败: {e}")
+            logger.error(f"获取图片路径失败: {type(e)}:{e!r}")
             image_seg = None
 
         # 尝试直接发送图片


### PR DESCRIPTION
- 移除NGA平台支持及相关解析器
- 快手解析器改用浏览器自动化技术获取数据
- 添加评论解析和格式化功能
- 移除HTTP重试机制
- 清理无用依赖项
- resolve #4

BREAKING CHANGE: 移除了NGA平台支持

## Summary by Sourcery

将快手内容解析切换为基于浏览器驱动的流程，并新增结构化评论渲染，同时移除已废弃的 NGA 平台支持和 HTTP 重试逻辑。

新功能：
- 为快手视频新增评论获取与格式化功能，在解析结果中包含带层级关系的父评论和子评论。

增强：
- 重构快手解析器，通过共享的浏览器自动化层获取 `INIT_STATE` 数据和评论载荷，而不再直接使用 HTTP 请求。
- 收紧渲染错误日志记录，在图片路径处理失败时加入异常类型和 `repr` 信息。
- 优化快手数据模型，引入结构化评论类型，并移除未使用的系统启动/表情结构。

杂务：
- 从平台枚举和解析器导出中移除 NGA 平台支持。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Switch KuaiShou content parsing to a browser-driven flow and add structured comment rendering while removing deprecated NGA platform support and HTTP retry behavior.

New Features:
- Add comment fetching and formatting for KuaiShou videos, including threaded parent and child comments in parser results.

Enhancements:
- Refactor KuaiShou parser to obtain INIT_STATE data and comment payloads via the shared browser automation layer instead of direct HTTP requests.
- Tighten render error logging by including exception type and repr for image path failures.
- Refine KuaiShou data models to introduce structured comment types and drop unused system startup/emoji structures.

Chores:
- Remove NGA platform support from platform enums and parser exports.

</details>