### PR TITLE
feat(render): 为贴纸渲染添加描述性 alt 文本

### DIFF
--- a/src/nonebot_plugin_parser_lite/render/templates/macros.jinja
+++ b/src/nonebot_plugin_parser_lite/render/templates/macros.jinja
@@ -239,7 +239,7 @@
             {% set size_class = 'h-6' if size == 'small' else 'h-12' %}
             {% set _ = html_parts.append(
                             '<img class="inline-block align-text-bottom ' ~ size_class ~ '"
-                 src="' ~ src ~ '" />'
+                 src="' ~ src ~ '" alt="' ~ cont.desc ~ '"/>'
                         ) %}
             {# 5. 视频封面 + 播放按钮 #}
         {% elif cls == 'VideoContent' %}

--- a/src/nonebot_plugin_parser_lite/render/templates/macros.jinja
+++ b/src/nonebot_plugin_parser_lite/render/templates/macros.jinja
@@ -239,7 +239,7 @@
             {% set size_class = 'h-6' if size == 'small' else 'h-12' %}
             {% set _ = html_parts.append(
                             '<img class="inline-block align-text-bottom ' ~ size_class ~ '"
-                 src="' ~ src ~ '" alt="' ~ cont.desc ~ '"/>'
+                 src="' ~ src ~ '" alt="' ~ (cont.desc|e) ~ '"/>'
                         ) %}
             {# 5. 视频封面 + 播放按钮 #}
         {% elif cls == 'VideoContent' %}


### PR DESCRIPTION
在图片标签中增加了`alt`属性，其值为`cont.desc`，以提高图片的可访问性。这样不仅有助于屏幕阅读器描述图片内容，还能在图片无法显示时提供替代文本。@sourcery-ai /summary

## Summary by Sourcery

增强内容：
- 在宏模板中为渲染的图片添加描述性 alt 文本，以提升可访问性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Add descriptive alt text to rendered images in the macro template to enhance accessibility.

</details>