### PR TITLE
feat(render): 添加视频封面渲染功能

### DIFF
--- a/src/nonebot_plugin_parser_lite/render/__init__.py
+++ b/src/nonebot_plugin_parser_lite/render/__init__.py
@@ -185,7 +185,13 @@ class Renderer:
 
         # 视频封面
         if isinstance(cont, VideoContent):
-            path = await cont.get_cover_path()
+            try:
+                path = await cont.get_cover_path()
+            except Exception as e:
+                logger.warning(
+                    f"get_cover_path() failed for {type(cont).__name__}: {e}"
+                )
+                return []
             return [UniHelper.img_seg(path)] if path else []
         # 图片
         if isinstance(cont, ImageContent):


### PR DESCRIPTION
- 添加对 `VideoContent` 类型的支持，当内容为视频时，获取视频封面路径并构建可加入转发消息的图片片段。
- 将 `result.get_cover_path()` 替换为 `safe_path(result, "get_cover_path")` 以确保封面路径的安全获取。

## Summary by Sourcery

添加视频封面渲染支持，并在访问渲染结果中的封面路径时提升安全性。

新功能：
- 支持为视频内容构建可转发的分段：在可用时，将其封面图像作为图片分段使用。

改进：
- 使用安全助手方法获取解析结果的封面路径，而不是直接调用封面路径方法，以避免在路径不可用时可能发生的失败。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add video cover rendering support and improve safety when accessing cover paths in render results.

New Features:
- Support building forwardable segments for video content by using its cover image as an image segment when available.

Enhancements:
- Use a safe helper to obtain parse result cover paths instead of directly calling the cover path method, avoiding potential failures when the path is unavailable.

</details>