### PR TITLE
feat: 更新表情图片格式为webp

### DIFF
--- a/src/nonebot_plugin_parser_lite/parsers/heybox/model.py
+++ b/src/nonebot_plugin_parser_lite/parsers/heybox/model.py
@@ -54,7 +54,7 @@ class CommentItem(Struct):
         if self.is_cy:
             content.append(
                 create_sticker(
-                    url="https://emoji.awkchan.top/assets/heybox/cy.png",
+                    url="https://emoji.awkchan.top/assets/heybox/cy.webp",
                     size="small",
                     desc="插眼",
                 )

--- a/src/nonebot_plugin_parser_lite/parsers/tieba/utils.py
+++ b/src/nonebot_plugin_parser_lite/parsers/tieba/utils.py
@@ -124,7 +124,7 @@ def build_content(posts: Posts) -> list[MediaContent | str]:
         elif isinstance(part, FragEmoji):
             contents.append(
                 create_sticker(
-                    url=f"https://emoji.awkchan.top/assets/tieba/{part.id}.png",
+                    url=f"https://emoji.awkchan.top/assets/tieba/{part.id}.webp",
                     size="small",
                     desc=part.desc,
                 )
@@ -180,7 +180,7 @@ def build_comment(contents: Contents) -> list[MediaContent | str]:
         elif isinstance(part, FragEmoji):
             content.append(
                 create_sticker(
-                    url=f"https://emoji.awkchan.top/assets/tieba/{part.id}.png",
+                    url=f"https://emoji.awkchan.top/assets/tieba/{part.id}.webp",
                     size="small",
                     desc=part.desc,
                 )

--- a/src/nonebot_plugin_parser_lite/render/__init__.py
+++ b/src/nonebot_plugin_parser_lite/render/__init__.py
@@ -339,7 +339,7 @@ class Renderer:
             "platform": {
                 "display_name": result.platform.display_name,
                 "name": result.platform.name,
-                "logo_path": f"https://emoji.awkchan.top/assets/logo/{result.platform.name}.png",
+                "logo_path": f"https://emoji.awkchan.top/assets/logo/{result.platform.name}.webp",
             },
             "content": result.content,
             "cover_path": await safe_src(result, "get_cover_path"),

--- a/src/nonebot_plugin_parser_lite/utils/format.py
+++ b/src/nonebot_plugin_parser_lite/utils/format.py
@@ -39,7 +39,7 @@ def replace_placeholder_to_sticker(
         size = size_resolver(name) if size_resolver is not None else "small"
         result.append(
             create_sticker(
-                url=f"https://emoji.awkchan.top/assets/{platform}/{name}.png",
+                url=f"https://emoji.awkchan.top/assets/{platform}/{name}.webp",
                 size=size,
                 desc=name,
             )


### PR DESCRIPTION
- 将嘿box解析器中的cy表情从png格式更新为webp格式
- 将贴吧解析器中的表情资源从png格式更新为webp格式
- 将渲染模块中的平台logo从png格式更新为webp格式
- 将格式化工具中的占位符表情从png格式更新为webp格式

## 由 Sourcery 提供的总结

在各解析器和渲染工具中，将表情和徽标资源的 URL 从 PNG 更新为 WebP 图片。

增强内容：
- 将贴吧表情资源从 PNG 切换为 WebP URL。
- 将小黑盒 CY 表情资源从 PNG 切换为 WebP URL。
- 在渲染模块中，将平台徽标 URL 从 PNG 切换为 WebP。
- 在格式化工具中，将占位表情 URL 从 PNG 切换为 WebP。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update emoji and logo asset URLs to use WebP images instead of PNG across parsers and rendering utilities.

Enhancements:
- Switch Tieba emoji resources from PNG to WebP URLs.
- Switch Heybox CY emoji resource from PNG to WebP URL.
- Switch platform logo URLs from PNG to WebP in the render module.
- Switch placeholder emoji URLs from PNG to WebP in the formatting utilities.

</details>