### PR TITLE
fix(render): 修复平台图标加载超时

### DIFF
--- a/src/nonebot_plugin_parser_lite/parsers/data.py
+++ b/src/nonebot_plugin_parser_lite/parsers/data.py
@@ -7,6 +7,7 @@ from collections.abc import Sequence
 from ..utils.ffmpeg import FFmpeg
 
 from ..download.task import DownloadTaskWrapper
+from ..download import DOWNLOADER
 
 
 def repr_path_task(path_task: DownloadTaskWrapper[Path]) -> str:
@@ -128,6 +129,12 @@ class Platform:
     """ 平台名称 """
     display_name: str
     """ 平台显示名称 """
+
+    async def get_logo_path(self) -> Path:
+        return await DOWNLOADER.download_img(
+            url=f"https://emoji.awkchan.top/assets/logo/{self.name}.webp",
+            img_name=f"{self.name}.webp"
+        )
 
 
 @dataclass(repr=False, slots=True)

--- a/src/nonebot_plugin_parser_lite/render/__init__.py
+++ b/src/nonebot_plugin_parser_lite/render/__init__.py
@@ -331,7 +331,7 @@ class Renderer:
             "platform": {
                 "display_name": result.platform.display_name,
                 "name": result.platform.name,
-                "logo_path": f"https://emoji.awkchan.top/assets/logo/{result.platform.name}.webp",
+                "logo_path": await safe_src(result.platform, "get_logo_path"),
             },
             "content": result.content,
             "cover_path": await safe_src(result, "get_cover_path"),


### PR DESCRIPTION
- 引入DOWNLOADER用于图标下载
- 实现Platform类的get_logo_path方法
- 使用safe_src安全调用获取图标路径

## Summary by Sourcery

通过共享的下载器和平台 API 加载平台 logo，以防止超时并集中管理图片获取。

New Features:
- 为 `Platform` 添加异步的 `get_logo_path` 方法，通过下载器解析平台 logo 路径。

Bug Fixes:
- 通过使用共享下载器下载 logo，而不是直接使用远程 URL，修复平台图标加载超时的问题。

Enhancements:
- 在渲染解析结果时使用 `safe_src` 安全地解析平台 logo 路径。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Route platform logo loading through the shared downloader and platform API to prevent timeouts and centralize image retrieval.

New Features:
- Add an asynchronous get_logo_path method to Platform for resolving platform logo paths via the downloader.

Bug Fixes:
- Fix platform icon loading timeouts by downloading logos through the shared downloader instead of using direct remote URLs.

Enhancements:
- Use safe_src to safely resolve platform logo paths when rendering parse results.

</details>