### PR TITLE
feat(render): 修复评论区图片缩放异常

### DIFF
--- a/src/nonebot_plugin_parser_lite/render/templates/default.html.jinja
+++ b/src/nonebot_plugin_parser_lite/render/templates/default.html.jinja
@@ -44,18 +44,18 @@
         document.addEventListener("DOMContentLoaded", function() {
             document
                 .querySelectorAll(".comment .single-image img")
-                .forEach((img_container) => {
+                .forEach((img) => {
                     const applyStyle = () => {
-                        const h = img_container.offsetHeight;
-                        const w = img_container.offsetWidth;
+                        const h = img.offsetHeight;
+                        const w = img.offsetWidth;
                         if (!h || !w || !isFinite(h / w)) return;
                         const aspectRatio = h / w;
                         if (aspectRatio >= 0.9) {
                             // 竖图：限制宽度，放高
-                            img_container.classList.add("max-w-36", "h-auto");
+                            img.classList.add("max-w-36", "h-auto");
                         } else {
                             // 横图：限制高度，放宽
-                            img_container.classList.add("max-h-36", "w-auto");
+                            img.classList.add("max-h-36", "w-auto");
                         }
                     };
                     applyStyle();

--- a/src/nonebot_plugin_parser_lite/render/templates/default.html.jinja
+++ b/src/nonebot_plugin_parser_lite/render/templates/default.html.jinja
@@ -43,7 +43,7 @@
     <script defer>
         document.addEventListener("DOMContentLoaded", function() {
             document
-                .querySelectorAll(".comment .single-image")
+                .querySelectorAll(".comment .single-image img")
                 .forEach((img_container) => {
                     const applyStyle = () => {
                         const h = img_container.offsetHeight;
@@ -52,10 +52,10 @@
                         const aspectRatio = h / w;
                         if (aspectRatio >= 0.9) {
                             // 竖图：限制宽度，放高
-                            img_container.classList.add("max-w-36");
+                            img_container.classList.add("max-w-36", "h-auto");
                         } else {
                             // 横图：限制高度，放宽
-                            img_container.classList.add("max-h-36");
+                            img_container.classList.add("max-h-36", "w-auto");
                         }
                     };
                     applyStyle();

--- a/src/nonebot_plugin_parser_lite/render/templates/macros.jinja
+++ b/src/nonebot_plugin_parser_lite/render/templates/macros.jinja
@@ -107,7 +107,7 @@
         {% set src = item.src %}
         {% set is_live = item.is_live %}
         <div class="mt-3">
-            <div class="single-image relative rounded-2xl overflow-hidden border border-gray-100 shadow-sm">
+            <div class="single-image relative rounded-2xl overflow-hidden border border-gray-100 shadow-sm inline-block">
                 <img src="{{ src }}" class="w-full h-auto max-h-[400px] object-cover" />
                 {% if is_live %}
                     <div class="live-tag-strict absolute bottom-2 right-2 flex items-center">
@@ -121,7 +121,30 @@
                 {% endif %}
             </div>
         </div>
-        {# 2 张及以上：九宫格 media-grid #}
+        {# 4 张：2×2 四宫格 #}
+    {% elif count == 4 %}
+        <div class="mt-3">
+            <div class="media-grid outline-1 outline-slate-200 rounded-xl overflow-hidden grid grid-cols-2 gap-[2px] shadow-sm">
+                {% for item in visible_imgs %}
+                    {% set src = item.src %}
+                    {% set is_live = item.is_live %}
+                    <div class="relative w-full h-full">
+                        <img src="{{ src }}" class="square-img" />
+                        {% if is_live %}
+                            <div class="live-tag-strict absolute bottom-2 right-2 flex items-center">
+                                <i class="live-icon"
+                                   style="width: 16px;
+                                          height: 17px"
+                                   aria-hidden="true"></i>
+                                <span class="text-[9px] font-bold uppercase tracking-widest"
+                                      style="padding-left: 1.3px">Live</span>
+                            </div>
+                        {% endif %}
+                    </div>
+                {% endfor %}
+            </div>
+        </div>
+        {# 其他 ≥2 张：九宫格 media-grid #}
     {% else %}
         <div class="mt-3">
             <div class="media-grid outline-1 outline-slate-200 rounded-xl overflow-hidden grid grid-cols-3 gap-[2px] shadow-sm">

--- a/src/nonebot_plugin_parser_lite/render/templates/tailwind.css
+++ b/src/nonebot_plugin_parser_lite/render/templates/tailwind.css
@@ -382,6 +382,9 @@
   .w-full {
     width: 100%;
   }
+  .grid-cols-2 {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
   .grid-cols-3 {
     grid-template-columns: repeat(3, minmax(0, 1fr));
   }


### PR DESCRIPTION
- 修改图片选择器以正确应用样式到 img 元素而非容器
- 为竖图添加 max-w-36 和 h-auto 样式，为横图添加 max-h-36 和 w-auto 样式
- 将单张图片容器设置为 inline-block 以改善布局
- 新增四张图片时的 2x2 四宫格布局支持
- 添加 grid-cols-2 CSS 类定义以支持两列网格布局

Co-authored-by: Copilot <copilot@github.com>

## Summary by Sourcery

调整评论中的图片渲染方式，以修复缩放问题，并为四张图片新增专用的 2×2 布局。

新功能：
- 当评论中恰好有四张图片时，支持 2×2 媒体网格布局。

增强改进：
- 将单张图片容器改为 `inline-block`，以改善评论布局的对齐效果。
- 更新图片样式应用脚本，直接作用于 `img` 元素，并通过 `max-width/height` 和自动缩放来区分纵向与横向图片。
- 扩展类 Tailwind 的工具类，新增 `grid-cols-2` 类以支持两列媒体网格布局。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust comment image rendering to fix scaling issues and add a dedicated 2×2 layout for four images.

New Features:
- Support a 2×2 media grid layout when exactly four images are present in a comment.

Enhancements:
- Change single-image containers to inline-block to improve comment layout alignment.
- Update the image style application script to target img elements directly and differentiate vertical vs horizontal images using max-width/height and auto sizing.
- Extend Tailwind-style utilities with a grid-cols-2 class to support two-column media grids.

</details>