### PR TITLE
feat(render): 优化图文转发构建并确保转发媒体发送

### DIFF
--- a/src/nonebot_plugin_parser_lite/matchers/__init__.py
+++ b/src/nonebot_plugin_parser_lite/matchers/__init__.py
@@ -1,5 +1,6 @@
 import asyncio
 from dataclasses import dataclass
+from itertools import chain
 import re
 from typing import ClassVar, TypeVar
 
@@ -146,7 +147,10 @@ async def _send_parse_result(session: Uninfo, result: ParseResult) -> None:
     summary_msg = await RENDERER.render_messages(result)
     await summary_msg.send()
     # 全文本内容，无需再发送媒体
-    if all(isinstance(c, str) for c in result.content):
+    if all(
+        isinstance(c, str)
+        for c in chain(result.content, result.repost.content if result.repost else [])
+    ):
         return
     if pconfig.lazy_download:
         download_cmd = ", ".join(pconfig.download_command)

--- a/src/nonebot_plugin_parser_lite/render/__init__.py
+++ b/src/nonebot_plugin_parser_lite/render/__init__.py
@@ -22,6 +22,7 @@ from ..parsers.data import (
     LivePhotoContent,
     MediaContent,
     ParseResult,
+    StickerContent,
     VideoContent,
 )
 
@@ -73,9 +74,7 @@ class Renderer:
         """
         # 尝试获取图片路径，以便在直接发送失败时使用文件发送
         try:
-            # 复用 cache_or_render_image 方法获取图片段，同时确保图片已保存
             image_seg = await self.cache_or_render_image(result)
-            # 获取图片路径
         except Exception:
             logger.error(f"获取图片路径失败: {traceback.format_exc()}")
             image_seg = None
@@ -96,7 +95,6 @@ class Renderer:
         - 需要立即发送的音视频（逐条 yield）
         - 可合并转发的图文 / 图片（统一收集后一次发送）
         """
-        forwardable_segs: list[ForwardNodeInner] = []
         failed_count = 0
         repost_medias = result.repost.content if result.repost else []
         media_contents = [
@@ -107,7 +105,7 @@ class Renderer:
         for cont in media_contents:
             # 先处理需要立即发送的音视频
             try:
-                async for msg in self._handle_immediate_media(cont):
+                async for msg in self.__handle_immediate_media(cont):
                     yield msg
             except DownloadLimitException as e:
                 yield UniMessage(str(e))
@@ -116,21 +114,9 @@ class Renderer:
                 failed_count += 1
                 continue
 
-            # 再尝试构建可转发的图文 / 图片片段
-            try:
-                seg = await self._build_forwardable_segment(cont)
-            except DownloadException:
-                failed_count += 1
-                continue
-
-            if seg:
-                forwardable_segs.extend(seg)
-
-        # 处理图文转发部分
-        if forwardable_segs:
-            # 根据“当前 + 转发”的文本/媒体顺序构建完整列表
-            ordered_segs = self._build_ordered_forward_segs(result, forwardable_segs)
-
+        # 2构建图文 / 图片的转发列表（含主帖 + 转发，按顺序）
+        ordered_segs = await self.__build_forward_segs(result)
+        if ordered_segs:
             if pconfig.need_forward_contents or len(ordered_segs) > 4:
                 forward_msg = UniHelper.construct_forward_message(ordered_segs)
                 yield UniMessage(forward_msg)
@@ -143,7 +129,7 @@ class Renderer:
             yield UniMessage(message)
             raise DownloadException(message)
 
-    async def _handle_immediate_media(
+    async def __handle_immediate_media(
         self, cont: MediaContent
     ) -> AsyncGenerator[UniMessage[Any], None]:
         """
@@ -157,8 +143,6 @@ class Renderer:
             return
 
         path = await cont.get_path()
-        logger.debug(f"立即发送{type(cont).__name__}: {path}")
-
         if (
             isinstance(cont, VideoContent)
             and pconfig.need_upload_video
@@ -172,100 +156,106 @@ class Renderer:
         elif isinstance(cont, AudioContent):
             yield UniMessage(UniHelper.record_seg(path))
 
-    async def _build_forwardable_segment(
-        self, cont: MediaContent
-    ) -> list[ForwardNodeInner]:
-        """构建可加入转发消息的片段（图片 / 图文 / LivePhoto）。"""
-
-        # 视频封面
-        if isinstance(cont, VideoContent):
-            try:
-                path = await cont.get_cover_path()
-            except Exception as e:
-                logger.warning(
-                    f"get_cover_path() failed for {type(cont).__name__}: {e}"
-                )
-                return []
-            return [UniHelper.img_seg(path)] if path else []
-
-        # 文本
-        if isinstance(cont, str):
-            return [cont]
-
-        # 图片
-        if isinstance(cont, ImageContent):
-            path = await cont.get_path()
-            return [UniHelper.img_seg(path)]
-
-        # 图文：图片 + 可选文字说明
-        if isinstance(cont, GraphicContent):
-            path = await cont.get_path()
-            seg: ForwardNodeInner = UniHelper.img_seg(path)
-            if cont.alt:
-                seg = seg + cont.alt
-            return [seg]
-
-        # Live Photo：根据配置决定用视频还是图+视频
-        if isinstance(cont, LivePhotoContent):
-            if pconfig.live_photo:
-                live_path = await cont.get_live()
-                return [UniHelper.video_seg(live_path)]
-            base_path = await cont.get_base()
-            live_path = await cont.get_path()
-            return [
-                UniHelper.img_seg(base_path),
-                UniHelper.video_seg(live_path),
-            ]
-
-        return []
-
-    def _build_ordered_forward_segs(
+    async def __build_forward_segs(
         self,
         result: ParseResult,
-        media_segs: list[ForwardNodeInner],
     ) -> list[ForwardNodeInner]:
-        """根据当前内容和转发内容构造有序的转发段列表。
+        """根据当前内容和转发内容构造有序的转发段列表（文本 + 媒体，保持顺序）
 
-        顺序：
-        1. 当前帖子的纯文本（作者：文本）
-        2. 当前帖子的所有媒体片段
-        3. 若有转发：
-           3.1 一条“作者[转发原作者]：当前文本”说明
-           3.2 原帖文本（原作者[被转作者]：原帖标题+内容）
+        规则：
+        - 主帖：
+          - 文本片段按顺序聚合，输出 "作者：文本" 节点
+          - 媒体片段（Image/Graphic/LivePhoto/Video 封面等）按出现顺序插入对应消息段
+        - 如有转发：
+          - 插入一条说明
+          - 然后对转发 ParseResult 做同样处理
         """
+
+        async def build_nodes(pr: ParseResult) -> list[ForwardNodeInner]:
+            author_name = pr.author.name
+            nodes: list[ForwardNodeInner] = []
+            text_buffer: list[str] = []
+
+            async def flush_text() -> None:
+                nonlocal text_buffer
+                if text_buffer:
+                    text = "\n".join(text_buffer).strip()
+                    if text:
+                        nodes.append(f"{author_name}：{text}")
+                    text_buffer = []
+
+            async def append_media(cont: MediaContent) -> None:
+                """将单个媒体内容转换为若干 ForwardNodeInner，并追加到 nodes"""
+                try:
+                    # 视频：使用封面图作为转发节点
+                    if isinstance(cont, VideoContent):
+                        path = await cont.get_cover_path()
+                        if path:
+                            nodes.append(UniHelper.img_seg(path))
+                        return
+
+                    # 图片
+                    if isinstance(cont, ImageContent):
+                        path = await cont.get_path()
+                        nodes.append(UniHelper.img_seg(path))
+                        return
+
+                    # 图文：图片 + 可选文字说明
+                    if isinstance(cont, GraphicContent):
+                        path = await cont.get_path()
+                        seg: ForwardNodeInner = UniHelper.img_seg(path)
+                        if cont.alt:
+                            seg = seg + cont.alt
+                        nodes.append(seg)
+                        return
+
+                    # Live Photo
+                    if isinstance(cont, LivePhotoContent):
+                        if pconfig.live_photo:
+                            live_path = await cont.get_live()
+                            nodes.append(UniHelper.video_seg(live_path))
+                        else:
+                            base_path = await cont.get_base()
+                            live_path = await cont.get_path()
+                            nodes.append(UniHelper.img_seg(base_path))
+                            nodes.append(UniHelper.video_seg(live_path))
+                        return
+                except Exception as e:
+                    # 统一当作媒体构建失败处理
+                    logger.warning(f"构建转发媒体片段失败: {type(cont).__name__}: {e}")
+                    nodes.append(f"[媒体加载失败：{type(cont).__name__}]")
+
+            # 按 content 顺序遍历
+            for item in pr.content:
+                if isinstance(item, str):
+                    # 文本：缓冲，遇到媒体或结束时 flush
+                    if item:
+                        text_buffer.append(item)
+                elif isinstance(item, StickerContent):
+                    text_buffer.append(item.desc or "[表情]")
+                elif isinstance(item, MediaContent) and item.need_send:
+                    # 媒体：先输出之前的文本，再输出媒体段
+                    await flush_text()
+                    await append_media(item)
+                else:
+                    # 其他类型暂不处理
+                    continue
+
+            # 收尾文本
+            await flush_text()
+            return nodes
+
         ordered: list[ForwardNodeInner] = []
-        author_name = result.author.name if result.author else "未知用户"
-
-        # 1. 当前文本
-        if plain := "".join(
-            f"\n{c}" for c in result.content if isinstance(c, str) and c
-        ):
-            ordered.append(f"{author_name}：{plain}")
-
-        # 2. 当前媒体
-        ordered.extend(media_segs)
-
-        # # 3. 转发内容
-        # if not result.repost:
-        #     return ordered
-
-        # repost = result.repost
-        # repost_author = repost.author.name if repost.author else "未知用户"
-
-        # # 3.1 当前作者带“转发”说明 + 自己的文字
-        # current_plain = build_plain_text(list(result.content))
-        # ordered.append(f"{repost_author}[转发{author_name}]：{current_plain}")
-
-        # # 3.2 原帖文字：标题 + 内容
-        # repost_text_parts: list[str] = []
-        # if repost.title:
-        #     repost_text_parts.append(repost.title)
-        # if plain_repost := build_plain_text(list(repost.content)):
-        #     repost_text_parts.append(plain_repost)
-        # if repost_text_parts:
-        #     repost_text = "\n".join(repost_text_parts)
-        #     ordered.append(f"{repost_author}[被转作者]：{repost_text}")
-
+        # 1. 主帖节点
+        ordered.extend(await build_nodes(result))
+        # 2. 转发内容
+        repost = result.repost
+        if not repost:
+            return ordered
+        # 2.1 转发说明
+        ordered.append(">>>>>原帖<<<<<")
+        # 2.2 原帖节点
+        ordered.extend(await build_nodes(repost))
         return ordered
 
     @property
@@ -279,7 +269,7 @@ class Renderer:
     async def render_image(self, result: ParseResult) -> bytes:
         """使用 HTML 绘制通用社交媒体帖子卡片"""
         # 准备模板数据
-        template_data = await self._resolve_parse_result(result)
+        template_data = await self.resolve_parse_result(result)
 
         # 处理模板针对
         template_name = "default.html.jinja"
@@ -338,7 +328,7 @@ class Renderer:
             quality=85,
         )
 
-    async def _resolve_parse_result(self, result: ParseResult) -> dict[str, Any]:
+    async def resolve_parse_result(self, result: ParseResult) -> dict[str, Any]:
         """解析 ParseResult 为模板可用的字典数据"""
 
         data: dict[str, Any] = {
@@ -366,7 +356,7 @@ class Renderer:
         }
 
         if result.repost:
-            data["repost"] = await self._resolve_parse_result(result.repost)
+            data["repost"] = await self.resolve_parse_result(result.repost)
 
         # 添加二维码支持
         if pconfig.append_qrcode and result.url:


### PR DESCRIPTION
- resolve #58 

@sourcery-ai /summary

## Summary by Sourcery

改进解析结果的转换和发送方式，尤其针对混合文本/媒体的帖子和转发内容。

新功能：
- 在构建转发消息节点时包含贴纸内容描述。

错误修复：
- 通过在提前返回前同时检查主帖和转发内容，确保在主帖为纯文本但转发中包含媒体时，媒体仍能被发送。

改进与优化：
- 优化转发消息的构建方式，直接从解析结果（包括转发内容）中生成有序的文本与媒体节点，并在媒体发送失败时进行更优雅的处理。
- 将“解析结果到模板的解析器”公开为一个公共方法，并对转发数据递归使用该方法。
- 通过将即时媒体处理与可转发消息的构建分离，简化即时媒体的处理流程。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve how parsed results are transformed and sent, especially for mixed text/media posts and reposts.

New Features:
- Include sticker content descriptions when building forward message nodes.

Bug Fixes:
- Ensure media is still sent when the main post has text-only content but the repost contains media by checking both contents before early-returning.

Enhancements:
- Refine forward message construction to derive ordered text and media nodes directly from the parse result, including reposts, and handle media failures more gracefully.
- Expose the parse-result-to-template resolver as a public method and use it recursively for repost data.
- Simplify immediate media handling by separating it from forwardable message construction.

</details>

## Summary by Sourcery

改进混合文本/媒体帖子及转帖的渲染与发送，确保主内容和被转帖内容中的媒体都能被正确转发和呈现。

新功能：
- 在构建转发消息节点时包含贴纸内容描述。
- 将“解析结果到模板的解析器”暴露为公共方法，以便在转帖数据上复用并进行递归解析。

错误修复：
- 当主帖子只有文本而转帖包含媒体时，通过同时检查两部分内容，确保不会错误地跳过媒体发送，从而仍能发送媒体。

优化改进：
- 重构转发消息的构建逻辑，从主帖子和转帖的解析结果中直接提取有序的文本和媒体节点，并在媒体构建失败时进行更优雅的处理。
- 将即时媒体处理与可转发消息的构建分离，以简化处理流程并避免重复。
- 通过递归使用公开的解析器方法，统一转帖的模板数据解析逻辑。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve rendering and sending of mixed text/media posts and reposts to ensure media from both main and reposted content is correctly forwarded and represented.

New Features:
- Include sticker content descriptions when constructing forward message nodes.
- Expose the parse-result-to-template resolver as a public method for reuse and recursion on repost data.

Bug Fixes:
- Ensure media is still sent when the main post is text-only but the repost contains media by checking both contents before skipping media sending.

Enhancements:
- Refactor forward-message construction to derive ordered text and media nodes directly from parse results for both main posts and reposts, with more graceful handling of media build failures.
- Separate immediate media handling from forwardable message construction to simplify processing and avoid duplication.
- Unify template data resolution for reposts by recursively using the public resolver method.

</details>