### PR TITLE
feat(bilibili): 添加作者黑名单检查与提示支持

### DIFF
--- a/src/nonebot_plugin_parser_lite/helper.py
+++ b/src/nonebot_plugin_parser_lite/helper.py
@@ -21,7 +21,7 @@ from nonebot_plugin_alconna.uniseg import (
 
 from .config import pconfig
 from .constants import EMOJI_MAP
-# from .exception import TipException
+from .exception import TipException
 
 ForwardNodeInner = str | Segment | UniMessage
 """转发消息节点内部允许的类型"""
@@ -169,15 +169,15 @@ class UniHelper:
             await cls.message_reaction(event, "resolving")
 
             try:
-                result = await func(*args, **kwargs)
-            # except TipException as e:
-            #     await UniMessage.text(e.message).send()
-            #     raise
+                await func(*args, **kwargs)
+            except TipException as e:
+                await UniMessage.text(e.message).send()
+                await cls.message_reaction(event, "fail")
             except Exception:
                 await cls.message_reaction(event, "fail")
                 raise
-
-            await cls.message_reaction(event, "done")
-            return result
+            else:
+                await cls.message_reaction(event, "done")
+            return
 
         return wrapper

--- a/src/nonebot_plugin_parser_lite/parsers/bilibili/__init__.py
+++ b/src/nonebot_plugin_parser_lite/parsers/bilibili/__init__.py
@@ -655,7 +655,8 @@ class BilibiliParser(BaseParser):
                     author_mid = module.module_author.mid
                     break
 
-        await self.raise_if_in_black_list(author_mid)
+        if author_mid:
+            await self.raise_if_in_black_list(author_mid)
 
         if not author_name and hasattr(opus_data, "name_avatar"):
             author_name, author_face = opus_data.name_avatar

--- a/src/nonebot_plugin_parser_lite/parsers/bilibili/__init__.py
+++ b/src/nonebot_plugin_parser_lite/parsers/bilibili/__init__.py
@@ -116,7 +116,7 @@ class BilibiliParser(BaseParser):
             await self.load_black_list()
             assert self.black_mids is not None
         if mid in self.black_mids:
-            raise TipException("用户在黑名单中，请勿使用")
+            raise TipException("该up属于黑名单")
 
     @handle("b23.tv", r"b23\.tv/[0-9a-zA-Z._?%&+\-=/#]+")
     @handle("bili2233", r"bili2233\.cn/[0-9a-zA-Z._?%&+\-=/#]+")

--- a/src/nonebot_plugin_parser_lite/parsers/bilibili/__init__.py
+++ b/src/nonebot_plugin_parser_lite/parsers/bilibili/__init__.py
@@ -30,6 +30,7 @@ from ..base import (
     BaseParser,
     Comment,
     DownloadException,
+    TipException,
     DurationLimitException,
     MediaContent,
     ParseException,
@@ -63,6 +64,59 @@ class BilibiliParser(BaseParser):
         self.headers = HEADERS.copy()
         self._credential: Credential | None = None
         self._cookies_file = pconfig.config_dir / "bilibili_cookies.json"
+        self.black_mids: list[int] | None = None
+        """黑名单作者列表"""
+
+    async def load_black_list(self) -> None:
+        """初始化黑名单"""
+        ck = await self.credential
+        if not ck:
+            logger.info("B站未登录，跳过黑名单加载")
+            self.black_mids = []
+            return
+
+        cookies = ck.get_cookies()
+        if not cookies:
+            logger.info("B站 Cookie 为空，跳过黑名单加载")
+            self.black_mids = []
+            return
+
+        request_headers = self.headers.copy()
+        request_headers["Cookie"] = "; ".join(f"{k}={v}" for k, v in cookies.items())
+
+        url = "https://api.bilibili.com/x/relation/blacks"
+        try:
+            async with AsyncClient() as client:
+                response = await client.get(url, headers=request_headers)
+            response.raise_for_status()
+            data: dict[str, Any] = response.json() or {}
+
+            code = data.get("code")
+            if code != 0:
+                logger.error(f"获取B站黑名单列表失败: code={code}, data={data}")
+                self.black_mids = []
+                return
+
+            black_list = data.get("data", {}).get("list") or []
+            self.black_mids = [obj["mid"] for obj in black_list if "mid" in obj]
+            logger.debug(f"B站黑名单列表: {black_list}")
+            logger.info(f"已加载 {len(self.black_mids)} 个 B 站黑名单用户")
+        except Exception as e:
+            logger.exception(f"请求 B 站黑名单接口异常: {e}")
+            if self.black_mids is None:
+                self.black_mids = []
+
+    async def raise_if_in_black_list(self, mid: int):
+        """
+        检查用户是否在黑名单中
+
+        :raise TipException: 用户在黑名单中
+        """
+        if self.black_mids is None:
+            await self.load_black_list()
+            assert self.black_mids is not None
+        if mid in self.black_mids:
+            raise TipException("用户在黑名单中，请勿使用")
 
     @handle("b23.tv", r"b23\.tv/[0-9a-zA-Z._?%&+\-=/#]+")
     @handle("bili2233", r"bili2233\.cn/[0-9a-zA-Z._?%&+\-=/#]+")
@@ -172,6 +226,9 @@ class BilibiliParser(BaseParser):
         video = await self._get_video(bvid=bvid, avid=avid)
         # 转换为 msgspec struct
         video_info = convert(await video.get_info(), VideoInfo)
+
+        await self.raise_if_in_black_list(video_info.owner.mid)
+
         # 获取简介
         text = f"简介: {video_info.desc}" if video_info.desc else ""
         # up
@@ -295,6 +352,8 @@ class BilibiliParser(BaseParser):
         dynamic_info_data = await dynamic.get_info()
         logger.debug(f"B站动态链接 dynamic_info_data 原始：{dynamic_info_data}")
         dynamic_info = convert(dynamic_info_data, DynamicData).item
+
+        await self.raise_if_in_black_list(dynamic_info.modules.module_author.mid)
 
         # 作者
         author = self.create_author(
@@ -586,21 +645,23 @@ class BilibiliParser(BaseParser):
         # 提取作者信息
         author_name = ""
         author_face = ""
-        author_mid = ""
+        author_mid = 0
 
         if hasattr(opus_data.item, "modules"):
             for module in opus_data.item.modules:
                 if module.module_type == "MODULE_TYPE_AUTHOR" and module.module_author:
                     author_name = module.module_author.name
                     author_face = module.module_author.face
-                    author_mid = str(module.module_author.mid)
+                    author_mid = module.module_author.mid
                     break
+
+        await self.raise_if_in_black_list(author_mid)
 
         if not author_name and hasattr(opus_data, "name_avatar"):
             author_name, author_face = opus_data.name_avatar
 
         author = self.create_author(
-            name=author_name, id=author_mid, avatar_url=author_face
+            name=author_name, id=str(author_mid), avatar_url=author_face
         )
 
         # 按顺序处理图文内容（参考 parse_read 的逻辑）
@@ -719,6 +780,9 @@ class BilibiliParser(BaseParser):
         info_dict = await room.get_room_info()
 
         room_data = convert(info_dict, RoomData)
+
+        await self.raise_if_in_black_list(room_data.mid)
+
         contents: list[MediaContent | str] = [room_data.detail]
         # 下载封面
         if cover := room_data.cover:
@@ -728,7 +792,9 @@ class BilibiliParser(BaseParser):
         if keyframe := room_data.keyframe:
             contents.append(self.create_image(keyframe))
 
-        author = self.create_author(name=room_data.name, avatar_url=room_data.avatar)
+        author = self.create_author(
+            name=room_data.name, avatar_url=room_data.avatar, id=str(room_data.mid)
+        )
 
         url = f"https://www.bilibili.com/blackboard/live/live-activity-player.html?enterTheRoom=0&cid={room_id}"
 
@@ -767,11 +833,15 @@ class BilibiliParser(BaseParser):
 
         favdata = convert(fav_dict, FavData)
 
+        await self.raise_if_in_black_list(favdata.info.upper.mid)
+
         return self.result(
             title=favdata.title,
             timestamp=favdata.timestamp,
             author=self.create_author(
-                name=favdata.info.upper.name, avatar_url=favdata.info.upper.face
+                name=favdata.info.upper.name,
+                avatar_url=favdata.info.upper.face,
+                id=str(favdata.info.upper.mid),
             ),
             content=[
                 self.create_graphic(fav.cover, fav.desc) for fav in favdata.medias

--- a/src/nonebot_plugin_parser_lite/parsers/bilibili/__init__.py
+++ b/src/nonebot_plugin_parser_lite/parsers/bilibili/__init__.py
@@ -84,23 +84,64 @@ class BilibiliParser(BaseParser):
         request_headers = self.headers.copy()
         request_headers["Cookie"] = "; ".join(f"{k}={v}" for k, v in cookies.items())
 
-        url = "https://api.bilibili.com/x/relation/blacks"
+        base_url = "https://api.bilibili.com/x/relation/blacks"
+        page_size = 50
+        black_mids: list[int] = []
+
         try:
             async with AsyncClient() as client:
-                response = await client.get(url, headers=request_headers)
-            response.raise_for_status()
-            data: dict[str, Any] = response.json() or {}
+                resp = await client.get(
+                    base_url,
+                    headers=request_headers,
+                    params={"ps": page_size, "pn": 1},
+                )
+                resp.raise_for_status()
+                data: dict[str, Any] = resp.json()
 
-            code = data.get("code")
-            if code != 0:
-                logger.error(f"获取B站黑名单列表失败: code={code}, data={data}")
-                self.black_mids = []
-                return
+                code = data.get("code")
+                if code != 0:
+                    logger.error(f"获取B站黑名单列表失败: code={code}, data={data}")
+                    self.black_mids = []
+                    return
 
-            black_list = data.get("data", {}).get("list") or []
-            self.black_mids = [obj["mid"] for obj in black_list if "mid" in obj]
-            logger.debug(f"B站黑名单列表: {black_list}")
-            logger.info(f"已加载 {len(self.black_mids)} 个 B 站黑名单用户")
+                data_root = data.get("data", {})
+                first_list = data_root.get("list", [])
+                total = data_root.get("total", 0)
+
+                black_mids.extend(obj["mid"] for obj in first_list)
+
+                # 计算剩余页数
+                pages = (total + page_size - 1) // page_size if total > page_size else 1
+                for pn in range(2, pages + 1):
+                    try:
+                        resp = await client.get(
+                            base_url,
+                            headers=request_headers,
+                            params={"ps": page_size, "pn": pn},
+                        )
+                        resp.raise_for_status()
+                        page_data: dict[str, Any] = resp.json()
+                        if page_data.get("code") != 0:
+                            logger.warning(
+                                f"获取B站黑名单第 {pn} 页失败: {page_data!r}"
+                            )
+                            continue
+                        page_list = page_data.get("data", {}).get("list", [])
+                        black_mids.extend(obj["mid"] for obj in page_list)
+                        logger.debug(
+                            f"[BiliParser] 黑名单第 {pn} 页加载完成, 当前共 {len(black_mids)} 个"
+                        )
+                        await asyncio.sleep(0.2)
+                    except Exception as e:  # noqa: BLE001
+                        logger.warning(f"请求B站黑名单第 {pn} 页异常: {e}")
+                        continue
+
+            self.black_mids = black_mids
+            logger.debug(f"B站黑名单列表: {black_mids}")
+            logger.info(
+                f"已加载 {len(self.black_mids)} 个 B 站黑名单用户 (pages={pages})"
+            )
+
         except Exception as e:
             logger.exception(f"请求 B 站黑名单接口异常: {e}")
             if self.black_mids is None:

--- a/src/nonebot_plugin_parser_lite/parsers/bilibili/live.py
+++ b/src/nonebot_plugin_parser_lite/parsers/bilibili/live.py
@@ -2,6 +2,10 @@ from msgspec import Struct
 
 
 class RoomInfo(Struct):
+    uid: int
+    """主播mid"""
+    room_id: int
+    """直播间id"""
     title: str
     """标题"""
     cover: str
@@ -70,3 +74,11 @@ class RoomData(Struct):
     @property
     def avatar(self) -> str:
         return self.anchor_info.base_info.face
+
+    @property
+    def mid(self) -> int:
+        return self.room_info.uid
+
+    @property
+    def room_id(self) -> int:
+        return self.room_info.room_id


### PR DESCRIPTION
添加了黑名单检查功能，以防止解析来自黑名单用户的视频、动态或直播内容。
- 在 `helper.py` 中取消了 `TipException` 的注释，并修改了 `UniHelper` 类中的装饰器，以便在捕获 `TipException` 时发送消息并标记为失败。
- 在 `bilibili/__init__.py` 中添加了 `TipException` 的导入，并在 `BilibiliParser` 类中添加了 `black_mids` 属性，用于存储黑名单作者列表。
- 在 `BilibiliParser` 类中添加了 `load_black_list` 方法，用于初始化黑名单。
- 在 `BilibiliParser` 类中添加了 `raise_if_in_black_list` 方法，用于检查用户是否在黑名单中，并在用户在黑名单中时抛出 `TipException`。
- 在 `BilibiliParser` 类的多个方法中调用了 `raise_if_in_black_list` 方法，以确保在处理视频、动态或直播内容前检查作者是否在黑名单中。
- 修改了 `RoomData` 类，添加了 `uid` 和 `room_id` 属性，并更新了 `mid` 和 `room_id` 属性的 getter 方法，以便在 `live.py` 中使用。
- @sourcery-ai /summary

## Summary by Sourcery

添加对 B 站作者黑名单的支持，以防止解析被屏蔽用户的内容，并将黑名单命中结果以用户可见的提示形式展示，而不是通用的失败消息。

新功能：
- 引入从官方 API 加载的 B 站作者黑名单，并存储在解析器实例上。
- 在视频、动态、专栏（opus）、直播以及收藏夹解析过程中统一执行黑名单检查，跳过来自被屏蔽作者的内容。
- 通过 `RoomData` 暴露额外的直播间元数据（`uid` 和 `room_id`），用于黑名单检查和作者身份识别。

增强：
- 将辅助装饰器改造为捕获 `TipException`，将异常信息发送给用户，并将本次操作标记为失败，同时仍能正确更新消息的表情/反应状态。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add Bilibili author blacklist support to prevent parsing content from blocked users and surface blacklist hits as user-facing tips instead of generic failures.

New Features:
- Introduce a Bilibili author blacklist loaded from the official API and stored on the parser instance.
- Enforce blacklist checks across video, dynamic, opus, live, and favorite list parsing to skip content from blocked authors.
- Expose additional live room metadata (uid and room_id) through RoomData for use in blacklist checks and author identification.

Enhancements:
- Convert the helper decorator to catch TipException, send its message to the user, and mark the operation as failed while still updating message reaction states appropriately.

</details>