### PR TITLE
feat(bilibili): 添加定时同步B站黑名单功能

### DIFF
--- a/src/nonebot_plugin_parser_lite/parsers/bilibili/__init__.py
+++ b/src/nonebot_plugin_parser_lite/parsers/bilibili/__init__.py
@@ -47,7 +47,6 @@ from .live import RoomData
 from .opus import ImageNode, OpusItem, TextNode
 from .video import AIConclusion, VideoInfo
 
-from nonebot_plugin_apscheduler import scheduler
 
 # 选择客户端
 select_client("curl_cffi")
@@ -68,6 +67,7 @@ class BilibiliParser(BaseParser):
         self._cookies_file = pconfig.config_dir / "bilibili_cookies.json"
         self.black_mids: list[int] | None = None
         """黑名单作者列表"""
+        self._black_list_job_added: bool = False
 
     async def load_black_list(self) -> None:
         """初始化黑名单"""
@@ -144,6 +144,23 @@ class BilibiliParser(BaseParser):
                 f"已加载 {len(self.black_mids)} 个 B 站黑名单用户 (pages={pages})"
             )
 
+            # 首次成功加载黑名单后，注册定时刷新任务（最多注册一次）
+            if not self._black_list_job_added:
+                try:
+                    from nonebot_plugin_apscheduler import scheduler
+
+                    scheduler.add_job(
+                        self.load_black_list,
+                        "interval",
+                        hours=1,
+                        id="sync-bili-black-list",
+                        replace_existing=True,
+                    )
+                    self._black_list_job_added = True
+                    logger.info("已注册 B 站黑名单定时同步任务（每 1 小时刷新一次）")
+                except Exception as e:  # noqa: BLE001
+                    logger.warning(f"注册 B 站黑名单定时任务失败: {e}")
+
         except Exception as e:
             logger.exception(f"请求 B 站黑名单接口异常: {e}")
             if self.black_mids is None:
@@ -158,9 +175,6 @@ class BilibiliParser(BaseParser):
         if self.black_mids is None:
             await self.load_black_list()
             assert self.black_mids is not None
-            scheduler.add_job(
-                self.load_black_list, "interval", hours=1, id="sync-bili-black-list"
-            )
         if mid in self.black_mids:
             raise TipException("该up属于黑名单")
 
@@ -976,6 +990,7 @@ class BilibiliParser(BaseParser):
                     yield "登录成功"
                     self._credential = self._qr_login.get_credential()
                     self._save_credential()
+                    await self.load_black_list()
                     break
                 case QrCodeLoginEvents.CONF:
                     if scan_tip_pending:

--- a/src/nonebot_plugin_parser_lite/parsers/bilibili/__init__.py
+++ b/src/nonebot_plugin_parser_lite/parsers/bilibili/__init__.py
@@ -47,6 +47,8 @@ from .live import RoomData
 from .opus import ImageNode, OpusItem, TextNode
 from .video import AIConclusion, VideoInfo
 
+from nonebot_plugin_apscheduler import scheduler
+
 # 选择客户端
 select_client("curl_cffi")
 # 模拟浏览器，第二参数数值参考 curl_cffi 文档
@@ -156,6 +158,9 @@ class BilibiliParser(BaseParser):
         if self.black_mids is None:
             await self.load_black_list()
             assert self.black_mids is not None
+            scheduler.add_job(
+                self.load_black_list, "interval", hours=1, id="sync-bili-black-list"
+            )
         if mid in self.black_mids:
             raise TipException("该up属于黑名单")
 


### PR DESCRIPTION
- 引入 nonebot_plugin_apscheduler 调度器
- 实现每小时自动更新B站黑名单列表的定时任务
- 避免手动重新加载导致的延迟问题

## Summary by Sourcery

在首次加载 B 站黑名单后，以及成功扫码登录后，自动定期同步 B 站黑名单。

新功能：
- 使用 APScheduler 安排每小时执行一次的后台任务，在黑名单成功加载后定期刷新 B 站黑名单。
- 在二维码登录成功后立即触发一次 B 站黑名单的初始加载。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add automatic periodic synchronization of the Bilibili blacklist after it is first loaded and on successful QR login.

New Features:
- Schedule an hourly background job via APScheduler to refresh the Bilibili blacklist once it has been loaded successfully.
- Trigger an initial Bilibili blacklist load immediately after successful QR code login.

</details>
- 当黑名单首次加载时，使用现有的调度器安排一个每小时运行一次的后台任务，以重新加载 Bilibili 黑名单。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在首次加载 B 站黑名单后，以及成功扫码登录后，自动定期同步 B 站黑名单。

新功能：
- 使用 APScheduler 安排每小时执行一次的后台任务，在黑名单成功加载后定期刷新 B 站黑名单。
- 在二维码登录成功后立即触发一次 B 站黑名单的初始加载。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add automatic periodic synchronization of the Bilibili blacklist after it is first loaded and on successful QR login.

New Features:
- Schedule an hourly background job via APScheduler to refresh the Bilibili blacklist once it has been loaded successfully.
- Trigger an initial Bilibili blacklist load immediately after successful QR code login.

</details>

</details>
- 添加一个基于 APScheduler 的定时任务，每小时刷新一次 Bilibili 黑名单。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在首次加载 B 站黑名单后，以及成功扫码登录后，自动定期同步 B 站黑名单。

新功能：
- 使用 APScheduler 安排每小时执行一次的后台任务，在黑名单成功加载后定期刷新 B 站黑名单。
- 在二维码登录成功后立即触发一次 B 站黑名单的初始加载。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add automatic periodic synchronization of the Bilibili blacklist after it is first loaded and on successful QR login.

New Features:
- Schedule an hourly background job via APScheduler to refresh the Bilibili blacklist once it has been loaded successfully.
- Trigger an initial Bilibili blacklist load immediately after successful QR code login.

</details>
- 当黑名单首次加载时，使用现有的调度器安排一个每小时运行一次的后台任务，以重新加载 Bilibili 黑名单。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在首次加载 B 站黑名单后，以及成功扫码登录后，自动定期同步 B 站黑名单。

新功能：
- 使用 APScheduler 安排每小时执行一次的后台任务，在黑名单成功加载后定期刷新 B 站黑名单。
- 在二维码登录成功后立即触发一次 B 站黑名单的初始加载。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add automatic periodic synchronization of the Bilibili blacklist after it is first loaded and on successful QR login.

New Features:
- Schedule an hourly background job via APScheduler to refresh the Bilibili blacklist once it has been loaded successfully.
- Trigger an initial Bilibili blacklist load immediately after successful QR code login.

</details>

</details>

</details>