### PR TITLE
feat(render): 美化转发样式

### DIFF
--- a/src/nonebot_plugin_parser_lite/render/templates/default.html.jinja
+++ b/src/nonebot_plugin_parser_lite/render/templates/default.html.jinja
@@ -37,13 +37,6 @@
                 border: none;
                 outline: none;
             }
-
-            .repost-env {
-                background-color: #f7f7f7;
-                padding: 1rem;
-                border-radius: 0.75rem;
-                border: 1px solid #e5e7eb;
-            }
         </style>
     </head>
     <body class="flex justify-center break-all">{{ render_content(result) }}</body>

--- a/src/nonebot_plugin_parser_lite/render/templates/macros.jinja
+++ b/src/nonebot_plugin_parser_lite/render/templates/macros.jinja
@@ -268,7 +268,7 @@
 {# 3. 内容+转发宏（Tailwind 样式 + is_repost） #}
 {% macro render_content(result, is_repost=False) %}
     {% set comments = result.comments %}
-    <div class="{{ 'w-[540px]' if is_repost else 'w-[600px]' }} bg-white overflow-hidden flex flex-col rounded-lg {% if not is_repost %}shadow-lg{% endif %}">
+    <div class="{{ 'w-[536px] bg-[#f7f7f7]' if is_repost else 'w-[600px] bg-white' }} overflow-hidden flex flex-col rounded-lg {% if not is_repost %}shadow-lg{% endif %}">
         {# Header #}
         <div class="px-8 pt-8 pb-2 flex justify-between items-center">
             <div class="flex items-center space-x-3">
@@ -316,7 +316,7 @@
         {# 转发内容：嵌套一层卡片，用 is_repost=True #}
         {% if result.repost %}
             <div class="quoue shadow-sm m-8 mt-0 rounded-xl outline-1 outline-slate-200">
-                <div class="repost-env">{{ render_content(result.repost, True) }}</div>
+                {{ render_content(result.repost, True) }}
             </div>
         {% endif %}
         {# 主体内容和评论之间的间隔 #}

--- a/src/nonebot_plugin_parser_lite/render/templates/tailwind.css
+++ b/src/nonebot_plugin_parser_lite/render/templates/tailwind.css
@@ -382,8 +382,8 @@
   .w-14 {
     width: calc(var(--spacing) * 14);
   }
-  .w-\[540px\] {
-    width: 540px;
+  .w-\[536px\] {
+    width: 536px;
   }
   .w-\[600px\] {
     width: 600px;
@@ -601,6 +601,9 @@
         transparent
       );
     }
+  }
+  .bg-\[\#f7f7f7\] {
+    background-color: #f7f7f7;
   }
   .object-cover {
     object-fit: cover;


### PR DESCRIPTION
- 调整转发内容宽度从 540px 到 536px，保持与原设计一致的视觉效果。

## Summary by Sourcery

调整转发卡片的布局和样式，使其在视觉上与原始设计更加一致。

新功能：
- 为转发卡片新增专用的浅灰色背景工具类。

改进：
- 将转发卡片宽度从 540px 调整为 536px，以符合原始设计规范。
- 通过移除额外的包装容器来简化转发的标记结构，同时保持由现有宏控制的圆角与阴影卡片外观。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust repost card layout and styling for better visual consistency with the original design.

New Features:
- Introduce a dedicated light gray background utility class for repost cards.

Enhancements:
- Change repost card width from 540px to 536px to align with the original design specs.
- Simplify repost markup by removing the extra wrapper container while keeping rounded and shadowed card appearance driven by existing macros.

</details>