### PR TITLE
fix(rednote): 修复表情解析未在正文生效

### DIFF
--- a/src/nonebot_plugin_parser_lite/parsers/rednote/__init__.py
+++ b/src/nonebot_plugin_parser_lite/parsers/rednote/__init__.py
@@ -95,7 +95,7 @@ class RedNoteParser(BaseParser):
         """从 note_data 构建最终解析结果"""
         note_detail = note_data.noteData
 
-        contents: list[MediaContent | str] = replace_placeholder_to_sticker(
+        contents = replace_placeholder_to_sticker(
             note_detail.desc, REDNOTE_PATTERN, "rednote"
         )
         contents.extend(note_detail.medias)

--- a/src/nonebot_plugin_parser_lite/parsers/rednote/__init__.py
+++ b/src/nonebot_plugin_parser_lite/parsers/rednote/__init__.py
@@ -4,6 +4,8 @@ from urllib.parse import parse_qsl
 
 from httpx import AsyncClient
 
+from ...utils.format import replace_placeholder_to_sticker
+
 from ..base import (
     BaseParser,
     Comment,
@@ -15,7 +17,7 @@ from ..base import (
     pconfig,
 )
 from ..cookie import ck2dict
-from .discovery import NoteDetailWrapper, decoder as discoveryDecoder
+from .discovery import NoteDetailWrapper, decoder as discoveryDecoder, REDNOTE_PATTERN
 
 INITIAL_STATE = re.compile(
     pattern=r"window\.__INITIAL_STATE__=(.*?)</script>",
@@ -93,7 +95,9 @@ class RedNoteParser(BaseParser):
         """从 note_data 构建最终解析结果"""
         note_detail = note_data.noteData
 
-        contents: list[MediaContent | str] = [note_detail.desc]
+        contents: list[MediaContent | str] = replace_placeholder_to_sticker(
+            note_detail.desc, REDNOTE_PATTERN, "rednote"
+        )
         contents.extend(note_detail.medias)
 
         author = self.create_author(


### PR DESCRIPTION
- 引入 utils.format 模块中的 replace_placeholder_to_sticker 函数
- 导入 REDNOTE_PATTERN 正则表达式模式
- 使用表情符号替换功能处理笔记描述内容
- resolve #44

## Summary by Sourcery

错误修复：
- 确保 Rednote 笔记描述中的表情符号/贴纸能够被正确解析和渲染，而不是保留为原始占位符。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Ensure emojis/stickers in Rednote note descriptions are correctly parsed and rendered instead of remaining as raw placeholders.

</details>