### PR TITLE
feat(render): 添加视频时长显示功能

### DIFF
--- a/src/nonebot_plugin_parser_lite/parsers/data.py
+++ b/src/nonebot_plugin_parser_lite/parsers/data.py
@@ -48,16 +48,19 @@ class VideoContent(MediaContent):
 
     @property
     def display_duration(self) -> str:
-        total_seconds = int(self.duration)
-        if total_seconds <= 0:
-            return "0:00"
+        try:
+            total_seconds = int(self.duration)
+            if total_seconds <= 0:
+                return "0:00"
 
-        minutes, seconds = divmod(total_seconds, 60)
-        if minutes < 60:
-            return f"{minutes}:{seconds:02d}"
+            minutes, seconds = divmod(total_seconds, 60)
+            if minutes < 60:
+                return f"{minutes}:{seconds:02d}"
 
-        hours, minutes = divmod(minutes, 60)
-        return f"{hours}:{minutes:02d}:{seconds:02d}"
+            hours, minutes = divmod(minutes, 60)
+            return f"{hours}:{minutes:02d}:{seconds:02d}"
+        except Exception:
+            return "NaN"
 
 
 @dataclass(repr=False, slots=True)

--- a/src/nonebot_plugin_parser_lite/parsers/data.py
+++ b/src/nonebot_plugin_parser_lite/parsers/data.py
@@ -59,7 +59,7 @@ class VideoContent(MediaContent):
 
             hours, minutes = divmod(minutes, 60)
             return f"{hours}:{minutes:02d}:{seconds:02d}"
-        except Exception:
+        except (TypeError, ValueError):
             return "NaN"
 
 

--- a/src/nonebot_plugin_parser_lite/render/templates/macros.jinja
+++ b/src/nonebot_plugin_parser_lite/render/templates/macros.jinja
@@ -250,13 +250,9 @@
                             '<i class="fa-icon fa-play ml-1"></i>'
                             '</div>'
                             '</div>'
+                            '<div class="absolute bottom-2 right-2 flex items-center bg-black/60 text-white h-[19px] px-1.5 rounded-[2px] text-[10px] font-mono">' ~ cont.display_duration ~ '</div>'
                             '</div>'
                         ) %}
-            {#
-              <div class="absolute bottom-2 right-2 flex items-center bg-black/60 text-white h-[19px] px-1.5 rounded-[2px] text-[10px] font-mono">
-                05:24
-              </div>
-            #}
         {% endif %}
     {% endfor %}
     {% set _ = flush_images() %}

--- a/src/nonebot_plugin_parser_lite/render/templates/macros.jinja
+++ b/src/nonebot_plugin_parser_lite/render/templates/macros.jinja
@@ -250,7 +250,9 @@
                             '<i class="fa-icon fa-play ml-1"></i>'
                             '</div>'
                             '</div>'
+                            {% if cont.display_duration %}
                             '<div class="absolute bottom-2 right-2 flex items-center bg-black/60 text-white h-[19px] px-1.5 rounded-[2px] text-[10px] font-mono">' ~ cont.display_duration ~ '</div>'
+                            {% endif %}
                             '</div>'
                         ) %}
         {% endif %}

--- a/src/nonebot_plugin_parser_lite/render/templates/macros.jinja
+++ b/src/nonebot_plugin_parser_lite/render/templates/macros.jinja
@@ -250,9 +250,7 @@
                             '<i class="fa-icon fa-play ml-1"></i>'
                             '</div>'
                             '</div>'
-                            {% if cont.display_duration %}
                             '<div class="absolute bottom-2 right-2 flex items-center bg-black/60 text-white h-[19px] px-1.5 rounded-[2px] text-[10px] font-mono">' ~ cont.display_duration ~ '</div>'
-                            {% endif %}
                             '</div>'
                         ) %}
         {% endif %}


### PR DESCRIPTION
在视频播放器底部添加了视频时长显示组件，以增强用户体验。 该组件显示为黑色半透明背景的白色文本，位于右下角， 采用10px等宽字体显示格式化的持续时间信息。

Co-authored-by: Copilot <copilot@github.com>

## Summary by Sourcery

在渲染的视频卡片上添加可见的视频时长覆盖层，并使时长格式化在面对无效数据时更健壮。

新功能：
- 在视频缩略图右下角显示格式化后的视频时长覆盖层。

错误修复：
- 在时长解析失败时返回回退值，以避免时长格式化出错。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a visible video duration overlay to the rendered video cards and make duration formatting more robust against invalid data.

New Features:
- Display formatted video duration as an overlay in the bottom-right corner of video thumbnails.

Bug Fixes:
- Guard duration formatting against errors by returning a fallback value when duration parsing fails.

</details>