### PR TITLE
feat(parser,render): 强化解析结果类型并统一媒体网格布局

### DIFF
--- a/src/nonebot_plugin_parser_lite/parsers/tieba/__init__.py
+++ b/src/nonebot_plugin_parser_lite/parsers/tieba/__init__.py
@@ -1,9 +1,8 @@
 from re import Match
 from typing import ClassVar
 
-from ..base import BaseParser, handle, Platform
+from ..base import BaseParser, handle, Platform, PlatformEnum
 from .utils import get_post, build_comments, build_content
-from ...constants import PlatformEnum
 
 
 class TiebaParser(BaseParser):

--- a/src/nonebot_plugin_parser_lite/render/templates/macros.jinja
+++ b/src/nonebot_plugin_parser_lite/render/templates/macros.jinja
@@ -121,34 +121,10 @@
                 {% endif %}
             </div>
         </div>
-        {# 两图：左右两张等大的方图 #}
-    {% elif count == 2 %}
-        <div class="mt-3">
-            <div class="media-group aspect-[16/9] rounded-xl outline-1 outline-slate-200 overflow-hidden grid grid-cols-2 gap-0.5">
-                {% for item in visible_imgs %}
-                    {% set src = item.src %}
-                    <img src="{{ src }}" class="square-img" />
-                {% endfor %}
-            </div>
-        </div>
-        {# 三图：左一竖图 + 右两小图 #}
-    {% elif count == 3 %}
-        <div class="mt-3">
-            <div class="media-group rounded-xl outline-1 outline-slate-200 overflow-hidden grid grid-cols-2 grid-rows-2 gap-0.5">
-                {% for item in visible_imgs %}
-                    {% set src = item.src %}
-                    {% if loop.index == 1 %}
-                        <img src="{{ src }}" class="square-img row-span-2" />
-                    {% else %}
-                        <img src="{{ src }}" class="square-img" />
-                    {% endif %}
-                {% endfor %}
-            </div>
-        </div>
-        {# 4 张及以上：九宫格 media-grid #}
+        {# 2 张及以上：九宫格 media-grid #}
     {% else %}
         <div class="mt-3">
-            <div class="media-grid outline-1 outline-slate-200 rounded-xl overflow-hidden grid grid-cols-3 gap-[2px] bg-gray-100 border border-gray-100 shadow-sm">
+            <div class="media-grid outline-1 outline-slate-200 rounded-xl overflow-hidden grid grid-cols-3 gap-[2px] shadow-sm">
                 {% for item in visible_imgs %}
                     {% set src = item.src %}
                     {% set is_live = item.is_live %}

--- a/src/nonebot_plugin_parser_lite/render/templates/macros.jinja
+++ b/src/nonebot_plugin_parser_lite/render/templates/macros.jinja
@@ -199,10 +199,8 @@
             {% set alt = cont.alt or "" %}
             {% set _ = html_parts.append(
                             '<div class="mt-3 space-y-1">'
-                            '<div class="grid grid-cols-1 gap-1">'
-                            '<div class="relative overflow-hidden rounded-md bg-slate-100">'
-                            '<img src="' ~ src ~ '" class="w-full h-full object-cover block" />'
-                            '</div>'
+                            '<div class="single-image relative rounded-2xl overflow-hidden border border-gray-100 shadow-sm">'
+                            '<img src="' ~ src ~ '" class="w-full h-auto max-h-[400px] object-cover" />'
                             '</div>'
                             '<p class="text-xs text-slate-500">' ~ (alt|e) ~ '</p>'
                             '</div>'

--- a/src/nonebot_plugin_parser_lite/render/templates/tailwind.css
+++ b/src/nonebot_plugin_parser_lite/render/templates/tailwind.css
@@ -292,9 +292,6 @@
   .bottom-2 {
     bottom: calc(var(--spacing) * 2);
   }
-  .row-span-2 {
-    grid-row: span 2 / span 2;
-  }
   .m-8 {
     margin: calc(var(--spacing) * 8);
   }
@@ -324,12 +321,6 @@
   }
   .grid {
     display: grid;
-  }
-  .aspect-\[0\.68\/1\] {
-    aspect-ratio: 0.68/1;
-  }
-  .aspect-\[16\/9\] {
-    aspect-ratio: 16/9;
   }
   .aspect-video {
     aspect-ratio: var(--aspect-video);
@@ -391,14 +382,8 @@
   .w-full {
     width: 100%;
   }
-  .grid-cols-2 {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
   .grid-cols-3 {
     grid-template-columns: repeat(3, minmax(0, 1fr));
-  }
-  .grid-rows-2 {
-    grid-template-rows: repeat(2, minmax(0, 1fr));
   }
   .gap-y-3 {
     row-gap: calc(var(--spacing) * 3);
@@ -423,9 +408,6 @@
   }
   .justify-center {
     justify-content: center;
-  }
-  .gap-0\.5 {
-    gap: calc(var(--spacing) * 0.5);
   }
   .gap-\[2px\] {
     gap: 2px;
@@ -582,9 +564,6 @@
   }
   .bg-gray-50 {
     background-color: var(--color-gray-50);
-  }
-  .bg-gray-100 {
-    background-color: var(--color-gray-100);
   }
   .bg-slate-100 {
     background-color: var(--color-slate-100);


### PR DESCRIPTION
- 移除typing_extensions中的Unpack导入
- 删除ParseResultKwargs TypedDict定义
- 重构BaseParser.result方法，直接接收参数而非使用**kwargs
- 添加详细的参数类型注解和文档字符串
- 初始化默认值处理逻辑
- 更新import语句顺序
- 修复Comment和ParseResult中content字段类型定义，移除None选项
- 移除多余的括号和空白行

## Summary by Sourcery

统一图片网格渲染，清理未使用的样式工具类，并让 Tieba 解析器的导入与基础解析器 API 对齐。

Enhancements:
- 通过对包含两张及以上图片的帖子统一使用单一的 3x3 网格布局，并移除针对 2 张和 3 张图片的专用布局，从而简化媒体渲染。
- 从模板样式表中移除仅用于已删除媒体布局的、类似 Tailwind 的未使用工具类。
- 将 TiebaParser 更新为从基础解析器模块而不是常量模块中导入 PlatformEnum，以反映当前的 API 表面。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify image grid rendering, clean up unused styling utilities, and align Tieba parser imports with the base parser API.

Enhancements:
- Simplify media rendering by using a single 3x3 grid layout for posts with two or more images and removing specialized 2- and 3-image layouts.
- Remove unused Tailwind-style utility classes from the template stylesheet that were only needed by the dropped media layouts.
- Update TiebaParser to import PlatformEnum from the base parser module instead of the constants module to reflect the current API surface.

</details>

Bug 修复：
- 禁止 `Comment.content` 和 `ParseResult.content` 中出现 `None` 值，以保证内容序列非空且一致。
- 在访问 `ParseResult` 的 `extra_info` 时增加保护，以避免在缺失额外数据时产生运行时错误。

增强改进：
- 用一个完整类型标注且有文档说明的工厂方法，替换基于 `kwargs` 的 `BaseParser.result` 辅助函数和 `ParseResultKwargs` `TypedDict`，并为 `stats`、`comments` 和 `extra` 初始化合理的默认值。
- 将若干 `ParseResult` 和 `Comment` 字段标记为可选，并调整辅助函数以安全处理缺失数据。
- 将多图渲染统一为单一的 3x3 媒体网格实现，并移除未使用的 Tailwind 风格工具类。
- 收紧评论创建工具，仅接受非空内容元素，并移除已废弃的辅助函数。
- 更新 `TiebaParser`，从基础解析器模块而非常量模块导入 `PlatformEnum`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

统一图片网格渲染，清理未使用的样式工具类，并让 Tieba 解析器的导入与基础解析器 API 对齐。

Enhancements:
- 通过对包含两张及以上图片的帖子统一使用单一的 3x3 网格布局，并移除针对 2 张和 3 张图片的专用布局，从而简化媒体渲染。
- 从模板样式表中移除仅用于已删除媒体布局的、类似 Tailwind 的未使用工具类。
- 将 TiebaParser 更新为从基础解析器模块而不是常量模块中导入 PlatformEnum，以反映当前的 API 表面。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify image grid rendering, clean up unused styling utilities, and align Tieba parser imports with the base parser API.

Enhancements:
- Simplify media rendering by using a single 3x3 grid layout for posts with two or more images and removing specialized 2- and 3-image layouts.
- Remove unused Tailwind-style utility classes from the template stylesheet that were only needed by the dropped media layouts.
- Update TiebaParser to import PlatformEnum from the base parser module instead of the constants module to reflect the current API surface.

</details>

</details>

Bug 修复：
- 在 `Comment.content` 和 `ParseResult.content` 中禁止使用 `None`，以保持内容序列的一致性和非空特性。
- 在模板渲染时对缺失的统计信息和评论进行防护，当可选字段不存在时避免运行时错误。

增强改进：
- 用完整带类型注解且有文档说明的工厂方法替换基于 `kwargs` 的 `BaseParser.result` 辅助函数和 `ParseResultKwargs` `TypedDict`，为解析结果显式设置默认值。
- 将多个 `ParseResult` 和 `Comment` 字段（如 `stats`、`comments`、`extra`、`location`、`parent_author` 等）明确标记为可选，并调整 `extra_info` 和 `render.resolve_parse_result` 等访问器，以安全地处理缺失数据。
- 简化 Jinja 模板中的媒体网格布局，将多图处理统一为单一的九宫格实现，并清理未使用的 CSS 工具类。
- 调整 `TiebaParser` 的导入方式，从基础解析器模块而不是常量模块中引入 `PlatformEnum`。
- 收紧评论创建工具函数，只接受非空的内容元素，并清理解析器工具函数和模板中的少量空白和格式问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

统一图片网格渲染，清理未使用的样式工具类，并让 Tieba 解析器的导入与基础解析器 API 对齐。

Enhancements:
- 通过对包含两张及以上图片的帖子统一使用单一的 3x3 网格布局，并移除针对 2 张和 3 张图片的专用布局，从而简化媒体渲染。
- 从模板样式表中移除仅用于已删除媒体布局的、类似 Tailwind 的未使用工具类。
- 将 TiebaParser 更新为从基础解析器模块而不是常量模块中导入 PlatformEnum，以反映当前的 API 表面。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify image grid rendering, clean up unused styling utilities, and align Tieba parser imports with the base parser API.

Enhancements:
- Simplify media rendering by using a single 3x3 grid layout for posts with two or more images and removing specialized 2- and 3-image layouts.
- Remove unused Tailwind-style utility classes from the template stylesheet that were only needed by the dropped media layouts.
- Update TiebaParser to import PlatformEnum from the base parser module instead of the constants module to reflect the current API surface.

</details>

Bug 修复：
- 禁止 `Comment.content` 和 `ParseResult.content` 中出现 `None` 值，以保证内容序列非空且一致。
- 在访问 `ParseResult` 的 `extra_info` 时增加保护，以避免在缺失额外数据时产生运行时错误。

增强改进：
- 用一个完整类型标注且有文档说明的工厂方法，替换基于 `kwargs` 的 `BaseParser.result` 辅助函数和 `ParseResultKwargs` `TypedDict`，并为 `stats`、`comments` 和 `extra` 初始化合理的默认值。
- 将若干 `ParseResult` 和 `Comment` 字段标记为可选，并调整辅助函数以安全处理缺失数据。
- 将多图渲染统一为单一的 3x3 媒体网格实现，并移除未使用的 Tailwind 风格工具类。
- 收紧评论创建工具，仅接受非空内容元素，并移除已废弃的辅助函数。
- 更新 `TiebaParser`，从基础解析器模块而非常量模块导入 `PlatformEnum`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

统一图片网格渲染，清理未使用的样式工具类，并让 Tieba 解析器的导入与基础解析器 API 对齐。

Enhancements:
- 通过对包含两张及以上图片的帖子统一使用单一的 3x3 网格布局，并移除针对 2 张和 3 张图片的专用布局，从而简化媒体渲染。
- 从模板样式表中移除仅用于已删除媒体布局的、类似 Tailwind 的未使用工具类。
- 将 TiebaParser 更新为从基础解析器模块而不是常量模块中导入 PlatformEnum，以反映当前的 API 表面。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify image grid rendering, clean up unused styling utilities, and align Tieba parser imports with the base parser API.

Enhancements:
- Simplify media rendering by using a single 3x3 grid layout for posts with two or more images and removing specialized 2- and 3-image layouts.
- Remove unused Tailwind-style utility classes from the template stylesheet that were only needed by the dropped media layouts.
- Update TiebaParser to import PlatformEnum from the base parser module instead of the constants module to reflect the current API surface.

</details>

</details>

</details>

Bug 修复：
- 更正 `Comment` 和 `ParseResult` 的 `content` 字段类型，禁止 `None` 值，并确保统计字段在初始化时保持一致。

增强：
- 用一个完整类型标注且有文档说明的方法替换泛化的、基于 `**kwargs` 的 `BaseParser.result` 辅助函数，该方法会初始化合理的默认值。
- 移除 `ParseResultKwargs` 的 `TypedDict` 和 `Unpack` 引用，改为直接在 `BaseParser.result` 上使用参数类型标注。
- 清理解析器模块中的导入、多余的括号和空白字符，并调整 `TiebaParser` 的导入以使用基础模块中的 `PlatformEnum`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

统一图片网格渲染，清理未使用的样式工具类，并让 Tieba 解析器的导入与基础解析器 API 对齐。

Enhancements:
- 通过对包含两张及以上图片的帖子统一使用单一的 3x3 网格布局，并移除针对 2 张和 3 张图片的专用布局，从而简化媒体渲染。
- 从模板样式表中移除仅用于已删除媒体布局的、类似 Tailwind 的未使用工具类。
- 将 TiebaParser 更新为从基础解析器模块而不是常量模块中导入 PlatformEnum，以反映当前的 API 表面。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify image grid rendering, clean up unused styling utilities, and align Tieba parser imports with the base parser API.

Enhancements:
- Simplify media rendering by using a single 3x3 grid layout for posts with two or more images and removing specialized 2- and 3-image layouts.
- Remove unused Tailwind-style utility classes from the template stylesheet that were only needed by the dropped media layouts.
- Update TiebaParser to import PlatformEnum from the base parser module instead of the constants module to reflect the current API surface.

</details>

Bug 修复：
- 禁止 `Comment.content` 和 `ParseResult.content` 中出现 `None` 值，以保证内容序列非空且一致。
- 在访问 `ParseResult` 的 `extra_info` 时增加保护，以避免在缺失额外数据时产生运行时错误。

增强改进：
- 用一个完整类型标注且有文档说明的工厂方法，替换基于 `kwargs` 的 `BaseParser.result` 辅助函数和 `ParseResultKwargs` `TypedDict`，并为 `stats`、`comments` 和 `extra` 初始化合理的默认值。
- 将若干 `ParseResult` 和 `Comment` 字段标记为可选，并调整辅助函数以安全处理缺失数据。
- 将多图渲染统一为单一的 3x3 媒体网格实现，并移除未使用的 Tailwind 风格工具类。
- 收紧评论创建工具，仅接受非空内容元素，并移除已废弃的辅助函数。
- 更新 `TiebaParser`，从基础解析器模块而非常量模块导入 `PlatformEnum`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

统一图片网格渲染，清理未使用的样式工具类，并让 Tieba 解析器的导入与基础解析器 API 对齐。

Enhancements:
- 通过对包含两张及以上图片的帖子统一使用单一的 3x3 网格布局，并移除针对 2 张和 3 张图片的专用布局，从而简化媒体渲染。
- 从模板样式表中移除仅用于已删除媒体布局的、类似 Tailwind 的未使用工具类。
- 将 TiebaParser 更新为从基础解析器模块而不是常量模块中导入 PlatformEnum，以反映当前的 API 表面。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify image grid rendering, clean up unused styling utilities, and align Tieba parser imports with the base parser API.

Enhancements:
- Simplify media rendering by using a single 3x3 grid layout for posts with two or more images and removing specialized 2- and 3-image layouts.
- Remove unused Tailwind-style utility classes from the template stylesheet that were only needed by the dropped media layouts.
- Update TiebaParser to import PlatformEnum from the base parser module instead of the constants module to reflect the current API surface.

</details>

</details>

Bug 修复：
- 在 `Comment.content` 和 `ParseResult.content` 中禁止使用 `None`，以保持内容序列的一致性和非空特性。
- 在模板渲染时对缺失的统计信息和评论进行防护，当可选字段不存在时避免运行时错误。

增强改进：
- 用完整带类型注解且有文档说明的工厂方法替换基于 `kwargs` 的 `BaseParser.result` 辅助函数和 `ParseResultKwargs` `TypedDict`，为解析结果显式设置默认值。
- 将多个 `ParseResult` 和 `Comment` 字段（如 `stats`、`comments`、`extra`、`location`、`parent_author` 等）明确标记为可选，并调整 `extra_info` 和 `render.resolve_parse_result` 等访问器，以安全地处理缺失数据。
- 简化 Jinja 模板中的媒体网格布局，将多图处理统一为单一的九宫格实现，并清理未使用的 CSS 工具类。
- 调整 `TiebaParser` 的导入方式，从基础解析器模块而不是常量模块中引入 `PlatformEnum`。
- 收紧评论创建工具函数，只接受非空的内容元素，并清理解析器工具函数和模板中的少量空白和格式问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

统一图片网格渲染，清理未使用的样式工具类，并让 Tieba 解析器的导入与基础解析器 API 对齐。

Enhancements:
- 通过对包含两张及以上图片的帖子统一使用单一的 3x3 网格布局，并移除针对 2 张和 3 张图片的专用布局，从而简化媒体渲染。
- 从模板样式表中移除仅用于已删除媒体布局的、类似 Tailwind 的未使用工具类。
- 将 TiebaParser 更新为从基础解析器模块而不是常量模块中导入 PlatformEnum，以反映当前的 API 表面。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify image grid rendering, clean up unused styling utilities, and align Tieba parser imports with the base parser API.

Enhancements:
- Simplify media rendering by using a single 3x3 grid layout for posts with two or more images and removing specialized 2- and 3-image layouts.
- Remove unused Tailwind-style utility classes from the template stylesheet that were only needed by the dropped media layouts.
- Update TiebaParser to import PlatformEnum from the base parser module instead of the constants module to reflect the current API surface.

</details>

Bug 修复：
- 禁止 `Comment.content` 和 `ParseResult.content` 中出现 `None` 值，以保证内容序列非空且一致。
- 在访问 `ParseResult` 的 `extra_info` 时增加保护，以避免在缺失额外数据时产生运行时错误。

增强改进：
- 用一个完整类型标注且有文档说明的工厂方法，替换基于 `kwargs` 的 `BaseParser.result` 辅助函数和 `ParseResultKwargs` `TypedDict`，并为 `stats`、`comments` 和 `extra` 初始化合理的默认值。
- 将若干 `ParseResult` 和 `Comment` 字段标记为可选，并调整辅助函数以安全处理缺失数据。
- 将多图渲染统一为单一的 3x3 媒体网格实现，并移除未使用的 Tailwind 风格工具类。
- 收紧评论创建工具，仅接受非空内容元素，并移除已废弃的辅助函数。
- 更新 `TiebaParser`，从基础解析器模块而非常量模块导入 `PlatformEnum`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

统一图片网格渲染，清理未使用的样式工具类，并让 Tieba 解析器的导入与基础解析器 API 对齐。

Enhancements:
- 通过对包含两张及以上图片的帖子统一使用单一的 3x3 网格布局，并移除针对 2 张和 3 张图片的专用布局，从而简化媒体渲染。
- 从模板样式表中移除仅用于已删除媒体布局的、类似 Tailwind 的未使用工具类。
- 将 TiebaParser 更新为从基础解析器模块而不是常量模块中导入 PlatformEnum，以反映当前的 API 表面。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify image grid rendering, clean up unused styling utilities, and align Tieba parser imports with the base parser API.

Enhancements:
- Simplify media rendering by using a single 3x3 grid layout for posts with two or more images and removing specialized 2- and 3-image layouts.
- Remove unused Tailwind-style utility classes from the template stylesheet that were only needed by the dropped media layouts.
- Update TiebaParser to import PlatformEnum from the base parser module instead of the constants module to reflect the current API surface.

</details>

</details>

</details>

</details>