### PR TITLE
fix(bilibili): 修复B站解析器中ck_header初始化问题

### DIFF
--- a/src/nonebot_plugin_parser_lite/parsers/bilibili/__init__.py
+++ b/src/nonebot_plugin_parser_lite/parsers/bilibili/__init__.py
@@ -68,7 +68,7 @@ class BilibiliParser(BaseParser):
         self.headers = HEADERS.copy()
         self._credential: Credential | None = None
         self._cookies_file = pconfig.config_dir / "bilibili_cookies.json"
-        self.ck_header: dict[str, str]
+        self.ck_header = self.headers.copy()
         self.black_mids: list[int] | None = None
         """黑名单作者列表"""
         self._black_list_job_added: bool = False
@@ -87,7 +87,6 @@ class BilibiliParser(BaseParser):
             self.black_mids = []
             return
 
-        self.ck_header = self.headers.copy()
         self.ck_header["Cookie"] = "; ".join(f"{k}={v}" for k, v in cookies.items())
 
         base_url = "https://api.bilibili.com/x/relation/blacks"


### PR DESCRIPTION
初始化时正确复制headers，避免后续Cookie设置时出现未定义错误， 确保B站API请求能够正常携带认证信息。

- resolve #85

## Summary by Sourcery

Bug Fixes:
- 通过在解析器初始化期间复制默认 headers，而不是在加载黑名单时延迟复制，修复了在设置 cookies 时可能出现的 `ck_header` 未定义问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix potential undefined ck_header when setting cookies by copying default headers during parser initialization instead of lazily in blacklist loading.

</details>