### PR TITLE
feat(buff): 注册解析器并修复URL与评论图片解析

### DIFF
--- a/src/nonebot_plugin_parser_lite/parsers/__init__.py
+++ b/src/nonebot_plugin_parser_lite/parsers/__init__.py
@@ -26,6 +26,7 @@ from .zhihu import ZhiHuParser
 from .duitang import DuiTangParser
 from .heybox import HeyBoxParser
 from .lofter import LofterParser
+from .buff import BuffParser
 
 __all__ = [
     "AcfunParser",
@@ -53,5 +54,6 @@ __all__ = [
     "DuiTangParser",
     "HeyBoxParser",
     "LofterParser",
+    "BuffParser",
     "handle",
 ]

--- a/src/nonebot_plugin_parser_lite/parsers/buff/__init__.py
+++ b/src/nonebot_plugin_parser_lite/parsers/buff/__init__.py
@@ -83,7 +83,7 @@ class BuffParser(BaseParser):
 
     # https://buff.163.com/s/news-detail_share.html?article_id=87832&comment_type=228
     @handle(
-        "https://buff.163.com/s/news-detail_share.html",
+        "buff.163.com/s/news-detail_share.html",
         r"(?=[^#]*article_id=(?P<article_id>[^&]+))(?=[^#]*comment_type=228)",
     )
     async def parse_video(self, searched: Match[str]):
@@ -113,7 +113,7 @@ class BuffParser(BaseParser):
     # parse gallery
     # https://buff.163.com/s/preview_share.html?game=csgo&preview_id=V1092280822&comment_type=216
     @handle(
-        "https://buff.163.com/s/preview_share.html",
+        "buff.163.com/s/preview_share.html",
         r"(?=[^#]*game=(?P<game>[^&]+))(?=[^#]*preview_id=(?P<preview_id>[^&]+))(?=[^#]*comment_type=216)",
     )
     async def parse_gallery(self, searched: Match[str]):
@@ -146,7 +146,7 @@ class BuffParser(BaseParser):
 
     # https://buff.163.com/s/news-detail_share.html?article_id=87855&comment_type=211
     @handle(
-        "https://buff.163.com/s/news-detail_share.html",
+        "buff.163.com/s/news-detail_share.html",
         r"(?=[^#]*article_id=(?P<article_id>[^&]+))(?=[^#]*comment_type=211)",
     )
     async def parse_news(self, searched: Match[str]):
@@ -176,7 +176,7 @@ class BuffParser(BaseParser):
 
     # https://buff.163.com/s/topic-detail_share.html?social_topic_post_id=P1093043595&comment_type=239
     @handle(
-        "https://buff.163.com/s/topic-detail_share.html",
+        "buff.163.com/s/topic-detail_share.html",
         r"(?=[^#]*social_topic_post_id=(?P<post_id>[^&]+))(?=[^#]*comment_type=239)",
     )
     async def parse_topic(self, searched: Match[str]):

--- a/src/nonebot_plugin_parser_lite/parsers/buff/comments.py
+++ b/src/nonebot_plugin_parser_lite/parsers/buff/comments.py
@@ -13,7 +13,7 @@ class Author(Struct):
 
 
 class Picture(Struct):
-    image_url: str
+    icon_url: str
     is_emoji: bool
     name: str
 
@@ -35,7 +35,7 @@ class Comment(Struct):
         for pic in self.pictures:
             if pic.is_emoji:
                 sticker = create_sticker(
-                    url=pic.image_url,
+                    url=pic.icon_url,
                     size="medium",
                     desc=pic.name,
                 )
@@ -44,7 +44,7 @@ class Comment(Struct):
                 if placeholder in text:
                     text = text.replace(placeholder, "", 1)
             else:
-                contents.append(create_image(pic.image_url))
+                contents.append(create_image(pic.icon_url))
 
         if text:
             contents.insert(0, text)


### PR DESCRIPTION
新增BuffParser类来处理BUFF分享链接，包括新闻、预览、话题等类型的内容解析

Co-authored-by: Copilot <copilot@github.com>

## Summary by Sourcery

公开 Buff 解析器，并使其 URL 匹配和评论图片字段与当前的 BUFF 分享/链接格式保持一致。

新功能：
- 在全局 parsers 包中注册 `BuffParser`，从而使插件可以处理 BUFF 链接。

错误修复：
- 更新 BUFF URL 处理逻辑，使其在不区分协议（scheme）的情况下匹配链接，并使用正确的 `icon_url` 字段来显示评论中的图片。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Expose the Buff parser and align its URL matching and comment picture fields with the current BUFF share/link format.

New Features:
- Register BuffParser in the global parsers package so BUFF links can be handled by the plugin.

Bug Fixes:
- Update BUFF URL handlers to match links regardless of scheme and to use the correct icon_url field for comment pictures.

</details>