### PR TITLE
feat(bilibili): 更新登录凭证存储逻辑以支持补全buvid

### DIFF
--- a/src/nonebot_plugin_parser_lite/parsers/bilibili/__init__.py
+++ b/src/nonebot_plugin_parser_lite/parsers/bilibili/__init__.py
@@ -2,6 +2,7 @@ import asyncio
 import contextlib
 import json
 import re
+import aiofiles
 from collections.abc import AsyncGenerator
 from re import Match
 from typing import Any, ClassVar
@@ -972,9 +973,8 @@ class BilibiliParser(BaseParser):
         if self._credential is None:
             return
 
-        self._cookies_file.write_text(
-            json.dumps(await self._credential.get_buvid_cookies())
-        )
+        async with aiofiles.open(self._cookies_file, "w", encoding="utf-8") as f:
+            await f.write(json.dumps(await self._credential.get_buvid_cookies()))
 
     async def login_with_qrcode(self) -> bytes:
         """通过二维码登录获取哔哩哔哩登录凭证"""
@@ -1017,7 +1017,10 @@ class BilibiliParser(BaseParser):
         """
         if self._cookies_file.exists():
             try:
-                cookies_raw = self._cookies_file.read_text()
+                async with aiofiles.open(
+                    self._cookies_file, encoding="utf-8"
+                ) as f:
+                    cookies_raw = await f.read()
                 cookies = json.loads(cookies_raw)
                 self._credential = Credential.from_cookies(cookies)
                 return
@@ -1252,9 +1255,8 @@ class BilibiliParser(BaseParser):
         if await self._credential.check_refresh():
             logger.info("哔哩哔哩凭证需要刷新")
             if self._credential.has_ac_time_value() and self._credential.has_bili_jct():
-                if (
-                    not self._credential.has_buvid3()
-                    or not self._credential.has_buvid4()
+                if not (
+                    self._credential.has_buvid3() and self._credential.has_buvid4()
                 ):
                     self._credential.buvid3, self._credential.buvid4 = await get_buvid()
                 await self._credential.refresh()

--- a/src/nonebot_plugin_parser_lite/parsers/bilibili/__init__.py
+++ b/src/nonebot_plugin_parser_lite/parsers/bilibili/__init__.py
@@ -12,6 +12,7 @@ from bilibili_api.dynamic import Dynamic
 from bilibili_api.favorite_list import get_video_favorite_list_content
 from bilibili_api.live import LiveRoom
 from bilibili_api.login_v2 import QrCodeLogin, QrCodeLoginEvents
+from bilibili_api.utils.network import get_buvid
 from bilibili_api.opus import Opus
 from bilibili_api.video import (
     AudioStreamDownloadURL,
@@ -966,12 +967,14 @@ class BilibiliParser(BaseParser):
         logger.debug(f"音频流质量: {audio_stream.audio_quality.name}")
         return video_stream.url, audio_stream.url
 
-    def _save_credential(self):
+    async def _save_credential(self):
         """存储哔哩哔哩登录凭证"""
         if self._credential is None:
             return
 
-        self._cookies_file.write_text(json.dumps(self._credential.get_cookies()))
+        self._cookies_file.write_text(
+            json.dumps(await self._credential.get_buvid_cookies())
+        )
 
     async def login_with_qrcode(self) -> bytes:
         """通过二维码登录获取哔哩哔哩登录凭证"""
@@ -991,7 +994,7 @@ class BilibiliParser(BaseParser):
                 case QrCodeLoginEvents.DONE:
                     yield "登录成功"
                     self._credential = self._qr_login.get_credential()
-                    self._save_credential()
+                    await self._save_credential()
                     await self.load_black_list()
                     break
                 case QrCodeLoginEvents.CONF:
@@ -1030,7 +1033,7 @@ class BilibiliParser(BaseParser):
         if await credential.check_valid():
             logger.info(f"`parser_bili_ck` 有效, 保存到 {self._cookies_file}")
             self._credential = credential
-            self._save_credential()
+            await self._save_credential()
         else:
             logger.warning("`parser_bili_ck` 已过期, 请更新 ck")
 
@@ -1249,9 +1252,14 @@ class BilibiliParser(BaseParser):
         if await self._credential.check_refresh():
             logger.info("哔哩哔哩凭证需要刷新")
             if self._credential.has_ac_time_value() and self._credential.has_bili_jct():
+                if (
+                    not self._credential.has_buvid3()
+                    or not self._credential.has_buvid4()
+                ):
+                    self._credential.buvid3, self._credential.buvid4 = await get_buvid()
                 await self._credential.refresh()
                 logger.info(f"哔哩哔哩凭证刷新成功, 保存到 {self._cookies_file}")
-                self._save_credential()
+                await self._save_credential()
             else:
                 logger.warning(
                     "哔哩哔哩凭证刷新需要包含 `SESSDATA`, `ac_time_value` 项"


### PR DESCRIPTION
支持存储buvid3和buvid4标识符，并将凭证保存方法改为异步操作。

- 添加get_buvid导入用于获取buvid标识符
- 将_save_credential方法改为异步方法
- 使用get_buvid_cookies替代get_cookies方法
- 在凭证刷新时检查并更新buvid3/buvid4
- 调用处均改为await方式调用

## Summary by Sourcery

持久化额外的 Bilibili 凭证标识符，并使凭证保存过程完全异步化。

新功能：
- 将 `buvid3` 和 `buvid4` 标识符作为 Bilibili 凭证 cookies 的一部分进行存储和持久化。

改进：
- 将凭证保存改为异步操作，并相应地更新所有调用方。
- 在将凭证数据写入磁盘时，使用感知 `buvid` 的 cookie 读取方式。
- 在可能的情况下，确保在刷新 Bilibili 凭证之前已填充 `buvid3`/`buvid4`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Persist additional Bilibili credential identifiers and make credential saving fully asynchronous.

New Features:
- Store and persist buvid3 and buvid4 identifiers as part of the Bilibili credential cookies.

Enhancements:
- Change credential saving to an asynchronous operation and update all call sites accordingly.
- Use buvid-aware cookie retrieval when writing credential data to disk.
- Ensure buvid3/buvid4 are populated before refreshing Bilibili credentials when possible.

</details>