### PR TITLE
feat(browser): 修改浏览器路径配置为字符串类型并优化查找逻辑

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ plite_browser_path=None
 plite_live_photo=True
 
 # [可选] 浏览器是否使用无头模式，无头模式有可能会被检测到
-plite_headless=False
+plite_headless=""
 
 # [可选] 最大评论数量
 plite_max_comments=5

--- a/README.md
+++ b/README.md
@@ -136,14 +136,14 @@ plite_lazy_download_timeout=30
 plite_download_command=["xz", "下载"]
 
 # [可选] 浏览器程序路径，如果无法识别浏览器请填写此配置
-plite_browser_path=None
+plite_browser_path=""
 
 # [可选] 是否使用 ffmpeg 转码 Live Photo，若设备配置不佳，请禁用此功能
 # 禁用后将分别发送 Live Photo 底图和动图部分
 plite_live_photo=True
 
 # [可选] 浏览器是否使用无头模式，无头模式有可能会被检测到
-plite_headless=""
+plite_headless=False
 
 # [可选] 最大评论数量
 plite_max_comments=5

--- a/src/nonebot_plugin_parser_lite/config.py
+++ b/src/nonebot_plugin_parser_lite/config.py
@@ -49,7 +49,7 @@ class Config(BaseModel):
     """懒下载模式等待命令超时时间"""
     plite_download_command: list[str] = ["xz", "下载"]
     """在懒下载模式中用户请求下载视频时的命令列表"""
-    plite_browser_path: str | None = None
+    plite_browser_path: str = ""
     """浏览器程序路径，如果无法识别浏览器请填写此配置"""
     plite_live_photo: bool = True
     """是否使用 ffmpeg 转码 Live Photo"""
@@ -164,7 +164,7 @@ class Config(BaseModel):
         return self.plite_lazy_download_timeout
 
     @property
-    def browser_path(self) -> str | None:
+    def browser_path(self) -> str:
         """浏览器程序路径"""
         return self.plite_browser_path
 

--- a/src/nonebot_plugin_parser_lite/utils/browser.py
+++ b/src/nonebot_plugin_parser_lite/utils/browser.py
@@ -140,9 +140,15 @@ def _resolve_browser_path() -> str:
 
 
 browser_path = _resolve_browser_path()
+
+if system == "Linux":
+    logger.warning(
+        "You are running on Linux. If there is no desktop environment, please enable headless mode."
+    )
+
 logger.info(f"Launching browser from {browser_path}")
 co = ChromiumOptions()
-# co.mute(True)
+co.mute(True)
 # co.incognito(True)
 # co.no_imgs(True)
 co.auto_port(True)
@@ -155,4 +161,5 @@ BROWSER = Chromium(co)
 
 @driver.on_shutdown
 def close_browser():
+    logger.info("Closing browser launched by Parser Lite")
     BROWSER.quit()

--- a/src/nonebot_plugin_parser_lite/utils/browser.py
+++ b/src/nonebot_plugin_parser_lite/utils/browser.py
@@ -14,7 +14,7 @@ system = platform.system()
 driver = get_driver()
 
 
-def _find_browser_from_system() -> str | None:
+def _find_browser_from_system() -> str:
     """从系统默认安装位置寻找浏览器."""
     if system == "Darwin":
         mac_paths = (
@@ -38,11 +38,11 @@ def _find_browser_from_system() -> str | None:
                 value, _ = winreg.QueryValueEx(key, "")
                 # DefaultIcon 的值通常形如 "C:\\...\\chrome.exe,0"
                 return value.split(",")[0]
-    return None
+    return ""
 
 
-def _find_browser_from_playwright() -> str | None:
-    """从 ms-playwright 默认目录寻找 Chromium."""
+def _find_browser_from_playwright() -> str:
+    """从 ms-playwright 默认目录寻找 Chromium 可执行文件"""
     home = Path.home()
     if system == "Windows":
         base = home / "AppData" / "Local" / "ms-playwright"
@@ -51,29 +51,40 @@ def _find_browser_from_playwright() -> str | None:
     else:
         base = home / ".cache" / "ms-playwright"
 
+    if not base.is_dir():
+        return ""
+
     chromium_dirs = sorted(base.glob("chromium-*"))
     for chromium_dir in reversed(chromium_dirs):
+        if not chromium_dir.is_dir():
+            continue
+
         if system == "Windows":
-            exe_path = chromium_dir / "chrome-win" / "chrome.exe"
+            # 任意 chrome-win*/chrome.exe
+            exe_candidates = chromium_dir.glob("chrome-win*/chrome.exe")
         elif system == "Darwin":
-            exe_path = (
+            # 任意 chrome-mac*/Chromium.app
+            exe_candidates = [
                 chromium_dir
                 / "chrome-mac"
                 / "Chromium.app"
                 / "Contents"
                 / "MacOS"
                 / "Chromium"
-            )
+            ]
         else:  # Linux
-            exe_path = chromium_dir / "chrome-linux" / "chrome"
+            # 任意 chrome-linux*/chrome 或 chrome-linux64*/chrome
+            exe_candidates = chromium_dir.glob("chrome-linux*/chrome")
 
-        if exe_path.is_file():
-            return str(exe_path)
+        for exe_path in exe_candidates:
+            if exe_path.is_file():
+                # 返回绝对路径，避免相对路径带来的工作目录依赖
+                return str(exe_path.resolve())
 
-    return None
+    return ""
 
 
-def _find_browser_from_puppeteer() -> str | None:
+def _find_browser_from_puppeteer() -> str:
     """从 Puppeteer 默认目录寻找 Chromium/Chrome."""
     home = Path.home()
     candidates: list[Path] = []
@@ -102,9 +113,9 @@ def _find_browser_from_puppeteer() -> str | None:
             for app in base.rglob("Chromium.app"):
                 exe = app / "Contents" / "MacOS" / "Chromium"
                 if exe.is_file():
-                    return str(exe)
+                    return str(exe.resolve())
 
-    return None
+    return ""
 
 
 def _resolve_browser_path() -> str:


### PR DESCRIPTION
- 将配置项 plite_browser_path 从 str | None 类型改为 str 类型
- 将默认值从 None 改为空字符串 ""
- 更新浏览器查找函数返回值类型为 str，统一返回空字符串而非 None
- 优化 playwright 浏览器查找逻辑，支持更多 Chrome 目录结构
- 修复 macOS 下 Chromium.app 路径解析问题
- 添加目录存在性检查，增强错误处理能力
- resolve #84

## Summary by Sourcery

统一浏览器路径处理方式，始终使用字符串值，并增强跨平台的自动浏览器发现鲁棒性。

New Features:
- 支持额外的 Playwright Chromium 目录结构，并将浏览器可执行文件解析为绝对路径。

Bug Fixes:
- 修复在 macOS 上定位由 Playwright 管理的浏览器时 `Chromium.app` 路径解析问题。
- 浏览器发现辅助函数返回空字符串而非 `None`，以避免可选类型处理问题。

Enhancements:
- 将 `plite_browser_path` 配置从“可选字符串”改为“必填字符串”，并使用空字符串作为默认值，从而简化配置处理。
- 在扫描 Playwright 和 Puppeteer 浏览器目录时，增加目录存在性检查以及更防御性（健壮）的逻辑。

Documentation:
- 更新配置文档，以反映新的基于字符串的浏览器路径配置及其默认值。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify browser path handling to always use string values and improve automatic browser discovery robustness across platforms.

New Features:
- Support additional Playwright Chromium directory structures and resolve browser executables to absolute paths.

Bug Fixes:
- Fix Chromium.app path resolution on macOS when locating Playwright-managed browsers.
- Return empty strings instead of None from browser discovery helpers to avoid optional-type handling issues.

Enhancements:
- Change plite_browser_path configuration from optional string to required string with an empty-string default to simplify configuration handling.
- Add directory existence checks and more defensive logic when scanning Playwright and Puppeteer browser directories.

Documentation:
- Update configuration documentation to reflect the new string-based browser path configuration and default values.

</details>