### PR TITLE
fix(bilibili): 支持B站视频分集短链

### DIFF
--- a/src/nonebot_plugin_parser_lite/parsers/bilibili/__init__.py
+++ b/src/nonebot_plugin_parser_lite/parsers/bilibili/__init__.py
@@ -64,8 +64,8 @@ class BilibiliParser(BaseParser):
         self._credential: Credential | None = None
         self._cookies_file = pconfig.config_dir / "bilibili_cookies.json"
 
-    @handle("b23.tv", r"b23\.tv/[A-Za-z\d\._?%&+\-=/#]+")
-    @handle("bili2233", r"bili2233\.cn/[A-Za-z\d\._?%&+\-=/#]+")
+    @handle("b23.tv", r"b23\.tv/[0-9a-zA-Z._?%&+\-=/#]+")
+    @handle("bili2233", r"bili2233\.cn/[0-9a-zA-Z._?%&+\-=/#]+")
     async def _parse_short_link(self, searched: Match[str]):
         """解析短链"""
         url = f"https://{searched.group(0)}"
@@ -74,7 +74,7 @@ class BilibiliParser(BaseParser):
     @handle("BV", r"^(?P<bvid>BV[0-9a-zA-Z]{10})(?:\s)?(?P<page_num>\d{1,3})?$")
     @handle(
         "/BV",
-        r"bilibili\.com(?:/video)?/(?P<bvid>BV[0-9a-zA-Z]{10})(?:\?p=(?P<page_num>\d{1,3}))?",
+        r"bilibili\.com(?:/video)?/(?P<bvid>BV[0-9A-Za-z]{10})(?:[/?].*)?(?:[?&]p=(?P<page_num>\d{1,3}))?",
     )
     async def _parse_bv(self, searched: Match[str]):
         """解析视频信息"""


### PR DESCRIPTION
- 修正了 b23.tv 和 bili2233 短链接的正则表达式，使用 [0-9a-zA-Z] 替代 [A-Za-z\d] 以提高匹配准确性

- 更新了 BV 号解析的正则表达式，添加了对 URL 中间部分的匹配支持， 使 /BV 链接能够正确解析包含查询参数的复杂URL

## Summary by Sourcery

通过收紧短链接匹配规则并支持带查询参数的更复杂 BV 视频 URL，改进 Bilibili URL 解析。

错误修复：
- 修正 b23.tv 和 bili2233 域名的 Bilibili 短链接正则表达式模式，以提升匹配准确性。
- 更新 BV 视频 URL 的正则表达式，以处理中间路径段和查询参数，从而使带分页参数的 `/BV` 链接能够被正确解析。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve Bilibili URL parsing by tightening short-link patterns and supporting more complex BV video URLs with query parameters.

Bug Fixes:
- Correct Bilibili short-link regex patterns for b23.tv and bili2233 domains to improve matching accuracy.
- Update BV video URL regex to handle intermediate path segments and query parameters so /BV links with page numbers are parsed correctly.

</details>