### PR TITLE
feat(matchers): 添加浏览器自动关闭功能并 修复快手解析器请求头设置问题

### DIFF
--- a/src/nonebot_plugin_parser/matchers/__init__.py
+++ b/src/nonebot_plugin_parser/matchers/__init__.py
@@ -16,6 +16,7 @@ from ..download import DOWNLOADER
 from ..parsers.data import AudioContent, VideoContent
 from nonebot import on_notice
 from nonebot_plugin_alconna.uniseg import message_reaction
+from ..browser import BROWSER
 
 
 def _get_enabled_parser_classes() -> list[type[BaseParser]]:
@@ -42,7 +43,10 @@ def get_parser_by_type(parser_type: type[T]) -> T:
     raise ValueError(f"未找到类型为 {parser_type} 的 parser 实例")
 
 
-@get_driver().on_startup
+driver = get_driver()
+
+
+@driver.on_startup
 def register_parser_matcher():
     enabled_classes = _get_enabled_parser_classes()
 
@@ -57,6 +61,11 @@ def register_parser_matcher():
     patterns = [p for _cls in enabled_classes for p in _cls._key_patterns]
     matcher = on_keyword_regex(*patterns)
     matcher.append_handler(parser_handler)
+
+
+@driver.on_shutdown
+def close_browser():
+    BROWSER.quit()
 
 
 # 缓存结果

--- a/src/nonebot_plugin_parser/parsers/kuaishou/__init__.py
+++ b/src/nonebot_plugin_parser/parsers/kuaishou/__init__.py
@@ -26,10 +26,6 @@ class KuaiShouParser(BaseParser):
         name=PlatformEnum.KUAISHOU, display_name="快手"
     )
 
-    def __init__(self):
-        super().__init__()
-        self.ios_headers["Referer"] = "https://v.kuaishou.com/"
-
     # https://v.kuaishou.com/2yAnzeZ
     @handle("v.kuaishou", r"v\.kuaishou\.com/[A-Za-z\d._?%&+\-=/#]+")
     @handle("kuaishou", r"(?:www\.)?kuaishou\.com/[A-Za-z\d._?%&+\-=/#]+")
@@ -46,7 +42,7 @@ class KuaiShouParser(BaseParser):
         real_url = real_url.replace("/fw/long-video/", "/fw/photo/")
         tab = BROWSER.new_tab()
         tab.set.user_agent(
-            "Mozilla/5.0 (iPhone; CPU iPhone OS 16_6 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.6 Mobile/15E148 Safari/604.1 Edg/132.0.0.0",
+            self.ios_headers["User-Agent"],
             "iPhone",
         )
         tab.set.load_mode.none()


### PR DESCRIPTION
- - 添加了浏览器在应用关闭时的自动关闭功能，
优化了驱动器获取方式以支持启动和关闭事件注册，
- 统一使用BROWSER实例进行浏览器操作
- 移除了硬编码的iOS用户代理字符串，
改用解析器基类中的请求头配置， 确保请求头的一致性配置

## Summary by Sourcery

在驱动启动/关闭时增加浏览器生命周期管理，并使快手解析器的请求头与共享解析器配置保持一致。

新功能：
- 在应用程序关闭时自动关闭共享的浏览器实例。

增强改进：
- 通过共享的驱动实例注册启动和关闭处理程序，用于匹配器和浏览器的生命周期管理。
- 在各个匹配器中统一使用共享的 `BROWSER` 实例进行浏览器操作。
- 对快手请求使用基础解析器的 iOS 请求头配置，而不是硬编码的 User-Agent 字符串。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add browser lifecycle management on driver startup/shutdown and align KuaiShou parser headers with the shared parser configuration.

New Features:
- Automatically close the shared browser instance when the application shuts down.

Enhancements:
- Register startup and shutdown handlers via a shared driver instance for matcher and browser lifecycle management.
- Use the shared BROWSER instance consistently for browser operations across matchers.
- Use the base parser's iOS header configuration for KuaiShou requests instead of hardcoded user-agent strings.

</details>