### PR TITLE
feat(bilibili): 初始化时设置请求头

### DIFF
--- a/src/nonebot_plugin_parser_lite/parsers/bilibili/__init__.py
+++ b/src/nonebot_plugin_parser_lite/parsers/bilibili/__init__.py
@@ -65,6 +65,8 @@ class BilibiliParser(BaseParser):
 
     def __init__(self):
         super().__init__()
+        self.headers = HEADERS.copy()
+        self.httpx.headers.update(self.headers)
         self._credential: Credential | None = None
         self._cookies_file = pconfig.config_dir / "bilibili_cookies.json"
         self.ck_header: dict[str, str]


### PR DESCRIPTION
配置Bilibili解析器的HTTP请求头，确保API请求携带必要的认证信息

Co-authored-by: Copilot <copilot@github.com>

## Summary by Sourcery

增强功能：
- 在解析器初始化期间设置默认的 Bilibili HTTP 请求头，并将其应用于共享的 HTTP 客户端。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Set default Bilibili HTTP request headers during parser initialization and apply them to the shared HTTP client.

</details>