### PR TITLE
feat(weibo): 切换至ajax状态API并使用共享会话解析微博

### DIFF
--- a/api_txt/weibo/statuses.json
+++ b/api_txt/weibo/statuses.json
@@ -1,0 +1,528 @@
+{
+  "visible": {
+    "type": 0,
+    "list_id": 0
+  },
+  "created_at": "Tue Nov 18 16:19:12 +0800 2025",
+  "id": 5234367615996775,
+  "idstr": "5234367615996775",
+  "mid": "5234367615996775",
+  "mblogid": "Qeq3Dpa2b",
+  "user": {
+    "id": 1980237443,
+    "idstr": "1980237443",
+    "pc_new": 7,
+    "screen_name": "青冥童子",
+    "profile_image_url": "https://tva1.sinaimg.cn/crop.0.0.399.399.50/76080683gw1el1hzd2gtoj20b40b4aav.jpg?KID=imgbed,tva&Expires=1777063194&ssig=W1BdjuqDpG",
+    "profile_url": "/u/1980237443",
+    "verified": true,
+    "verified_type": 0,
+    "domain": "",
+    "weihao": "",
+    "verified_type_ext": 2,
+    "status_total_counter": {
+      "total_cnt_format": "685.9万",
+      "comment_cnt": "542,500",
+      "repost_cnt": "3,116,366",
+      "like_cnt": "3,199,658",
+      "total_cnt": "6,858,524"
+    },
+    "avatar_large": "https://tva1.sinaimg.cn/crop.0.0.399.399.180/76080683gw1el1hzd2gtoj20b40b4aav.jpg?KID=imgbed,tva&Expires=1777063194&ssig=xrRgoo0dca",
+    "avatar_hd": "https://tva1.sinaimg.cn/crop.0.0.399.399.1024/76080683gw1el1hzd2gtoj20b40b4aav.jpg?KID=imgbed,tva&Expires=1777063194&ssig=G9z5Dlrfma",
+    "follow_me": false,
+    "following": false,
+    "mbrank": 2,
+    "mbtype": 12,
+    "v_plus": 0,
+    "user_ability": 2361868,
+    "planet_video": false,
+    "icon_list": [
+      {
+        "type": "vip",
+        "data": {
+          "mbrank": 2,
+          "mbtype": 12,
+          "svip": 1,
+          "vvip": 1
+        }
+      },
+      {
+        "type": "icon",
+        "data": {
+          "value": "1",
+          "icon_img": "https://d.sinaimg.cn/prd/106/1683/2026/02/28/feed_icon_shumiao2x.png",
+          "title": "树苗",
+          "url": "https://s.weibo.com/weibo?q=%23绿植领养%23"
+        }
+      }
+    ]
+  },
+  "source": "微博网页版",
+  "favorited": false,
+  "pic_ids": [],
+  "pic_num": 0,
+  "is_paid": false,
+  "mblog_vip_type": 0,
+  "number_display_strategy": {
+    "apply_scenario_flag": 19,
+    "display_text_min_number": 1000000,
+    "display_text": "100万+"
+  },
+  "reposts_count": 30,
+  "comments_count": 2,
+  "attitudes_count": 21,
+  "attitudes_status": 0,
+  "isLongText": false,
+  "mlevel": 0,
+  "content_auth": 0,
+  "is_show_bulletin": 2,
+  "comment_manage_info": {
+    "comment_permission_type": -1,
+    "approval_comment_type": 0,
+    "comment_sort_type": 0
+  },
+  "repost_type": 1,
+  "share_repost_type": 0,
+  "url_struct": [
+    {
+      "url_title": "野比大雄的微博视频",
+      "url_type_pic": "https://h5.sinaimg.cn/upload/2015/09/25/3/timeline_card_small_video.png",
+      "ori_url": "sinaweibo://video/vvs?mid=5234001406855704&object_id=1034:5234001246355474&url_type=39&object_type=video&pos=1",
+      "page_id": "2304445234001246355474",
+      "short_url": "http://t.cn/AX2rvlND",
+      "long_url": "https://video.weibo.com/show?fid=1034:5234001246355474",
+      "url_type": 39,
+      "result": false,
+      "storage_type": "oss",
+      "hide": 0,
+      "object_type": "",
+      "ttl": 3600,
+      "h5_target_url": "https://video.weibo.com/show?fid=1034:5234001246355474&from=1FFFF96039&weiboauthoruid=5819071204",
+      "need_save_obj": 0
+    }
+  ],
+  "title": {
+    "text": "公开",
+    "base_color": 1,
+    "icon_url": "http://h5.sinaimg.cn/upload/2015/07/14/34/timeline_title_public.png"
+  },
+  "mblogtype": 0,
+  "showFeedRepost": false,
+  "showFeedComment": false,
+  "pictureViewerSign": false,
+  "showPictureViewer": false,
+  "rcList": [],
+  "analysis_extra": "mblog_rt_mid:5234001406855704",
+  "readtimetype": "mblog",
+  "mixed_count": 0,
+  "is_show_mixed": false,
+  "mblog_feed_back_menus_format": [],
+  "isAd": false,
+  "isSinglePayAudio": false,
+  "isMarkdown": false,
+  "text": "电动车开门be like //\u003Ca href=/n/光之吸豚师二号机 usercard=\"name=@光之吸豚师二号机\"\u003E@光之吸豚师二号机\u003C/a\u003E:。//\u003Ca href=/n/重工组长于彦舒 usercard=\"name=@重工组长于彦舒\"\u003E@重工组长于彦舒\u003C/a\u003E:？",
+  "text_raw": "电动车开门be like //@光之吸豚师二号机:。//@重工组长于彦舒:？",
+  "region_name": "发布于 河南",
+  "retweeted_status": {
+    "created_at": "Mon Nov 17 16:04:01 +0800 2025",
+    "id": 5234001406855704,
+    "idstr": "5234001406855704",
+    "mid": "5234001406855704",
+    "mblogid": "QegwYsLtS",
+    "user": {
+      "id": 5819071204,
+      "idstr": "5819071204",
+      "pc_new": 7,
+      "screen_name": "野比大雄",
+      "profile_image_url": "https://tvax4.sinaimg.cn/crop.0.0.1080.1080.50/006lOefaly8hr4vv8gz4sj30u00u00vy.jpg?KID=imgbed,tva&Expires=1777063194&ssig=Eqj%2FX3QmzZ",
+      "profile_url": "/u/5819071204",
+      "verified": true,
+      "verified_type": 0,
+      "domain": "",
+      "weihao": "",
+      "verified_type_ext": 1,
+      "status_total_counter": {
+        "total_cnt_format": "1.10亿",
+        "comment_cnt": "3,599,811",
+        "repost_cnt": "61,429,531",
+        "like_cnt": "45,110,710",
+        "total_cnt": "110,140,052"
+      },
+      "avatar_large": "https://tvax4.sinaimg.cn/crop.0.0.1080.1080.180/006lOefaly8hr4vv8gz4sj30u00u00vy.jpg?KID=imgbed,tva&Expires=1777063194&ssig=AYQrb0vE6d",
+      "avatar_hd": "https://tvax4.sinaimg.cn/crop.0.0.1080.1080.1024/006lOefaly8hr4vv8gz4sj30u00u00vy.jpg?KID=imgbed,tva&Expires=1777063194&ssig=n918uMrEXB",
+      "follow_me": false,
+      "following": false,
+      "mbrank": 3,
+      "mbtype": 12,
+      "v_plus": 0,
+      "user_ability": 3427848,
+      "planet_video": false,
+      "icon_list": [
+        {
+          "type": "vip",
+          "data": {
+            "mbrank": 3,
+            "mbtype": 12,
+            "svip": 1,
+            "vvip": 1
+          }
+        },
+        {
+          "type": "icon",
+          "data": {
+            "value": "1",
+            "icon_img": "https://d.sinaimg.cn/prd/106/1683/2026/02/28/feed_icon_shumiao2x.png",
+            "title": "树苗",
+            "url": "https://s.weibo.com/weibo?q=%23绿植领养%23"
+          }
+        }
+      ]
+    },
+    "can_edit": false,
+    "textLength": 77,
+    "source": "微博视频号",
+    "favorited": false,
+    "pic_ids": [],
+    "geo": null,
+    "pic_num": 0,
+    "is_paid": false,
+    "mblog_vip_type": 0,
+    "number_display_strategy": {
+      "apply_scenario_flag": 19,
+      "display_text_min_number": 1000000,
+      "display_text": "100万+"
+    },
+    "reposts_count": 1670,
+    "comments_count": 386,
+    "attitudes_count": 9890,
+    "attitudes_status": 0,
+    "isLongText": false,
+    "mlevel": 0,
+    "content_auth": 0,
+    "is_show_bulletin": 2,
+    "comment_manage_info": {
+      "comment_permission_type": -1,
+      "approval_comment_type": 0,
+      "comment_sort_type": 0,
+      "ai_play_picture_type": 0
+    },
+    "mblogtype": 0,
+    "showFeedRepost": false,
+    "showFeedComment": false,
+    "pictureViewerSign": false,
+    "showPictureViewer": false,
+    "rcList": [],
+    "mixed_count": 0,
+    "is_show_mixed": false,
+    "mblog_feed_back_menus_format": [],
+    "isAd": false,
+    "isSinglePayAudio": false,
+    "isMarkdown": false,
+    "text": "当你试图在时尚的餐厅洗手时……是我孤闻寡陋了…再见\u003Cimg alt=\"[裂开]\" title=\"[裂开]\" src=\"https://face.t.sinajs.cn/t4/appstyle/expression/ext/normal/6d/202011_liekai_mobile.png\" /\u003E \u003Ca target=\"_blank\" href=\"https://video.weibo.com/show?fid=1034:5234001246355474\"\u003E\u003Cimg class=\"icon-link\" title=\"http://t.cn/AX2rvlND\" src=\"https://h5.sinaimg.cn/upload/2015/09/25/3/timeline_card_small_video_default.png\"/\u003E野比大雄的微博视频\u003C/a\u003E ​​​",
+    "text_raw": "当你试图在时尚的餐厅洗手时……是我孤闻寡陋了…再见[裂开] http://t.cn/AX2rvlND ​​​",
+    "region_name": "发布于 重庆"
+  },
+  "page_info": {
+    "type": "11",
+    "page_id": "2304445234001246355474",
+    "object_type": "video",
+    "object_id": "1034:5234001246355474",
+    "content1": "野比大雄的微博视频",
+    "content2": "当你试图在时尚的餐厅洗手时……是我孤闻寡陋了…再见[裂开]",
+    "act_status": 1,
+    "media_info": {
+      "name": "野比大雄的微博视频",
+      "stream_url": "http://f.video.weibocdn.com/o0/O5ogjlPdlx08t36nOhrq010412005oid0E010.mp4?label=mp4_720p&template=720x1280.24.0&ori=0&ps=1CwnkDw1GXwCQx&Expires=1777055994&ssig=LJqmd8duit&KID=unistore,video",
+      "stream_url_hd": "http://f.video.weibocdn.com/o0/O5ogjlPdlx08t36nOhrq010412005oid0E010.mp4?label=mp4_720p&template=720x1280.24.0&ori=0&ps=1CwnkDw1GXwCQx&Expires=1777055994&ssig=LJqmd8duit&KID=unistore,video",
+      "format": "mp4",
+      "h5_url": "https://video.weibo.com/show?fid=1034:5234001246355474",
+      "mp4_sd_url": "http://f.video.weibocdn.com/o0/O5ogjlPdlx08t36nOhrq010412005oid0E010.mp4?label=mp4_720p&template=720x1280.24.0&ori=0&ps=1CwnkDw1GXwCQx&Expires=1777055994&ssig=LJqmd8duit&KID=unistore,video",
+      "mp4_hd_url": "http://f.video.weibocdn.com/o0/O5ogjlPdlx08t36nOhrq010412005oid0E010.mp4?label=mp4_720p&template=720x1280.24.0&ori=0&ps=1CwnkDw1GXwCQx&Expires=1777055994&ssig=LJqmd8duit&KID=unistore,video",
+      "h265_mp4_hd": "http://f.video.weibocdn.com/o0/O5ogjlPdlx08t36nOhrq010412005oid0E010.mp4?label=mp4_720p&template=720x1280.24.0&ori=0&ps=1CwnkDw1GXwCQx&Expires=1777055994&ssig=LJqmd8duit&KID=unistore,video",
+      "h265_mp4_ld": "http://f.video.weibocdn.com/o0/O5ogjlPdlx08t36nOhrq010412005oid0E010.mp4?label=mp4_720p&template=720x1280.24.0&ori=0&ps=1CwnkDw1GXwCQx&Expires=1777055994&ssig=LJqmd8duit&KID=unistore,video",
+      "inch_4_mp4_hd": "http://f.video.weibocdn.com/o0/O5ogjlPdlx08t36nOhrq010412005oid0E010.mp4?label=mp4_720p&template=720x1280.24.0&ori=0&ps=1CwnkDw1GXwCQx&Expires=1777055994&ssig=LJqmd8duit&KID=unistore,video",
+      "inch_5_mp4_hd": "http://f.video.weibocdn.com/o0/O5ogjlPdlx08t36nOhrq010412005oid0E010.mp4?label=mp4_720p&template=720x1280.24.0&ori=0&ps=1CwnkDw1GXwCQx&Expires=1777055994&ssig=LJqmd8duit&KID=unistore,video",
+      "inch_5_5_mp4_hd": "http://f.video.weibocdn.com/o0/O5ogjlPdlx08t36nOhrq010412005oid0E010.mp4?label=mp4_720p&template=720x1280.24.0&ori=0&ps=1CwnkDw1GXwCQx&Expires=1777055994&ssig=LJqmd8duit&KID=unistore,video",
+      "mp4_720p_mp4": "http://f.video.weibocdn.com/o0/O5ogjlPdlx08t36nOhrq010412005oid0E010.mp4?label=mp4_720p&template=720x1280.24.0&ori=0&ps=1CwnkDw1GXwCQx&Expires=1777055994&ssig=LJqmd8duit&KID=unistore,video",
+      "hevc_mp4_720p": "",
+      "prefetch_type": 1,
+      "prefetch_size": 262144,
+      "act_status": 1,
+      "protocol": "general,dash",
+      "media_id": "5234001246355474",
+      "origin_total_bitrate": 4847376,
+      "video_orientation": "vertical",
+      "duration": 14,
+      "forward_strategy": -1,
+      "search_scheme": "sinaweibo://svssearch?containerid=232080",
+      "is_short_video": 0,
+      "vote_is_show": 0,
+      "belong_collection": 0,
+      "titles_display_time": "3",
+      "show_progress_bar": 1,
+      "show_mute_button": true,
+      "ext_info": {
+        "video_orientation": "vertical"
+      },
+      "next_title": "当你试图在时尚的餐厅洗手时……是我孤闻寡陋了…再见[裂开]",
+      "kol_title": "当你试图在时尚的餐厅洗手时……是我孤闻寡陋了…再见[裂开]",
+      "play_completion_actions": [
+        {
+          "type": "1",
+          "icon": "https://h5.sinaimg.cn/upload/100/1413/2021/12/22/feed_video_icon_replay.png",
+          "text": "重播",
+          "link": "",
+          "btn_code": 1000,
+          "show_position": 1,
+          "actionlog": {
+            "oid": "2304445234001246355474",
+            "act_code": 1221,
+            "act_type": 0,
+            "source": "video"
+          }
+        },
+        {
+          "type": 6,
+          "icon": "https://tvax4.sinaimg.cn/crop.0.0.1080.1080.180/006lOefaly8hr4vv8gz4sj30u00u00vy.jpg?KID=imgbed,tva&Expires=1777063194&ssig=AYQrb0vE6d",
+          "text": "",
+          "display_mode": 2,
+          "display_starttime": 5,
+          "display_endtime": 99999,
+          "countdown_time": 5,
+          "show_position": 48,
+          "scheme": "",
+          "link": "",
+          "btn_code": 1009,
+          "actionlog": {
+            "oid": "2304445234001246355474",
+            "act_code": 91,
+            "act_type": 0,
+            "source": "video",
+            "ext": "mid:5234001406855704|oid:1034:5234001246355474|muid:5819071204|authorid:5819071204"
+          },
+          "ext": {
+            "uid": "5819071204",
+            "user_name": "野比大雄",
+            "followers_count": 4331859,
+            "verified": true,
+            "verified_type": 0,
+            "verified_type_ext": 1,
+            "verified_reason": "搞笑幽默博主",
+            "level": 3
+          },
+          "display_type": 0
+        }
+      ],
+      "video_publish_time": 1763366604,
+      "play_loop_type": 0,
+      "author_mid": "5234001406855704",
+      "author_name": "野比大雄",
+      "extra_info": {
+        "sceneid": "feed"
+      },
+      "video_download_strategy": {
+        "abandon_download": 0
+      },
+      "jump_to": 6,
+      "media_type": "video",
+      "big_pic_info": {
+        "pic_big": {
+          "height": 961,
+          "url": "https://wx1.sinaimg.cn/orj1080/006lOefagy1i7f9vcbiygj30k00qp0vh.jpg",
+          "width": 720
+        },
+        "pic_small": {
+          "height": 240,
+          "url": "https://wx1.sinaimg.cn/or180/006lOefagy1i7f9vcbiygj30k00qp0vh.jpg",
+          "width": 180
+        },
+        "pic_middle": {
+          "height": 480,
+          "url": "https://wx1.sinaimg.cn/or360/006lOefagy1i7f9vcbiygj30k00qp0vh.jpg",
+          "width": 360
+        }
+      },
+      "online_users": "64.2万次观看",
+      "online_users_number": 642318,
+      "ttl": 3600,
+      "storage_type": "oss",
+      "is_keep_current_mblog": 0,
+      "has_recommend_video": 1,
+      "author_info": {
+        "id": 5819071204,
+        "idstr": "5819071204",
+        "pc_new": 7,
+        "screen_name": "野比大雄",
+        "profile_image_url": "https://tvax4.sinaimg.cn/crop.0.0.1080.1080.50/006lOefaly8hr4vv8gz4sj30u00u00vy.jpg?KID=imgbed,tva&Expires=1777063194&ssig=Eqj%2FX3QmzZ",
+        "profile_url": "/u/5819071204",
+        "verified": true,
+        "verified_type": 0,
+        "domain": "",
+        "weihao": "",
+        "verified_type_ext": 1,
+        "status_total_counter": {
+          "total_cnt_format": "1.10亿",
+          "comment_cnt": "3,599,811",
+          "repost_cnt": "61,429,531",
+          "like_cnt": "45,110,710",
+          "total_cnt": "110,140,052"
+        },
+        "avatar_large": "https://tvax4.sinaimg.cn/crop.0.0.1080.1080.180/006lOefaly8hr4vv8gz4sj30u00u00vy.jpg?KID=imgbed,tva&Expires=1777063194&ssig=AYQrb0vE6d",
+        "avatar_hd": "https://tvax4.sinaimg.cn/crop.0.0.1080.1080.1024/006lOefaly8hr4vv8gz4sj30u00u00vy.jpg?KID=imgbed,tva&Expires=1777063194&ssig=n918uMrEXB",
+        "follow_me": false,
+        "following": false,
+        "mbrank": 3,
+        "mbtype": 12,
+        "v_plus": 0,
+        "user_ability": 3427848,
+        "planet_video": false,
+        "verified_reason": "搞笑幽默博主",
+        "description": "介绍不来",
+        "location": "其他",
+        "gender": "m",
+        "followers_count": 4331859,
+        "followers_count_str": "433.2万",
+        "friends_count": 880,
+        "statuses_count": 38850,
+        "url": "http://blog.163.com/nobita138/blog/",
+        "svip": 1,
+        "vvip": 1,
+        "cover_image_phone": "https://wx4.sinaimg.cn/crop.0.0.640.640.640/006lOefagy1hr3sdwr56kj30sg0sgac0.jpg;https://wx4.sinaimg.cn/crop.0.0.640.640.640/006lOefagy1hr3ty9sx87j30u00u0aaa.jpg;https://wx3.sinaimg.cn/crop.0.0.640.640.640/006lOefagy1hr2xktyotfj30u00u03yj.jpg;https://wx1.sinaimg.cn/crop.0.0.640.640.640/006lOefagy1hr2xkxvwedj306e06e0hd.jpg;https://wx3.sinaimg.cn/crop.0.0.640.640.640/006lOefagy1hr2xyfdoe8j30u00u0goi.jpg"
+      },
+      "playback_list": [
+        {
+          "meta": {
+            "label": "mp4_720p",
+            "quality_index": 720,
+            "quality_desc": "高清",
+            "quality_label": "720p",
+            "quality_class": "HD",
+            "type": 1,
+            "quality_group": 720,
+            "is_hidden": false
+          },
+          "play_info": {
+            "type": 1,
+            "mime": "video/mp4",
+            "protocol": "general",
+            "label": "mp4_720p",
+            "url": "https://f.video.weibocdn.com/o0/O5ogjlPdlx08t36nOhrq010412005oid0E010.mp4?label=mp4_720p&template=720x1280.24.0&media_id=5234001246355474&tp=8x8A3El:YTkl0eM8&us=0&ori=1&bf=4&ot=v&lp=00001wXfQw&ps=mZ6WB&uid=zAJHe5v&ab=17399-g0,15568-g4,8012-g2,3601-g43,8013-g0&Expires=1777055994&ssig=LJqmd8duit&KID=unistore,video",
+            "bitrate": 714051,
+            "prefetch_range": "0-366078",
+            "video_codecs": "avc1.64001f",
+            "fps": 30,
+            "width": 720,
+            "height": 1280,
+            "size": 1285025,
+            "duration": 14.397,
+            "sar": "0.0",
+            "audio_codecs": "mp4a.40.5",
+            "audio_sample_rate": 44100,
+            "quality_label": "720p",
+            "quality_class": "HD",
+            "quality_desc": "高清",
+            "audio_channels": 2,
+            "audio_sample_fmt": "fltp",
+            "audio_bits_per_sample": 0,
+            "watermark": "none",
+            "extension": {
+              "transcode_info": {
+                "pcdn_rule_id": 0,
+                "pcdn_jank": 0,
+                "origin_video_dr": "SDR",
+                "ab_strategies": "17399-g0,15568-g4,8012-g2,3601-g43,8013-g0"
+              }
+            },
+            "video_decoder": "hard",
+            "prefetch_enabled": true,
+            "tcp_receive_buffer": 262144,
+            "dolby_atmos": false,
+            "color_transfer": "bt709",
+            "stereo_video": 0,
+            "first_pkt_end_pos": 65478
+          }
+        },
+        {
+          "meta": {
+            "label": "mp4_hd",
+            "quality_index": 480,
+            "quality_desc": "标清",
+            "quality_label": "480p",
+            "quality_class": "SD",
+            "type": 1,
+            "quality_group": 480,
+            "is_hidden": false
+          },
+          "play_info": {
+            "type": 1,
+            "mime": "video/mp4",
+            "protocol": "general",
+            "label": "mp4_hd",
+            "url": "https://f.video.weibocdn.com/o0/SPzEKObBlx08t36nQkNO0104120039Gq0E010.mp4?label=mp4_hd&template=540x960.24.0&media_id=5234001246355474&tp=8x8A3El:YTkl0eM8&us=0&ori=1&bf=4&ot=v&lp=00001wXfQw&ps=mZ6WB&uid=zAJHe5v&ab=17399-g0,15568-g4,8012-g2,3601-g43,8013-g0&Expires=1777055994&ssig=DzJgn6mXs6&KID=unistore,video",
+            "bitrate": 417981,
+            "prefetch_range": "0-224348",
+            "video_codecs": "avc1.64001f",
+            "fps": 30,
+            "width": 540,
+            "height": 960,
+            "size": 752210,
+            "duration": 14.397,
+            "sar": "0.0",
+            "audio_codecs": "mp4a.40.5",
+            "audio_sample_rate": 44100,
+            "quality_label": "480p",
+            "quality_class": "SD",
+            "quality_desc": "标清",
+            "audio_channels": 2,
+            "audio_sample_fmt": "fltp",
+            "audio_bits_per_sample": 0,
+            "watermark": "none",
+            "extension": {
+              "transcode_info": {
+                "pcdn_rule_id": 0,
+                "pcdn_jank": 0,
+                "origin_video_dr": "SDR",
+                "ab_strategies": "17399-g0,15568-g4,8012-g2,3601-g43,8013-g0"
+              }
+            },
+            "video_decoder": "hard",
+            "prefetch_enabled": true,
+            "tcp_receive_buffer": 262144,
+            "dolby_atmos": false,
+            "color_transfer": "bt709",
+            "stereo_video": 0,
+            "first_pkt_end_pos": 46496
+          }
+        }
+      ]
+    },
+    "page_pic": "https://wx1.sinaimg.cn/orj480/006lOefagy1i7f9vcbiygj30k00qp0vh.jpg",
+    "page_title": "野比大雄的微博视频",
+    "page_url": "sinaweibo://infopage?containerid=2304445234001246355474&containerid=2304445234001246355474&url_type=39&object_type=video&pos=2",
+    "pic_info": {
+      "pic_big": {
+        "height": "960",
+        "url": "https://wx1.sinaimg.cn/orj480/006lOefagy1i7f9vcbiygj30k00qp0vh.jpg",
+        "width": "540"
+      },
+      "pic_small": {
+        "height": "960",
+        "url": "https://wx1.sinaimg.cn/orj480/006lOefagy1i7f9vcbiygj30k00qp0vh.jpg",
+        "width": "540"
+      },
+      "pic_middle": {
+        "url": "https://wx1.sinaimg.cn/orj480/006lOefagy1i7f9vcbiygj30k00qp0vh.jpg",
+        "height": "960",
+        "width": "540"
+      }
+    },
+    "oid": "5819071204",
+    "type_icon": "",
+    "author_id": "5819071204",
+    "authorid": "5819071204",
+    "warn": "",
+    "actionlog": {},
+    "short_url": "http://t.cn/AX2rvlND"
+  },
+  "ok": 1
+}

--- a/src/nonebot_plugin_parser_lite/parsers/weibo/__init__.py
+++ b/src/nonebot_plugin_parser_lite/parsers/weibo/__init__.py
@@ -1,5 +1,3 @@
-# TODO: 解析似乎坏了
-
 import json
 from math import ceil
 from re import Match
@@ -8,7 +6,6 @@ from typing import ClassVar
 from uuid import uuid4
 
 from bs4 import BeautifulSoup, Tag
-from httpx import AsyncClient
 
 from ..base import (
     BaseParser,
@@ -22,6 +19,9 @@ from .article import decoder as articleDecoder
 from .common import WeiboData
 from .common import decoder as commonDecoder
 from .show import decoder as showDecoder
+from curl_cffi import AsyncSession
+
+SESSION = AsyncSession(impersonate="chrome131")
 
 
 class WeiBoParser(BaseParser):
@@ -166,44 +166,17 @@ class WeiBoParser(BaseParser):
         )
 
     async def parse_weibo_id(self, weibo_id: str):
-        """解析微博 id (无 Cookie + 伪装 XHR + 不跟随重定向)"""
+        """解析微博 id"""
         headers = {
-            "accept": "application/json, text/plain, */*",
-            "referer": f"https://m.weibo.cn/detail/{weibo_id}",
-            "origin": "https://m.weibo.cn",
-            "x-requested-with": "XMLHttpRequest",
-            "mweibo-pwa": "1",
-            "sec-fetch-site": "same-origin",
-            "sec-fetch-mode": "cors",
-            "sec-fetch-dest": "empty",
+            "referer": "https://weibo.com/",
             **self.headers,
         }
-
-        # 加时间戳参数，减少被缓存/规则命中的概率
-        ts = int(time() * 1000)
-        url = f"https://www.weibo.cn/statuses/show?id={weibo_id}&_={ts}"
-
         # 关键：不带 cookie、不跟随重定向（避免二跳携 cookie）
-        async with AsyncClient(
+        response = await SESSION.get(
+            "https://weibo.com/ajax/statuses/show",
+            params={"id": weibo_id},
             headers=headers,
-            follow_redirects=False,
-        ) as client:
-            response = await client.get(url)
-            if response.status_code != 200:
-                if response.status_code in (403, 418):
-                    raise ParseException(
-                        f"被风控拦截({response.status_code}), 可尝试更换 UA/Referer 或稍后重试"
-                    )
-                raise ParseException(
-                    f"获取数据失败 {response.status_code} {response.reason_phrase}"
-                )
-
-            ctype = response.headers.get("content-type", "")
-            if "application/json" not in ctype:
-                raise ParseException(
-                    f"获取数据失败 content-type is not application/json (got: {ctype})"
-                )
-
+        )
         weibo_data = commonDecoder.decode(response.content).data
 
         return self._collect_result(weibo_data)


### PR DESCRIPTION
## Summary by Sourcery

更新 Weibo 解析器，以使用较新的 AJAX statuses API，并通过共享的 HTTP 会话获取微博详情。

Enhancements:
- 将 Weibo ID 解析切换为使用带有 Chrome 模拟的共享 `curl_cffi AsyncSession`，请求 `ajax/statuses/show` 端点，替代之前的 `m.weibo.cn` JSON 端点。
- 简化请求头，并在 Weibo 解析器中移除自定义的重定向与 `content-type` 处理逻辑。
- 在 `api_txt` 下新增一个用于更新后端点的 Weibo statuses API 描述 JSON 文件。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update the Weibo parser to use the newer AJAX statuses API with a shared HTTP session for fetching weibo details.

Enhancements:
- Switch Weibo ID parsing to use a shared curl_cffi AsyncSession with Chrome impersonation against the ajax/statuses/show endpoint instead of the previous m.weibo.cn JSON endpoint.
- Simplify request headers and remove custom redirect and content-type handling logic in the Weibo parser.
- Add a new weibo statuses API description JSON file under api_txt for the updated endpoint.

</details>