### PR TITLE
refactor(parser): 统一使用基类HTTP客户端实例

### DIFF
--- a/src/nonebot_plugin_parser_lite/matchers/__init__.py
+++ b/src/nonebot_plugin_parser_lite/matchers/__init__.py
@@ -114,15 +114,19 @@ def get_parser_by_type(parser_type: type[T]) -> T:
 
 driver = get_driver()
 
+ENABLED_PLATFORM: list[BaseParser] = []
+
 
 @driver.on_startup
 def register_parser_matcher() -> None:
     """在启动时注册各平台解析器及其匹配规则。"""
+    global ENABLED_PLATFORM
     enabled_classes = _get_enabled_parser_classes()
 
     enabled_platforms: list[str] = []
     for parser_cls in enabled_classes:
         parser = parser_cls()
+        ENABLED_PLATFORM.append(parser)
         enabled_platforms.append(parser.platform.display_name)
         for keyword, _ in parser_cls._key_patterns:
             KEYWORD_PARSER_MAP[keyword] = parser
@@ -132,6 +136,14 @@ def register_parser_matcher() -> None:
     patterns = [pattern for cls_ in enabled_classes for pattern in cls_._key_patterns]
     matcher = on_keyword_regex(*patterns)
     matcher.append_handler(parser_handler)
+
+
+@driver.on_shutdown
+async def close_httpx() -> None:
+    if not ENABLED_PLATFORM:
+        return
+
+    await asyncio.gather(*(parser.aclose() for parser in ENABLED_PLATFORM))
 
 
 # 缓存结果

--- a/src/nonebot_plugin_parser_lite/parsers/acfun/__init__.py
+++ b/src/nonebot_plugin_parser_lite/parsers/acfun/__init__.py
@@ -1,6 +1,5 @@
 import re
 from typing import ClassVar
-from httpx import AsyncClient
 from ..base import (
     DOWNLOADER,
     BaseParser,
@@ -21,6 +20,7 @@ class AcfunParser(BaseParser):
     def __init__(self):
         super().__init__()
         self.headers["referer"] = "https://www.acfun.cn/"
+        self.httpx.headers.update(self.headers)
 
     @handle("acfun.cn", r"(?:ac=|/ac)(?P<acid>\d+)")
     async def _parse(self, searched: re.Match[str]):
@@ -59,10 +59,9 @@ class AcfunParser(BaseParser):
         # 拼接查询参数
         url = f"{url}?quickViewId=videoInfo_new&ajaxpipe=1"
 
-        async with AsyncClient(headers=self.headers) as client:
-            response = await client.get(url)
-            response.raise_for_status()
-            raw = response.text
+        response = await self.httpx.get(url)
+        response.raise_for_status()
+        raw = response.text
 
         matched = re.search(r"window\.videoInfo =(.*?)</script>", raw)
         if not matched:

--- a/src/nonebot_plugin_parser_lite/parsers/base.py
+++ b/src/nonebot_plugin_parser_lite/parsers/base.py
@@ -132,6 +132,10 @@ class BaseParser:
             headers=self.headers, timeout=self.timeout, follow_redirects=True
         )
 
+    async def aclose(self) -> None:
+        """关闭底层 HTTP 客户端，释放连接等资源。"""
+        await self.httpx.aclose()
+
     def __init_subclass__(cls, **kwargs):
         """自动注册子类到 _registry"""
         super().__init_subclass__(**kwargs)

--- a/src/nonebot_plugin_parser_lite/parsers/base.py
+++ b/src/nonebot_plugin_parser_lite/parsers/base.py
@@ -128,6 +128,9 @@ class BaseParser:
         self.ios_headers = IOS_HEADER.copy()
         self.android_headers = ANDROID_HEADER.copy()
         self.timeout = COMMON_TIMEOUT
+        self.httpx = AsyncClient(
+            headers=self.headers, timeout=self.timeout, follow_redirects=True
+        )
 
     def __init_subclass__(cls, **kwargs):
         """自动注册子类到 _registry"""
@@ -401,9 +404,7 @@ class BaseParser:
         :param ext_headers: 额外请求头
         """
 
-        return create_sticker(
-            url=url, size=size, desc=desc, ext_headers=ext_headers
-        )
+        return create_sticker(url=url, size=size, desc=desc, ext_headers=ext_headers)
 
     def create_live_photo(
         self,

--- a/src/nonebot_plugin_parser_lite/parsers/bilibili/__init__.py
+++ b/src/nonebot_plugin_parser_lite/parsers/bilibili/__init__.py
@@ -22,7 +22,6 @@ from bilibili_api.video import (
     VideoStreamDownloadURL,
 )
 from bilibili_api.exceptions import CookiesRefreshException
-from httpx import AsyncClient
 from msgspec import convert
 from nonebot import logger
 
@@ -88,58 +87,54 @@ class BilibiliParser(BaseParser):
 
         request_headers = self.headers.copy()
         request_headers["Cookie"] = "; ".join(f"{k}={v}" for k, v in cookies.items())
+        self.httpx.headers.update(request_headers)
 
         base_url = "https://api.bilibili.com/x/relation/blacks"
         page_size = 50
         black_mids: list[int] = []
 
         try:
-            async with AsyncClient() as client:
-                resp = await client.get(
-                    base_url,
-                    headers=request_headers,
-                    params={"ps": page_size, "pn": 1},
-                )
-                resp.raise_for_status()
-                data: dict[str, Any] = resp.json()
+            resp = await self.httpx.get(
+                base_url,
+                params={"ps": page_size, "pn": 1},
+            )
+            resp.raise_for_status()
+            data: dict[str, Any] = resp.json()
 
-                code = data.get("code")
-                if code != 0:
-                    logger.error(f"获取B站黑名单列表失败: code={code}, data={data}")
-                    self.black_mids = []
-                    return
+            code = data.get("code")
+            if code != 0:
+                logger.error(f"获取B站黑名单列表失败: code={code}, data={data}")
+                self.black_mids = []
+                return
 
-                data_root = data.get("data", {})
-                first_list = data_root.get("list", [])
-                total = data_root.get("total", 0)
+            data_root = data.get("data", {})
+            first_list = data_root.get("list", [])
+            total = data_root.get("total", 0)
 
-                black_mids.extend(obj["mid"] for obj in first_list)
+            black_mids.extend(obj["mid"] for obj in first_list)
 
-                # 计算剩余页数
-                pages = (total + page_size - 1) // page_size if total > page_size else 1
-                for pn in range(2, pages + 1):
-                    try:
-                        resp = await client.get(
-                            base_url,
-                            headers=request_headers,
-                            params={"ps": page_size, "pn": pn},
-                        )
-                        resp.raise_for_status()
-                        page_data: dict[str, Any] = resp.json()
-                        if page_data.get("code") != 0:
-                            logger.warning(
-                                f"获取B站黑名单第 {pn} 页失败: {page_data!r}"
-                            )
-                            continue
-                        page_list = page_data.get("data", {}).get("list", [])
-                        black_mids.extend(obj["mid"] for obj in page_list)
-                        logger.debug(
-                            f"[BiliParser] 黑名单第 {pn} 页加载完成, 当前共 {len(black_mids)} 个"
-                        )
-                        await asyncio.sleep(0.2)
-                    except Exception as e:  # noqa: BLE001
-                        logger.warning(f"请求B站黑名单第 {pn} 页异常: {e}")
+            # 计算剩余页数
+            pages = (total + page_size - 1) // page_size if total > page_size else 1
+            for pn in range(2, pages + 1):
+                try:
+                    resp = await self.httpx.get(
+                        base_url,
+                        params={"ps": page_size, "pn": pn},
+                    )
+                    resp.raise_for_status()
+                    page_data: dict[str, Any] = resp.json()
+                    if page_data.get("code") != 0:
+                        logger.warning(f"获取B站黑名单第 {pn} 页失败: {page_data!r}")
                         continue
+                    page_list = page_data.get("data", {}).get("list", [])
+                    black_mids.extend(obj["mid"] for obj in page_list)
+                    logger.debug(
+                        f"[BiliParser] 黑名单第 {pn} 页加载完成, 当前共 {len(black_mids)} 个"
+                    )
+                    await asyncio.sleep(0.2)
+                except Exception as e:  # noqa: BLE001
+                    logger.warning(f"请求B站黑名单第 {pn} 页异常: {e}")
+                    continue
 
             self.black_mids = black_mids
             logger.debug(f"B站黑名单列表: {black_mids}")
@@ -1041,88 +1036,79 @@ class BilibiliParser(BaseParser):
 
     async def _fetch_comments(self, oid: int, type: int) -> list[Comment]:
         """从 Bilibili API 获取评论数据，优先热评，失败时兜底普通评论"""
-        # 构造请求头（带 cookie）
-        request_headers = self.headers.copy()
-        if ck := await self.credential:
-            if cookies := ck.get_cookies():
-                request_headers["Cookie"] = "; ".join(
-                    f"{k}={v}" for k, v in cookies.items()
-                )
 
-        async with AsyncClient() as client:
-            try:
-                response = await client.get(
-                    "https://api.bilibili.com/x/v2/reply",
-                    params={
-                        "oid": oid,
-                        "type": type,
-                        "sort": 1,  # 按点赞数排序
-                        "ps": 7,
-                        "pn": 1,
-                        "nohot": 0,
-                    },
-                    headers=request_headers,
-                )
-                response.raise_for_status()
-                data = response.json()
-                logger.debug(f"bili评论返回: {data}")
+        try:
+            response = await self.httpx.get(
+                "https://api.bilibili.com/x/v2/reply",
+                params={
+                    "oid": oid,
+                    "type": type,
+                    "sort": 1,  # 按点赞数排序
+                    "ps": 7,
+                    "pn": 1,
+                    "nohot": 0,
+                },
+            )
+            response.raise_for_status()
+            data = response.json()
+            logger.debug(f"bili评论返回: {data}")
 
-                if data.get("code") != 0 or not data.get("data"):
-                    logger.debug(
-                        f"bili评论返回数据为空或错误: code={data.get('code')}, message={data.get('message')}"
-                    )
-                    return []
-
-                data_root = data["data"] or {}
-                upper_top = data_root.get("upper", {}).get("top")
-                hots: list[dict[str, Any]] = data_root.get("hots") or []
-                replies_raw: list[dict[str, Any]] = data_root.get("replies") or []
-
-                upper_list: list[dict[str, Any]] = [upper_top] if upper_top else []
-
-                def _append_unique(
-                    src: list[dict[str, Any]], out: list[dict[str, Any]], seen: set[int]
-                ) -> None:
-                    for item in src:
-                        try:
-                            rpid: int = item["rpid"]
-                        except Exception:
-                            # 没有 rpid 的异常项直接跳过
-                            continue
-                        if rpid in seen:
-                            continue
-                        seen.add(rpid)
-                        out.append(item)
-
-                merged: list[dict[str, Any]] = []
-                seen_rpids: set[int] = set()
-
-                has_upper = bool(upper_list)
-                has_hots = bool(hots)
-
-                if has_upper and has_hots:
-                    # 置顶 + 热评
-                    _append_unique(upper_list, merged, seen_rpids)
-                    _append_unique(hots, merged, seen_rpids)
-                elif has_upper and not has_hots:
-                    # 置顶 + 普通
-                    _append_unique(upper_list, merged, seen_rpids)
-                    _append_unique(replies_raw, merged, seen_rpids)
-                elif has_hots and not has_upper:
-                    # 只有热评
-                    _append_unique(hots, merged, seen_rpids)
-                else:
-                    # 没有置顶也没有热评 → 普通
-                    _append_unique(replies_raw, merged, seen_rpids)
-
+            if data.get("code") != 0 or not data.get("data"):
                 logger.debug(
-                    f"bili获得评论: upper={len(upper_list)}, hots={len(hots)}, replies={len(replies_raw)}, merged={len(merged)}",
+                    f"bili评论返回数据为空或错误: code={data.get('code')}, message={data.get('message')}"
                 )
-                return self._process_reply_list(merged)
-
-            except Exception as e:
-                logger.error(f"[Bilibili] 获取评论失败: {e!r}")
                 return []
+
+            data_root = data["data"] or {}
+            upper_top = data_root.get("upper", {}).get("top")
+            hots: list[dict[str, Any]] = data_root.get("hots") or []
+            replies_raw: list[dict[str, Any]] = data_root.get("replies") or []
+
+            upper_list: list[dict[str, Any]] = [upper_top] if upper_top else []
+
+            def _append_unique(
+                src: list[dict[str, Any]], out: list[dict[str, Any]], seen: set[int]
+            ) -> None:
+                for item in src:
+                    try:
+                        rpid: int = item["rpid"]
+                    except Exception:
+                        # 没有 rpid 的异常项直接跳过
+                        continue
+                    if rpid in seen:
+                        continue
+                    seen.add(rpid)
+                    out.append(item)
+
+            merged: list[dict[str, Any]] = []
+            seen_rpids: set[int] = set()
+
+            has_upper = bool(upper_list)
+            has_hots = bool(hots)
+
+            if has_upper and has_hots:
+                # 置顶 + 热评
+                _append_unique(upper_list, merged, seen_rpids)
+                _append_unique(hots, merged, seen_rpids)
+            elif has_upper and not has_hots:
+                # 置顶 + 普通
+                _append_unique(upper_list, merged, seen_rpids)
+                _append_unique(replies_raw, merged, seen_rpids)
+            elif has_hots and not has_upper:
+                # 只有热评
+                _append_unique(hots, merged, seen_rpids)
+            else:
+                # 没有置顶也没有热评 → 普通
+                _append_unique(replies_raw, merged, seen_rpids)
+
+            logger.debug(
+                f"bili获得评论: upper={len(upper_list)}, hots={len(hots)}, replies={len(replies_raw)}, merged={len(merged)}",
+            )
+            return self._process_reply_list(merged)
+
+        except Exception as e:
+            logger.error(f"[Bilibili] 获取评论失败: {e!r}")
+            return []
 
     def _format_content_with_emote(
         self, raw: str, emote: dict[str, Any]

--- a/src/nonebot_plugin_parser_lite/parsers/bilibili/__init__.py
+++ b/src/nonebot_plugin_parser_lite/parsers/bilibili/__init__.py
@@ -67,6 +67,7 @@ class BilibiliParser(BaseParser):
         self.headers = HEADERS.copy()
         self._credential: Credential | None = None
         self._cookies_file = pconfig.config_dir / "bilibili_cookies.json"
+        self.ck_header: dict[str, str]
         self.black_mids: list[int] | None = None
         """黑名单作者列表"""
         self._black_list_job_added: bool = False
@@ -85,9 +86,8 @@ class BilibiliParser(BaseParser):
             self.black_mids = []
             return
 
-        request_headers = self.headers.copy()
-        request_headers["Cookie"] = "; ".join(f"{k}={v}" for k, v in cookies.items())
-        self.httpx.headers.update(request_headers)
+        self.ck_header = self.headers.copy()
+        self.ck_header["Cookie"] = "; ".join(f"{k}={v}" for k, v in cookies.items())
 
         base_url = "https://api.bilibili.com/x/relation/blacks"
         page_size = 50
@@ -96,6 +96,7 @@ class BilibiliParser(BaseParser):
         try:
             resp = await self.httpx.get(
                 base_url,
+                headers=self.ck_header,
                 params={"ps": page_size, "pn": 1},
             )
             resp.raise_for_status()
@@ -119,6 +120,7 @@ class BilibiliParser(BaseParser):
                 try:
                     resp = await self.httpx.get(
                         base_url,
+                        headers=self.ck_header,
                         params={"ps": page_size, "pn": pn},
                     )
                     resp.raise_for_status()
@@ -1040,6 +1042,7 @@ class BilibiliParser(BaseParser):
         try:
             response = await self.httpx.get(
                 "https://api.bilibili.com/x/v2/reply",
+                headers=self.ck_header,
                 params={
                     "oid": oid,
                     "type": type,

--- a/src/nonebot_plugin_parser_lite/parsers/buff/__init__.py
+++ b/src/nonebot_plugin_parser_lite/parsers/buff/__init__.py
@@ -1,7 +1,6 @@
 from re import Match
 from typing import Any, ClassVar, TypeVar
 
-from httpx import AsyncClient
 from msgspec import convert
 from nonebot.log import logger
 
@@ -22,10 +21,9 @@ class BuffParser(BaseParser):
     async def _fetch_ok_json(
         self, url: str, params: dict[str, Any], err_msg: str, model: type[T]
     ) -> T:
-        async with AsyncClient(headers=self.headers) as client:
-            resp = await client.get(url, params=params)
-            resp.raise_for_status()
-            data = resp.json()
+        resp = await self.httpx.get(url, params=params)
+        resp.raise_for_status()
+        data = resp.json()
         if data.get("code") != "OK":
             raise ParseException(f"{err_msg}: {data}")
         return convert(data["data"], model)
@@ -66,13 +64,12 @@ class BuffParser(BaseParser):
 
     async def fetch_comments(self, comment_type: int, type_id: str) -> list[Comment]:
         try:
-            async with AsyncClient(headers=self.headers) as client:
-                resp = await client.get(
-                    "https://buff.163.com/api/comment/share/detail",
-                    params={"comment_type": comment_type, "type_id": type_id},
-                )
-                resp.raise_for_status()
-                data = resp.json()
+            resp = await self.httpx.get(
+                "https://buff.163.com/api/comment/share/detail",
+                params={"comment_type": comment_type, "type_id": type_id},
+            )
+            resp.raise_for_status()
+            data = resp.json()
 
             if data.get("code") != "OK":
                 logger.warning(f"buff 评论获取失败: {data}")

--- a/src/nonebot_plugin_parser_lite/parsers/douyin/__init__.py
+++ b/src/nonebot_plugin_parser_lite/parsers/douyin/__init__.py
@@ -4,7 +4,6 @@ from typing import ClassVar
 from msgspec import convert
 from nonebot import logger
 
-from httpx import AsyncClient
 from ...utils.browser import BROWSER
 
 from ..base import (
@@ -125,14 +124,12 @@ class DouyinParser(BaseParser):
         )
 
     async def parse_video_or_article(self, url: str):
-        async with AsyncClient(
-            headers=self.ios_headers,
-            follow_redirects=False,
-        ) as client:
-            response = await client.get(url)
-            if response.status_code != 200:
-                raise ParseException(f"status: {response.status_code}")
-            text = response.text
+        response = await self.httpx.get(
+            url, headers=self.ios_headers, follow_redirects=False
+        )
+        if response.status_code != 200:
+            raise ParseException(f"status: {response.status_code}")
+        text = response.text
 
         matched = ROUTER_PATTERN.search(text)
 

--- a/src/nonebot_plugin_parser_lite/parsers/duitang/__init__.py
+++ b/src/nonebot_plugin_parser_lite/parsers/duitang/__init__.py
@@ -4,7 +4,6 @@ from typing import ClassVar
 from msgspec import convert
 
 from ...utils.format import format_num
-from httpx import AsyncClient
 from ..base import BaseParser, Comment, MediaContent, Platform, PlatformEnum, handle
 from .model import AtlasData, BlogData, CommentData
 
@@ -18,13 +17,11 @@ class DuiTangParser(BaseParser):
     async def parse_blog(self, searched: Match[str]):
         blog_id = searched["blog_id"]
 
-        async with AsyncClient() as client:
-            blog_data = await self._fetch_blog_detail(client, blog_id=blog_id)
-            comment_data = await self._fetch_comments(
-                client,
-                subject_id=blog_data.id,
-                subject_type=0,
-            )
+        blog_data = await self._fetch_blog_detail(blog_id=blog_id)
+        comment_data = await self._fetch_comments(
+            subject_id=blog_data.id,
+            subject_type=0,
+        )
 
         content: list[MediaContent | str] = [
             blog_data.msg,
@@ -51,13 +48,11 @@ class DuiTangParser(BaseParser):
     async def parse_atlas(self, searched: Match[str]):
         atlas_id = searched["atlas_id"]
 
-        async with AsyncClient() as client:
-            atlas_data = await self._fetch_atlas_detail(client, atlas_id=atlas_id)
-            comment_data = await self._fetch_comments(
-                client,
-                subject_id=atlas_data.id,
-                subject_type=23,
-            )
+        atlas_data = await self._fetch_atlas_detail(atlas_id=atlas_id)
+        comment_data = await self._fetch_comments(
+            subject_id=atlas_data.id,
+            subject_type=23,
+        )
 
         content: list[MediaContent | str] = [
             atlas_data.desc,
@@ -83,18 +78,16 @@ class DuiTangParser(BaseParser):
 
     async def _fetch_atlas_detail(
         self,
-        client: AsyncClient,
         atlas_id: str,
     ) -> AtlasData:
         """
         调用堆糖接口获取图集详情数据。该方法只负责请求和基础校验，并将结果转换为 AtlasData 对象。
 
-        :param client: 复用的 AsyncClient 实例。
         :param atlas_id: 图集 ID。
         :return: 转换后的图集详情数据。
         :raises ValueError: 当接口返回 message 不为 "success" 时抛出。
         """
-        response = await client.get(
+        response = await self.httpx.get(
             "https://www.duitang.com/napi/vienna/atlas/detail/",
             params={"atlas_id": atlas_id},
         )
@@ -106,18 +99,16 @@ class DuiTangParser(BaseParser):
 
     async def _fetch_blog_detail(
         self,
-        client: AsyncClient,
         blog_id: str,
     ) -> BlogData:
         """
         调用堆糖接口获取博客图集详情数据。该方法只负责请求和基础校验，并将结果转换为 BlogData 对象。
 
-        :param client: 复用的 AsyncClient 实例。
         :param blog_id: 图集 ID。
         :return: 转换后的博客图集详情数据。
         :raises ValueError: 当接口返回 message 不为 "success" 时抛出。
         """
-        response = await client.get(
+        response = await self.httpx.get(
             "https://www.duitang.com/napi/blog/with_instance_tag/detail/",
             params={
                 "blog_id": blog_id,
@@ -132,7 +123,6 @@ class DuiTangParser(BaseParser):
 
     async def _fetch_comments(
         self,
-        client: AsyncClient,
         subject_id: int,
         subject_type: int,
         limit: int = 5,
@@ -140,14 +130,13 @@ class DuiTangParser(BaseParser):
         """
         调用堆糖接口获取图集评论数据。该方法支持限制返回条数，用于构建评论列表。
 
-        :param client: 复用的 AsyncClient 实例。
         :param subject_id: 图集 ID，作为评论主体 ID。
         :param subject_type: 图集类型，作为评论主体类型。
         :param limit: 拉取的评论条数上限。
         :return: 转换后的评论数据对象。
         :raises ValueError: 当接口返回 message 不为 "success" 时抛出。
         """
-        response = await client.get(
+        response = await self.httpx.get(
             "https://www.duitang.com/napi/vienna/comment/list/",
             params={
                 "start": 0,

--- a/src/nonebot_plugin_parser_lite/parsers/heybox/__init__.py
+++ b/src/nonebot_plugin_parser_lite/parsers/heybox/__init__.py
@@ -6,7 +6,6 @@ from nonebot.log import logger
 
 from ...utils.browser import BROWSER
 from ...utils.format import format_num
-from httpx import AsyncClient
 from ..base import BaseParser, Comment, ParseException, Platform, PlatformEnum, handle
 from .encrypt import build_url
 from .model import BaseResult
@@ -44,13 +43,13 @@ class HeyBoxParser(BaseParser):
             logger.info(f"成功获取到小黑盒tokenid: {self.x_xhh_tokenid[:5]}...")
             tab.close()
 
-        async with AsyncClient(
+        response = await self.httpx.get(
+            build_url(link_id),
             headers=self.headers,
             cookies={"x_xhh_tokenid": self.x_xhh_tokenid},
-        ) as client:
-            response = await client.get(build_url(link_id))
-            response.raise_for_status()
-            res = response.json()
+        )
+        response.raise_for_status()
+        res = response.json()
 
         if res.get("status") != "ok":
             raise ParseException(f"小黑盒解析失败: {res}")

--- a/src/nonebot_plugin_parser_lite/parsers/kugou.py
+++ b/src/nonebot_plugin_parser_lite/parsers/kugou.py
@@ -5,8 +5,6 @@ import contextlib
 from re import Match
 from typing import ClassVar
 
-from httpx import AsyncClient
-
 from .base import (
     BaseParser,
     PlatformEnum,
@@ -127,87 +125,86 @@ class KuGouParser(BaseParser):
     )
     async def _parse_kugou_share(self, searched: Match[str]):
         """解析酷狗分享链接"""
-        share_url = searched.group(0)
-        async with AsyncClient() as client:
-            response = await client.get(share_url)
-            response.raise_for_status()
-            html_text = response.text
+        share_url = searched[0]
+        response = await self.httpx.get(share_url)
+        response.raise_for_status()
+        html_text = response.text
 
-            # 提取歌曲hash
-            _hash = self._extract_hash(html_text)
+        # 提取歌曲hash
+        _hash = self._extract_hash(html_text)
 
-            if not _hash:
-                raise ParseException("未找到歌曲hash")
+        if not _hash:
+            raise ParseException("未找到歌曲hash")
 
-            # 获取歌曲信息
-            response = await client.get(
-                f"https://m.kugou.com/app/i/getSongInfo.php?cmd=playInfo&hash={_hash}"
-            )
-            playinfo = Decoder(PlayInfo).decode(response.content)
-            if playinfo.errcode != 0:
-                raise ParseException(
-                    f"酷狗音乐解析失败: {playinfo.errcode} {playinfo.error}"
-                )
-
-            # 创建音频内容
-            audio_url = playinfo.url
-            if not audio_url:
-                raise ParseException("未找到音频资源")
-
-            audio_name = f"{playinfo.fileName}.{playinfo.extName}"
-
-            audio_content = self.create_audio(
-                url=audio_url,
-                duration=playinfo.timeLength,
-                audio_name=audio_name,
-            )
-            author = self.create_author(
-                name=playinfo.singerName  # , playinfo.imgUrl.format(size=480)
+        # 获取歌曲信息
+        response = await self.httpx.get(
+            f"https://m.kugou.com/app/i/getSongInfo.php?cmd=playInfo&hash={_hash}"
+        )
+        playinfo = Decoder(PlayInfo).decode(response.content)
+        if playinfo.errcode != 0:
+            raise ParseException(
+                f"酷狗音乐解析失败: {playinfo.errcode} {playinfo.error}"
             )
 
-            # 获取歌词列表
-            response = await client.get(
-                f"https://krcs.kugou.com/search?hash={playinfo.hash}"
-            )
-            krcs = Decoder(KrcsSearch).decode(response.content)
-            if krcs.errcode != 200:
-                raise ParseException(f"酷狗音乐解析失败: 歌词搜索失败: {krcs.errmsg}")
-            if not krcs.candidates:
-                raise ParseException("未找到歌词")
+        # 创建音频内容
+        audio_url = playinfo.url
+        if not audio_url:
+            raise ParseException("未找到音频资源")
 
-            # 获取歌词内容
-            response = await client.get(
-                f"https://lyrics.kugou.com/download?ver=1&id={krcs.candidates[0].id}&accesskey={krcs.candidates[0].accesskey}&fmt=lrc"
-            )
-            lyrics = Decoder(Lyrics).decode(response.content)
-            if lyrics.error_code != 0:
-                raise ParseException(f"酷狗音乐解析失败: 歌词获取失败: {lyrics.info}")
-            # 构建歌词文本
-            lyric = base64.b64decode(lyrics.content).decode(lyrics.charset)
-            text = f"歌词:\n{lyric}"
+        audio_name = f"{playinfo.fileName}.{playinfo.extName}"
 
-            # 创建封面图片内容
-            cover_url = playinfo.album_img.format(size=480)
-            contents: list[MediaContent] = [
-                self.create_image(url=cover_url, need_send=False)
-            ]
+        audio_content = self.create_audio(
+            url=audio_url,
+            duration=playinfo.timeLength,
+            audio_name=audio_name,
+        )
+        author = self.create_author(
+            name=playinfo.singerName  # , playinfo.imgUrl.format(size=480)
+        )
 
-            contents.append(audio_content)
+        # 获取歌词列表
+        response = await self.httpx.get(
+            f"https://krcs.kugou.com/search?hash={playinfo.hash}"
+        )
+        krcs = Decoder(KrcsSearch).decode(response.content)
+        if krcs.errcode != 200:
+            raise ParseException(f"酷狗音乐解析失败: 歌词搜索失败: {krcs.errmsg}")
+        if not krcs.candidates:
+            raise ParseException("未找到歌词")
 
-            # 构建额外信息
-            extra = {
-                "info": f"比特率: {playinfo.bitRate}K | 时长: {int(float(playinfo.timeLength) // 60)}"
-                f":{int(float(playinfo.timeLength) % 60):02d}",
-                "lyric": text,
-                "type": "audio",
-                "type_tag": "音乐",
-                "type_icon": "fa-music",
-            }
+        # 获取歌词内容
+        response = await self.httpx.get(
+            f"https://lyrics.kugou.com/download?ver=1&id={krcs.candidates[0].id}&accesskey={krcs.candidates[0].accesskey}&fmt=lrc"
+        )
+        lyrics = Decoder(Lyrics).decode(response.content)
+        if lyrics.error_code != 0:
+            raise ParseException(f"酷狗音乐解析失败: 歌词获取失败: {lyrics.info}")
+        # 构建歌词文本
+        lyric = base64.b64decode(lyrics.content).decode(lyrics.charset)
+        text = f"歌词:\n{lyric}"
 
-            return self.result(
-                title=playinfo.songName,
-                author=author,
-                url=share_url,
-                content=contents,
-                extra=extra,
-            )
+        # 创建封面图片内容
+        cover_url = playinfo.album_img.format(size=480)
+        contents: list[MediaContent] = [
+            self.create_image(url=cover_url, need_send=False)
+        ]
+
+        contents.append(audio_content)
+
+        # 构建额外信息
+        extra = {
+            "info": f"比特率: {playinfo.bitRate}K | 时长: {int(float(playinfo.timeLength) // 60)}"
+            f":{int(float(playinfo.timeLength) % 60):02d}",
+            "lyric": text,
+            "type": "audio",
+            "type_tag": "音乐",
+            "type_icon": "fa-music",
+        }
+
+        return self.result(
+            title=playinfo.songName,
+            author=author,
+            url=share_url,
+            content=contents,
+            extra=extra,
+        )

--- a/src/nonebot_plugin_parser_lite/parsers/kuwo.py
+++ b/src/nonebot_plugin_parser_lite/parsers/kuwo.py
@@ -2,7 +2,6 @@ import contextlib
 from re import Match
 from typing import ClassVar
 
-from httpx import AsyncClient
 from nonebot import logger
 
 from .base import (
@@ -23,81 +22,69 @@ class KuWoParser(BaseParser):
     @handle("kuwo.cn", r"https?://[^\s]*?kuwo\.cn/play_detail/\d+")
     async def _parse_kuwo_share(self, searched: Match[str]):
         """解析酷我音乐分享链接"""
-        share_url = searched.group(0)
+        share_url = searched[0]
         logger.debug(f"触发酷我音乐解析: {share_url}")
 
         # 使用API解析
-        try:
-            async with AsyncClient() as client:
-                api_url = "https://api.bugpk.com/api/kuwo"
-                params = {"url": share_url}
-                resp = await client.get(api_url, params=params)
-                resp.raise_for_status()
-                data = resp.json()
+        resp = await self.httpx.get(
+            "https://api.bugpk.com/api/kuwo", params={"url": share_url}
+        )
+        resp.raise_for_status()
+        data = resp.json()
 
-                # 检查接口返回状态
-                if data.get("code") != 200:
-                    raise ParseException(
-                        f"酷我音乐接口返回错误: {data.get('msg', '未知错误')}"
-                    )
+        # 检查接口返回状态
+        if data.get("code") != 200:
+            raise ParseException(f"酷我音乐接口返回错误: {data.get('msg', '未知错误')}")
 
-                music_data = data["data"]
-                logger.info(
-                    f"酷我音乐解析成功: {music_data['title']} - {music_data['artist']}"
-                )
+        music_data = data["data"]
+        logger.info(f"酷我音乐解析成功: {music_data['title']} - {music_data['artist']}")
 
-                # 创建音频内容
-                audio_url = music_data["music_url"]
-                if not audio_url.startswith("http"):
-                    raise ParseException("无效音乐URL")
+        # 创建音频内容
+        audio_url = music_data["music_url"]
+        if not audio_url.startswith("http"):
+            raise ParseException("无效音乐URL")
 
-                # 解析时长
-                duration = 0.0
-                if music_data.get("songTimeMinutes"):
-                    # 格式为 "mm:ss"
-                    with contextlib.suppress(ValueError):
-                        minutes, seconds = map(
-                            int, music_data["songTimeMinutes"].split(":")
-                        )
-                        duration = minutes * 60 + seconds
-                # 创建有意义的音频文件名
-                audio_name = f"{music_data['title']}-{music_data['artist']}.mp3"
-                # 创建音频内容
-                audio_content = self.create_audio(
-                    audio_url, duration, audio_name=audio_name
-                )
-                # 构建文本内容
-                text = (
-                    f"专辑: {music_data['album']}\n发行时间: {music_data['releaseDate']}"
-                    f"\n时长: {music_data['songTimeMinutes']}"
-                )
-                if music_data.get("lyrics_url"):
-                    text += f"\n歌词:\n{music_data['lyrics_url']}"
+        # 解析时长
+        duration = 0.0
+        if music_data.get("songTimeMinutes"):
+            # 格式为 "mm:ss"
+            with contextlib.suppress(ValueError):
+                minutes, seconds = map(int, music_data["songTimeMinutes"].split(":"))
+                duration = minutes * 60 + seconds
+        # 创建有意义的音频文件名
+        audio_name = f"{music_data['title']}-{music_data['artist']}.mp3"
+        # 创建音频内容
+        audio_content = self.create_audio(audio_url, duration, audio_name=audio_name)
+        # 构建文本内容
+        text = (
+            f"专辑: {music_data['album']}\n发行时间: {music_data['releaseDate']}"
+            f"\n时长: {music_data['songTimeMinutes']}"
+        )
+        if music_data.get("lyrics_url"):
+            text += f"\n歌词:\n{music_data['lyrics_url']}"
 
-                # 创建封面图片内容
-                contents: list[MediaContent] = []
+        # 创建封面图片内容
+        contents: list[MediaContent] = []
 
-                if cover_url := music_data.get("pic"):
-                    contents.append(self.create_image(cover_url, need_send=False))
+        if cover_url := music_data.get("pic"):
+            contents.append(self.create_image(cover_url, need_send=False))
 
-                # 添加音频内容到列表
-                contents.append(audio_content)
+        # 添加音频内容到列表
+        contents.append(audio_content)
 
-                # 构建额外信息
-                extra = {
-                    "info": f"时长: {music_data['songTimeMinutes']} | 专辑: {music_data['album']}",
-                    "lyric": text,
-                    "type": "audio",
-                    "type_tag": "音乐",
-                    "type_icon": "fa-music",
-                }
+        # 构建额外信息
+        extra = {
+            "info": f"时长: {music_data['songTimeMinutes']} | 专辑: {music_data['album']}",
+            "lyric": text,
+            "type": "audio",
+            "type_tag": "音乐",
+            "type_icon": "fa-music",
+        }
 
-                return self.result(
-                    title=music_data["title"],
-                    author=self.create_author(name=music_data["artist"]),
-                    url=share_url,
-                    content=contents,
-                    extra=extra,
-                )
-        except Exception as e:
-            raise ParseException(f"酷我音乐解析失败: {e}") from e
+        return self.result(
+            title=music_data["title"],
+            author=self.create_author(name=music_data["artist"]),
+            url=share_url,
+            content=contents,
+            extra=extra,
+        )

--- a/src/nonebot_plugin_parser_lite/parsers/lofter/__init__.py
+++ b/src/nonebot_plugin_parser_lite/parsers/lofter/__init__.py
@@ -5,7 +5,6 @@ from msgspec import convert
 from nonebot import logger
 
 from ...utils.format import format_num
-from httpx import AsyncClient
 from ..base import (
     BaseParser,
     MediaContent,
@@ -40,24 +39,23 @@ class LofterParser(BaseParser):
         blog_id = int(searched["blog_hex"], 16)
         post_id = int(searched["post_hex"], 16)
 
-        async with AsyncClient() as client:
-            # 帖子详情
-            post_resp = await client.post(
-                "https://api.lofter.com/oldapi/post/detail.api",
-                params={"product": "lofter-android-8.1.20"},
-                data={
-                    "postid": post_id,
-                    "targetblogid": blog_id,
-                },
-            )
-            post_data = post_resp.json()
+        # 帖子详情
+        post_resp = await self.httpx.post(
+            "https://api.lofter.com/oldapi/post/detail.api",
+            params={"product": "lofter-android-8.1.20"},
+            data={
+                "postid": post_id,
+                "targetblogid": blog_id,
+            },
+        )
+        post_data = post_resp.json()
 
-            # 评论数据
-            com_resp = await client.get(
-                "https://www.lofter.com/comment/l1/hotnew.json",
-                params={"postId": post_id, "blogId": blog_id},
-            )
-            com_data = com_resp.json()
+        # 评论数据
+        com_resp = await self.httpx.get(
+            "https://www.lofter.com/comment/l1/hotnew.json",
+            params={"postId": post_id, "blogId": blog_id},
+        )
+        com_data = com_resp.json()
 
         # 校验帖子状态
         meta = post_data.get("meta") or {}

--- a/src/nonebot_plugin_parser_lite/parsers/netease.py
+++ b/src/nonebot_plugin_parser_lite/parsers/netease.py
@@ -2,7 +2,6 @@ import re
 from re import Match
 from typing import ClassVar
 
-from httpx import AsyncClient
 from nonebot import logger
 
 from .base import (
@@ -24,20 +23,12 @@ class NCMParser(BaseParser):
         super().__init__()
         self.short_url_pattern = re.compile(r"(http:|https:)//163cn\.tv/([a-zA-Z0-9]+)")
 
-    async def _get_redirect_url(self, url: str) -> str:
-        """获取重定向后的URL"""
-
-        async with AsyncClient(follow_redirects=True) as client:
-            response = await client.get(url)
-            response.raise_for_status()
-            return str(response.url)
-
     async def parse_ncm(self, ncm_url: str) -> dict:
         """解析网易云音乐链接"""
         # 处理短链接
         if matched := self.short_url_pattern.search(ncm_url):
             ncm_url = matched.group(0)
-            ncm_url = await self._get_redirect_url(ncm_url)
+            ncm_url = await self.get_redirect_url(ncm_url)
 
         # 获取网易云歌曲id
         matched = re.search(r"(?:\?|&)id=(\d+)", ncm_url) or re.search(
@@ -50,47 +41,42 @@ class NCMParser(BaseParser):
         ncm_id = matched.group(1)
         logger.info(f"成功提取ID: {ncm_id} 来自 {ncm_url}")
 
-        # 使用新API解析
-        try:
-            async with AsyncClient() as client:
-                api_url = "https://api.bugpk.com/api/163_music"
-                # 使用GET请求，参数包括ids、level和type
-                params = {"ids": ncm_id, "level": "standard", "type": "json"}
-                resp = await client.get(api_url, params=params)
-                resp.raise_for_status()
-                data = resp.json()
+        resp = await self.httpx.get(
+            "https://api.bugpk.com/api/163_music",
+            params={"ids": ncm_id, "level": "standard", "type": "json"},
+        )
+        resp.raise_for_status()
+        data = resp.json()
 
-                # 检查接口返回状态
-                if data.get("status") != 200:
-                    raise ParseException(f"网易云接口返回错误: {data}")
+        # 检查接口返回状态
+        if data.get("status") != 200:
+            raise ParseException(f"网易云接口返回错误: {data}")
 
-                logger.info(f"解析成功: {data['name']} - {data['ar_name']}")
-                audio_info = f"音质: standard | 大小: {data.get('size', '')}"
+        logger.info(f"解析成功: {data['name']} - {data['ar_name']}")
+        audio_info = f"音质: standard | 大小: {data.get('size', '')}"
 
-                # 提取歌词信息
-                lyric = ""
-                if data.get("lyric"):
-                    lyric = data["lyric"]
-                    logger.info(f"找到歌词，长度: {len(lyric)}字符")
+        # 提取歌词信息
+        lyric = ""
+        if data.get("lyric"):
+            lyric = data["lyric"]
+            logger.info(f"找到歌词，长度: {len(lyric)}字符")
 
-                # 成功获取，返回结果
-                return {
-                    "title": data["name"],
-                    "author": data["ar_name"],
-                    "audio_info": audio_info,
-                    "cover_url": data["pic"],
-                    "audio_url": data["url"],
-                    "mv_info": {},  # 新API没有返回MV信息
-                    "lyric": lyric,
-                }
-        except Exception as e:
-            raise ParseException(f"网易云音乐解析失败: {e}") from e
+        # 成功获取，返回结果
+        return {
+            "title": data["name"],
+            "author": data["ar_name"],
+            "audio_info": audio_info,
+            "cover_url": data["pic"],
+            "audio_url": data["url"],
+            "mv_info": {},  # 新API没有返回MV信息
+            "lyric": lyric,
+        }
 
     @handle("music.163.com", r"https?://[^\s]*?music\.163\.com.*?(?:id=\d+|song/\d+)")
     @handle("163cn.tv", r"https?://[^\s]*?163cn\.tv/[a-zA-Z0-9]+")
     async def _parse_netease(self, searched: Match[str]):
         """解析网易云音乐分享链接"""
-        share_url = searched.group(0)
+        share_url = searched[0]
         logger.debug(f"触发网易云解析: {share_url}")
 
         # 解析网易云音乐

--- a/src/nonebot_plugin_parser_lite/parsers/qsmusic/__init__.py
+++ b/src/nonebot_plugin_parser_lite/parsers/qsmusic/__init__.py
@@ -2,8 +2,6 @@ import re
 from re import Match
 from typing import ClassVar
 
-from httpx import AsyncClient
-
 from ..base import (
     BaseParser,
     PlatformEnum,
@@ -29,14 +27,11 @@ class QSMusicParser(BaseParser):
     @handle("qishui.douyin.com", r"https?://[^\s]*?qishui\.douyin\.com/s/[a-zA-Z0-9]+/")
     async def _parse_qsmusic_share(self, searched: Match[str]):
         """解析汽水音乐分享链接"""
-        share_url = searched.group(0)
+        share_url = searched[0]
 
-        async with AsyncClient(
-            follow_redirects=True, headers=self.ios_headers
-        ) as client:
-            response = await client.get(share_url)
-            response.raise_for_status()
-            html = response.text
+        response = await self.httpx.get(share_url, headers=self.ios_headers)
+        response.raise_for_status()
+        html = response.text
         if matched := ROUTER_DATA.search(html):
             raw = matched[1]
         else:

--- a/src/nonebot_plugin_parser_lite/parsers/rednote/__init__.py
+++ b/src/nonebot_plugin_parser_lite/parsers/rednote/__init__.py
@@ -2,8 +2,6 @@ import re
 from typing import ClassVar
 from urllib.parse import parse_qsl
 
-from httpx import AsyncClient
-
 from ...utils.format import replace_placeholder_to_sticker
 
 from ..base import (
@@ -71,18 +69,18 @@ class RedNoteParser(BaseParser):
 
         url += f"?xsec_token={xsec_token}&xsec_source=pc_share"
 
-        async with AsyncClient(
+        response = await self.httpx.get(
+            url,
             headers=self.ios_headers,
             cookies=ck2dict(pconfig.xhs_ck) if pconfig.xhs_ck else None,
-        ) as client:
-            response = await client.get(url)
-            response.raise_for_status()
-            html = response.text
+        )
+        response.raise_for_status()
+        html = response.text
 
-            if matched := INITIAL_STATE.search(html):
-                raw = matched[1].replace("undefined", "null")
-            else:
-                raise ParseException("小红书分享链接失效或内容已删除")
+        if matched := INITIAL_STATE.search(html):
+            raw = matched[1].replace("undefined", "null")
+        else:
+            raise ParseException("小红书分享链接失效或内容已删除")
         init_state = discoveryDecoder.decode(raw)
         note_data = init_state.noteData.data
 

--- a/src/nonebot_plugin_parser_lite/parsers/toutiao.py
+++ b/src/nonebot_plugin_parser_lite/parsers/toutiao.py
@@ -11,7 +11,6 @@ from .base import (
     handle,
 )
 from .data import Platform, MediaContent
-from httpx import AsyncClient
 
 
 class ToutiaoParser(BaseParser):
@@ -30,96 +29,88 @@ class ToutiaoParser(BaseParser):
     )
     async def _parse_toutiao_share(self, searched: Match[str]):
         """解析今日头条分享链接"""
-        share_url = searched.group(0)
+        share_url = searched[0]
         logger.debug(f"触发今日头条解析: {share_url}")
 
         # 使用API解析
+        resp = await self.httpx.get(
+            "https://api.bugpk.com/api/toutiao", params={"url": share_url}
+        )
+        resp.raise_for_status()
+
+        # 检查响应内容
+        if not resp.content:
+            raise ParseException("今日头条接口返回空内容")
+
         try:
-            async with AsyncClient() as client:
-                api_url = "https://api.bugpk.com/api/toutiao"
-                params = {"url": share_url}
-                resp = await client.get(api_url, params=params)
-                resp.raise_for_status()
+            # 获取原始响应文本
+            response_text = resp.text
 
-                # 检查响应内容
-                if not resp.content:
-                    raise ParseException("今日头条接口返回空内容")
+            # 提取JSON部分 - 找到第一个{和最后一个}，忽略前面的HTML警告
+            json_start = response_text.find("{")
+            json_end = response_text.rfind("}") + 1
 
-                try:
-                    # 获取原始响应文本
-                    response_text = resp.text
+            if json_start != -1 and json_end != -1:
+                # 提取纯JSON字符串
+                pure_json = response_text[json_start:json_end]
+                data = json.loads(pure_json)
+            else:
+                # 如果找不到JSON结构，尝试直接解析
+                data = resp.json()
+        except json.JSONDecodeError as e:
+            # 记录响应内容以便调试
+            logger.error(f"今日头条接口返回无效JSON: {resp.text[:100]}...")
+            raise ParseException(f"今日头条接口返回无效JSON: {e}") from e
 
-                    # 提取JSON部分 - 找到第一个{和最后一个}，忽略前面的HTML警告
-                    json_start = response_text.find("{")
-                    json_end = response_text.rfind("}") + 1
+        # 检查接口返回状态
+        if data.get("code") != 200:
+            raise ParseException(f"今日头条接口返回错误: {data.get('msg', '未知错误')}")
 
-                    if json_start != -1 and json_end != -1:
-                        # 提取纯JSON字符串
-                        pure_json = response_text[json_start:json_end]
-                        data = json.loads(pure_json)
-                    else:
-                        # 如果找不到JSON结构，尝试直接解析
-                        data = resp.json()
-                except json.JSONDecodeError as e:
-                    # 记录响应内容以便调试
-                    logger.error(f"今日头条接口返回无效JSON: {resp.text[:100]}...")
-                    raise ParseException(f"今日头条接口返回无效JSON: {e}") from e
+        video_data = data.get("data")
+        if not video_data or not isinstance(video_data, dict):
+            raise ParseException("今日头条接口返回无效数据")
 
-                # 检查接口返回状态
-                if data.get("code") != 200:
-                    raise ParseException(
-                        f"今日头条接口返回错误: {data.get('msg', '未知错误')}"
-                    )
+        logger.info(
+            f"今日头条解析成功: {video_data.get('title', '未知标题')} - {video_data.get('author', '未知作者')}"
+        )
 
-                video_data = data.get("data")
-                if not video_data or not isinstance(video_data, dict):
-                    raise ParseException("今日头条接口返回无效数据")
+        # 创建视频内容 - 使用get方法安全访问
+        video_url = video_data.get("url")
+        if not video_url or not video_url.startswith("http"):
+            raise ParseException("无效视频URL")
 
-                logger.info(
-                    f"今日头条解析成功: {video_data.get('title', '未知标题')} - {video_data.get('author', '未知作者')}"
-                )
+        # 解析封面 - 使用get方法安全访问
+        cover_url = video_data.get("cover")
 
-                # 创建视频内容 - 使用get方法安全访问
-                video_url = video_data.get("url")
-                if not video_url or not video_url.startswith("http"):
-                    raise ParseException("无效视频URL")
+        # 创建视频内容
+        video_content = self.create_video(
+            video_url,
+            cover_url,
+            0.0,  # API没有返回时长
+        )
 
-                # 解析封面 - 使用get方法安全访问
-                cover_url = video_data.get("cover")
+        # 构建内容列表
+        contents: list[MediaContent | str] = [
+            video_data.get("description", ""),
+            video_content,
+        ]
 
-                # 创建视频内容
-                video_content = self.create_video(
-                    video_url,
-                    cover_url,
-                    0.0,  # API没有返回时长
-                )
+        # 构建额外信息
+        extra = {
+            "info": f"作者: {video_data.get('author', '未知作者')}",
+            "type": "video",
+            "type_tag": "短视频",
+            "type_icon": "fa-video",
+        }
 
-                # 构建内容列表
-                contents: list[MediaContent | str] = [
-                    video_data.get("description", ""),
-                    video_content,
-                ]
+        # 构建作者信息 - 安全访问字段
+        author_name = video_data.get("author", "未知作者")
+        author_avatar = video_data.get("avatar")
 
-                # 构建额外信息
-                extra = {
-                    "info": f"作者: {video_data.get('author', '未知作者')}",
-                    "type": "video",
-                    "type_tag": "短视频",
-                    "type_icon": "fa-video",
-                }
-
-                # 构建作者信息 - 安全访问字段
-                author_name = video_data.get("author", "未知作者")
-                author_avatar = video_data.get("avatar")
-
-                return self.result(
-                    title=video_data.get("title", "无标题"),
-                    author=self.create_author(
-                        name=author_name, avatar_url=author_avatar
-                    ),
-                    url=share_url,
-                    content=contents,
-                    extra=extra,
-                )
-        except Exception as e:
-            raise ParseException(f"今日头条解析失败: {e}") from e
+        return self.result(
+            title=video_data.get("title", "无标题"),
+            author=self.create_author(name=author_name, avatar_url=author_avatar),
+            url=share_url,
+            content=contents,
+            extra=extra,
+        )

--- a/src/nonebot_plugin_parser_lite/parsers/weibo/__init__.py
+++ b/src/nonebot_plugin_parser_lite/parsers/weibo/__init__.py
@@ -1,3 +1,6 @@
+# TODO: 解析似乎坏了
+
+import json
 from math import ceil
 from re import Match
 from time import time
@@ -39,6 +42,7 @@ class WeiBoParser(BaseParser):
                 "origin": "https://weibo.com",
             }
         )
+        self.httpx.headers.update(self.headers)
 
     # https://weibo.com/tv/show/1034:5007449447661594?mid=5007452630158934
     @handle("weibo.com/tv", r"weibo\.com/tv/show/\d{4}:\d+\?mid=(?P<mid>\d+)")
@@ -80,18 +84,15 @@ class WeiBoParser(BaseParser):
         return await self.parse_article(_id)
 
     async def parse_article(self, _id: str):
-        url = "https://card.weibo.com/article/m/aj/detail"
-        params = {
-            "_rid": str(uuid4()),
-            "id": _id,
-            "_t": int(time() * 1000),
-        }
-
-        async with AsyncClient(
-            headers=self.headers,
-        ) as client:
-            response = await client.get(url, params=params)
-            response.raise_for_status()
+        response = await self.httpx.get(
+            "https://card.weibo.com/article/m/aj/detail",
+            params={
+                "_rid": str(uuid4()),
+                "id": _id,
+                "_t": int(time() * 1000),
+            },
+        )
+        response.raise_for_status()
 
         detail = articleDecoder.decode(response.content)
 
@@ -132,18 +133,18 @@ class WeiBoParser(BaseParser):
     async def parse_fid(self, fid: str):
         """解析 show (带 fid)"""
 
-        req_url = f"https://h5.video.weibo.com/api/component?page=/show/{fid}"
-        headers = {
-            "Referer": f"https://h5.video.weibo.com/show/{fid}",
-            "Content-Type": "application/x-www-form-urlencoded",
-            **self.headers,
-        }
+        payload = {"Component_Play_Playinfo": {"oid": fid}}
 
-        async with AsyncClient(headers=headers) as client:
-            response = await client.post(
-                req_url, data={"data": f'{{Component_Play_Playinfo": {{"oid": {fid}}}'}
-            )
-            response.raise_for_status()
+        response = await self.httpx.post(
+            f"https://h5.video.weibo.com/api/component?page=/show/{fid}",
+            data={"data": json.dumps(payload, ensure_ascii=False)},
+            headers={
+                "Referer": f"https://h5.video.weibo.com/show/{fid}",
+                "Content-Type": "application/x-www-form-urlencoded",
+                **self.headers,
+            },
+        )
+        response.raise_for_status()
 
         data = showDecoder.decode(response.content).data
         play_info = data.Component_Play_Playinfo

--- a/src/nonebot_plugin_parser_lite/parsers/x/__init__.py
+++ b/src/nonebot_plugin_parser_lite/parsers/x/__init__.py
@@ -1,7 +1,6 @@
 from re import Match
 from typing import ClassVar
 
-from httpx import AsyncClient
 from msgspec import convert
 
 from ...utils.format import format_num
@@ -42,7 +41,7 @@ class XParser(BaseParser):
     @handle("t.co", r"t.co/\w+")
     async def _parse_t_co(self, searched: Match[str]):
         url = f"https://{searched[0]}"
-        return await self.parse_with_redirect(url, self.headers)
+        return await self.parse_with_redirect(url)
 
     @handle("twitter.com", r"twitter.com/[0-9-a-zA-Z_]{1,20}/status/([0-9]+)")
     @handle("x.com", r"x.com/[0-9-a-zA-Z_]{1,20}/status/([0-9]+)")
@@ -51,13 +50,12 @@ class XParser(BaseParser):
         token_num = int(tweet_id) / 1e15
         token = str(token_num * 3.141592653589793).replace("0", "").replace(".", "")
 
-        async with AsyncClient(headers=self.headers) as client:
-            resp = await client.get(
-                "https://cdn.syndication.twimg.com/tweet-result",
-                params={"id": tweet_id, "token": token},
-            )
-            resp.raise_for_status()
-            data = resp.json()
+        resp = await self.httpx.get(
+            "https://cdn.syndication.twimg.com/tweet-result",
+            params={"id": tweet_id, "token": token},
+        )
+        resp.raise_for_status()
+        data = resp.json()
 
         tweet = convert(data, Tweet)
         return self.collect_data(tweet)

--- a/src/nonebot_plugin_parser_lite/parsers/zhihu/__init__.py
+++ b/src/nonebot_plugin_parser_lite/parsers/zhihu/__init__.py
@@ -1,8 +1,6 @@
 import re
 from typing import ClassVar
 
-from httpx import AsyncClient
-
 
 from ...utils.format import format_num
 
@@ -71,17 +69,16 @@ class ZhiHuParser(BaseParser):
         return answerDecoder.decode(raw)
 
     async def fetch_video(self, video_id: str):
-        async with AsyncClient() as client:
-            res = await client.post(
-                "https://www.zhihu.com/api/v4/video/play_info",
-                json={
-                    "content_id": video_id,
-                    "video_id": video_id,
-                    "content_type_str": "answer",
-                    "is_only_video": True,
-                },
-            )
-            data = res.json()
+        res = await self.httpx.post(
+            "https://www.zhihu.com/api/v4/video/play_info",
+            json={
+                "content_id": video_id,
+                "video_id": video_id,
+                "content_type_str": "answer",
+                "is_only_video": True,
+            },
+        )
+        data = res.json()
         if "video_play" not in data:
             raise ValueError(f"Invalid video data: {data}")
 


### PR DESCRIPTION
移除各解析器中独立的AsyncClient导入和实例化， 改用基类统一管理的httpx客户端实例， 提升代码一致性和资源复用效率。

BREAKING CHANGE: 各解析器不再需要单独创建AsyncClient实例， 统一通过基类的self.httpx属性进行HTTP请求。

Co-authored-by: Copilot <copilot@github.com>

## Summary by Sourcery

重构解析器以使用共享的基类 HTTP 客户端，而不是在每个解析器模块中创建临时的 `httpx.AsyncClient` 实例。

改进内容：
- 在 `BaseParser` 上引入一个可复用的 `AsyncClient` 实例，并将解析器实现中的所有 HTTP 请求都通过该共享客户端进行。
- 统一各解析器在以下平台上的请求行为：Bilibili、Toutiao、Kugou、Kuwo、Netease、Weibo、DuiTang、Lofter、Zhihu、Buff、Xiaohongshu、X/Twitter、Douyin、QSMusic、Heybox 和 AcFun。
- 在需要的情况下，将各个解析器中的通用请求头传递到共享的 HTTP 客户端中，以保持每个服务的特定需求不变。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor parsers to use a shared base-class HTTP client instead of creating ad-hoc httpx.AsyncClient instances in each parser module.

Enhancements:
- Introduce a reusable AsyncClient instance on the BaseParser and route all HTTP requests in parser implementations through this shared client.
- Align request behavior across parsers for platforms like Bilibili, Toutiao, Kugou, Kuwo, Netease, Weibo, DuiTang, Lofter, Zhihu, Buff, Xiaohongshu, X/Twitter, Douyin, QSMusic, Heybox, and AcFun.
- Propagate common headers from individual parsers into the shared HTTP client where needed to keep per-service requirements intact.

</details>