### PR TITLE
fix(bilibili): 简化评论获取并统一回复API调用

### DIFF
--- a/src/nonebot_plugin_parser_lite/parsers/bilibili/__init__.py
+++ b/src/nonebot_plugin_parser_lite/parsers/bilibili/__init__.py
@@ -1068,20 +1068,53 @@ class BilibiliParser(BaseParser):
                     )
                     return []
 
-                upper_top = data["data"].get("upper", {}).get("top")
-                if upper_top is None:
-                    upper_top_list = []
-                elif isinstance(upper_top, list):
-                    upper_top_list = upper_top
+                data_root = data["data"] or {}
+                upper_top = data_root.get("upper", {}).get("top")
+                hots: list[dict[str, Any]] = data_root.get("hots") or []
+                replies_raw: list[dict[str, Any]] = data_root.get("replies") or []
+
+                upper_list: list[dict[str, Any]] = [upper_top] if upper_top else []
+
+                def _append_unique(
+                    src: list[dict[str, Any]], out: list[dict[str, Any]], seen: set[int]
+                ) -> None:
+                    for item in src:
+                        try:
+                            rpid: int = item["rpid"]
+                        except Exception:
+                            # 没有 rpid 的异常项直接跳过
+                            continue
+                        if rpid in seen:
+                            continue
+                        seen.add(rpid)
+                        out.append(item)
+
+                merged: list[dict[str, Any]] = []
+                seen_rpids: set[int] = set()
+
+                has_upper = bool(upper_list)
+                has_hots = bool(hots)
+
+                if has_upper and has_hots:
+                    # 置顶 + 热评
+                    _append_unique(upper_list, merged, seen_rpids)
+                    _append_unique(hots, merged, seen_rpids)
+                elif has_upper and not has_hots:
+                    # 置顶 + 普通
+                    _append_unique(upper_list, merged, seen_rpids)
+                    _append_unique(replies_raw, merged, seen_rpids)
+                elif has_hots and not has_upper:
+                    # 只有热评
+                    _append_unique(hots, merged, seen_rpids)
                 else:
-                    upper_top_list = [upper_top]
+                    # 没有置顶也没有热评 → 普通
+                    _append_unique(replies_raw, merged, seen_rpids)
 
-                hots = data["data"].get("hots") or []
-                replies_raw = data["data"].get("replies") or []
+                logger.debug(
+                    f"bili获得评论: upper={len(upper_list)}, hots={len(hots)}, replies={len(replies_raw)}, merged={len(merged)}",
+                )
+                return self._process_reply_list(merged)
 
-                replies = upper_top_list + hots + replies_raw
-                logger.debug(f"bili获得评论: {len(replies)} 条")
-                return self._process_reply_list(replies)
             except Exception as e:
                 logger.error(f"[Bilibili] 获取评论失败: {e!r}")
                 return []

--- a/src/nonebot_plugin_parser_lite/parsers/bilibili/__init__.py
+++ b/src/nonebot_plugin_parser_lite/parsers/bilibili/__init__.py
@@ -1045,80 +1045,40 @@ class BilibiliParser(BaseParser):
                 )
 
         async with AsyncClient() as client:
-            # 1. 热评接口
-            hot_url = "https://api.bilibili.com/x/v2/reply/hot"
-            hot_params = {
-                "oid": oid,
-                "type": type,
-                "root": 0,
-                "ps": 10,
-                "pn": 1,
-            }
             try:
-                comments = await self._request_comment_api(
-                    client,
-                    api_url=hot_url,
-                    params=hot_params,
+                response = await client.get(
+                    "https://api.bilibili.com/x/v2/reply",
+                    params={
+                        "oid": oid,
+                        "type": type,
+                        "sort": 1,  # 按点赞数排序
+                        "ps": 20,
+                        "pn": 1,
+                        "nohot": 0,
+                    },
                     headers=request_headers,
-                    desc="[Bilibili] 热评API",
                 )
-                if comments:
-                    return comments
-            except Exception as e:
-                logger.error(f"[Bilibili] 获取热评失败: {e!r}")
+                response.raise_for_status()
+                data = response.json()
+                logger.debug(f"bili评论返回: {data}")
 
-            # 2. 兜底普通评论接口
-            fallback_url = "https://api.bilibili.com/x/v2/reply"
-            fallback_params = {
-                "oid": oid,
-                "type": type,
-                "sort": 1,  # 按点赞数排序
-                "ps": 20,
-                "pn": 1,
-            }
-            try:
-                comments = await self._request_comment_api(
-                    client,
-                    api_url=fallback_url,
-                    params=fallback_params,
-                    headers=request_headers,
-                    desc="[Bilibili] 兜底评论API",
+                if data.get("code") != 0 or not data.get("data"):
+                    logger.debug(
+                        f"bili评论返回数据为空或错误: code={data.get('code')}, message={data.get('message')}"
+                    )
+                    return []
+
+                replies = (
+                    data["data"].get("upper", {}).get("top", [])
+                    + data["data"].get("hots", [])
+                    + data["data"].get("replies", [])
                 )
-                # 如果兜底接口返回空列表，也视作“没有评论”，而不是错误
-                return comments
+
+                logger.debug(f"bili获得评论: {len(replies)} 条")
+                return self._process_reply_list(replies)
             except Exception as e:
-                logger.error(f"[Bilibili] 获取兜底评论失败: {e!r}")
+                logger.error(f"[Bilibili] 获取评论失败: {e!r}")
                 return []
-
-    async def _request_comment_api(
-        self,
-        client: AsyncClient,
-        *,
-        api_url: str,
-        params: dict[str, Any],
-        headers: dict[str, str],
-        desc: str,
-    ) -> list[Comment]:
-        """请求指定评论 API，并解析为标准评论列表格式。"""
-        logger.debug(f"{desc}: url={api_url}, 参数={params}")
-        response = await client.get(api_url, params=params, headers=headers)
-        response.raise_for_status()
-        data = response.json()
-        logger.debug(f"{desc} 返回: {data}")
-
-        if data.get("code") != 0 or not data.get("data"):
-            logger.debug(
-                f"{desc} 返回数据为空或错误: code={data.get('code')}, message={data.get('message')}"
-            )
-            return []
-
-        replies = data["data"].get("replies")
-        if not isinstance(replies, list):
-            logger.debug(f"{desc} 返回的 replies 不是列表类型")
-            return []
-
-        logger.debug(f"{desc} 获得评论: {len(replies)} 条")
-        return self._process_reply_list(replies)
 
     def _format_content_with_emote(
         self, raw: str, emote: dict[str, Any]

--- a/src/nonebot_plugin_parser_lite/parsers/bilibili/__init__.py
+++ b/src/nonebot_plugin_parser_lite/parsers/bilibili/__init__.py
@@ -1052,7 +1052,7 @@ class BilibiliParser(BaseParser):
                         "oid": oid,
                         "type": type,
                         "sort": 1,  # 按点赞数排序
-                        "ps": 20,
+                        "ps": 7,
                         "pn": 1,
                         "nohot": 0,
                     },
@@ -1068,12 +1068,18 @@ class BilibiliParser(BaseParser):
                     )
                     return []
 
-                replies = (
-                    data["data"].get("upper", {}).get("top", [])
-                    + data["data"].get("hots", [])
-                    + data["data"].get("replies", [])
-                )
+                upper_top = data["data"].get("upper", {}).get("top")
+                if upper_top is None:
+                    upper_top_list = []
+                elif isinstance(upper_top, list):
+                    upper_top_list = upper_top
+                else:
+                    upper_top_list = [upper_top]
 
+                hots = data["data"].get("hots") or []
+                replies_raw = data["data"].get("replies") or []
+
+                replies = upper_top_list + hots + replies_raw
                 logger.debug(f"bili获得评论: {len(replies)} 条")
                 return self._process_reply_list(replies)
             except Exception as e:


### PR DESCRIPTION
- resolve #66
- @sourcery-ai /summary

## Summary by Sourcery

统一 B 站评论获取流程，改为使用单一的回复 API 响应，并将合并后的结果视为规范（canonical）的评论列表。

Bug Fixes:
- 当没有热门评论可用时，通过在统一的回复 API 响应内回退，确保仍然将 B 站评论视为成功获取。

Enhancements:
- 使用一个统一的回复 API 调用替换之前分别请求热门评论和回退评论的方式，将置顶、热门和普通评论合并为一个去重后的列表。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify Bilibili comment retrieval to use a single reply API response and treat the merged result as the canonical comment list.

Bug Fixes:
- Ensure Bilibili comments are still considered successfully fetched when no hot comments are available by falling back within the unified reply API response.

Enhancements:
- Replace separate hot and fallback Bilibili comment requests with one unified reply API call that merges pinned, hot, and regular comments into a deduplicated list.

</details>

Bug 修复：
- 当热门评论不可用时，通过依赖统一的回复 API 响应，确保 Bilibili 评论仍被视为成功获取。

增强内容：
- 用一次统一的回复 API 调用替代原先分开的热门和回退 Bilibili 评论请求，将置顶、热门和普通评论合并为一个列表。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

统一 B 站评论获取流程，改为使用单一的回复 API 响应，并将合并后的结果视为规范（canonical）的评论列表。

Bug Fixes:
- 当没有热门评论可用时，通过在统一的回复 API 响应内回退，确保仍然将 B 站评论视为成功获取。

Enhancements:
- 使用一个统一的回复 API 调用替换之前分别请求热门评论和回退评论的方式，将置顶、热门和普通评论合并为一个去重后的列表。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify Bilibili comment retrieval to use a single reply API response and treat the merged result as the canonical comment list.

Bug Fixes:
- Ensure Bilibili comments are still considered successfully fetched when no hot comments are available by falling back within the unified reply API response.

Enhancements:
- Replace separate hot and fallback Bilibili comment requests with one unified reply API call that merges pinned, hot, and regular comments into a deduplicated list.

</details>

</details>