### PR TITLE
fix(parser/bilibili): 修复分P解析正则和bm下载

### DIFF
--- a/src/nonebot_plugin_parser_lite/parsers/bilibili/__init__.py
+++ b/src/nonebot_plugin_parser_lite/parsers/bilibili/__init__.py
@@ -188,7 +188,7 @@ class BilibiliParser(BaseParser):
     @handle("BV", r"^(?P<bvid>BV[0-9a-zA-Z]{10})(?:\s)?(?P<page_num>\d{1,3})?$")
     @handle(
         "/BV",
-        r"bilibili\.com(?:/video)?/(?P<bvid>BV[0-9A-Za-z]{10})(?:[/?].*)?(?:[?&]p=(?P<page_num>\d{1,3}))?",
+        r"bilibili\.com(?:/video)?/(?P<bvid>BV[0-9A-Za-z]{10})(?:.*?[?&]p=(?P<page_num>\d{1,3}))?",
     )
     async def _parse_bv(self, searched: Match[str]):
         """解析视频信息"""
@@ -200,7 +200,7 @@ class BilibiliParser(BaseParser):
     @handle("av", r"^av(?P<avid>\d{6,})(?:\s)?(?P<page_num>\d{1,3})?$")
     @handle(
         "/av",
-        r"bilibili\.com(?:/video)?/av(?P<avid>\d{6,})(?:\?p=(?P<page_num>\d{1,3}))?",
+        r"bilibili\.com(?:/video)?/av(?P<avid>\d{6,})(?:.*?[?&]p=(?P<page_num>\d{1,3}))?",
     )
     async def _parse_av(self, searched: Match[str]):
         """解析视频信息"""
@@ -318,7 +318,7 @@ class BilibiliParser(BaseParser):
                 video=video, page_index=page_info.index
             )
             if page_info.duration > pconfig.duration_maximum:
-                raise DurationLimitException
+                raise DurationLimitException(page_info.duration)
             if a_url is not None:
                 return await DOWNLOADER.download_av_and_merge(
                     v_url,

--- a/src/nonebot_plugin_parser_lite/parsers/bilibili/video.py
+++ b/src/nonebot_plugin_parser_lite/parsers/bilibili/video.py
@@ -102,5 +102,5 @@ class AIConclusion(Struct):
     @property
     def summary(self) -> str:
         if self.model_result and self.model_result.summary:
-            return f"AI总结: {self.model_result.summary}"
+            return self.model_result.summary
         return "该视频暂不支持AI总结"


### PR DESCRIPTION
## 由 Sourcery 提供的总结

更新 B 站解析器对多 P 视频 URL 和时长限制的处理，并调整 AI 总结输出的格式。

Bug 修复：
- 放宽对 B 站 BV 和 av URL 的正则表达式限制，使多 P 页面的参数能够从更多类型的 URL 中被正确提取。
- 当视频页面时长超过配置的最大值时，将实际超限的时长传入时长限制异常中。

功能增强：
- 对于视频，返回原始的 AI 生成总结文本，而不是在前面加上固定标签。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update Bilibili parser handling of multi-part video URLs and duration limits, and adjust AI summary output formatting.

Bug Fixes:
- Relax Bilibili BV and av URL regexes so multi-part page parameters are correctly extracted from more URL variants.
- Pass the offending duration into the duration limit exception when a video page exceeds the configured maximum.

Enhancements:
- Return the raw AI-generated summary text for videos instead of prefixing it with a fixed label.

</details>