### PR TITLE
refactor(render): 更新异常处理以包含具体的大小和时长

### DIFF
--- a/src/nonebot_plugin_parser_lite/config.py
+++ b/src/nonebot_plugin_parser_lite/config.py
@@ -80,12 +80,12 @@ class Config(BaseModel):
 
     @property
     def max_size(self) -> int:
-        """资源最大大小"""
+        """资源最大大小(mb)"""
         return self.plite_max_size
 
     @property
     def duration_maximum(self) -> int:
-        """视频/音频最大时长"""
+        """视频/音频最大时长(s)"""
         return self.plite_duration_maximum
 
     @property

--- a/src/nonebot_plugin_parser_lite/download/__init__.py
+++ b/src/nonebot_plugin_parser_lite/download/__init__.py
@@ -93,7 +93,7 @@ class StreamDownloader:
                 logger.warning(
                     f"媒体 url: {url} 大小 {file_size_mb:.2f} MB 超过 {pconfig.max_size} MB, 取消下载"
                 )
-                raise SizeLimitException
+                raise SizeLimitException(file_size_mb)
 
         async with self.client.stream(
             "GET", url, headers=headers, follow_redirects=True
@@ -143,7 +143,7 @@ class StreamDownloader:
                             logger.warning(
                                 f"媒体 url: {url} 实际下载大小 {file_size_mb:.2f} MB 超过 {pconfig.max_size} MB, 取消下载"
                             )
-                            raise SizeLimitException
+                            raise SizeLimitException(file_size_mb)
 
     @auto_task
     async def download_video(
@@ -279,7 +279,7 @@ class StreamDownloader:
                                 logger.warning(
                                     f"m3u8 视频大小 {file_size_mb:.2f} MB 超过 {pconfig.max_size} MB，取消下载"
                                 )
-                                raise SizeLimitException
+                                raise SizeLimitException(file_size_mb)
                     return
                 except SizeLimitException:
                     # 超限直接抛出，不再重试

--- a/src/nonebot_plugin_parser_lite/exception.py
+++ b/src/nonebot_plugin_parser_lite/exception.py
@@ -28,15 +28,17 @@ class DownloadLimitException(DownloadException):
 class SizeLimitException(DownloadLimitException):
     """下载大小超过限制异常"""
 
-    def __init__(self):
+    def __init__(self, size: float):
         super().__init__("媒体大小超过配置限制，取消下载")
+        self.size = round(size, 2)
 
 
 class DurationLimitException(DownloadLimitException):
     """下载时长超过限制异常"""
 
-    def __init__(self):
+    def __init__(self, duration: float):
         super().__init__("媒体时长超过配置限制，取消下载")
+        self.duration = duration
 
 
 class ZeroSizeException(DownloadException):

--- a/src/nonebot_plugin_parser_lite/exception.py
+++ b/src/nonebot_plugin_parser_lite/exception.py
@@ -38,7 +38,7 @@ class DurationLimitException(DownloadLimitException):
 
     def __init__(self, duration: float):
         super().__init__("媒体时长超过配置限制，取消下载")
-        self.duration = duration
+        self.duration = round(duration, 2)
 
 
 class ZeroSizeException(DownloadException):

--- a/src/nonebot_plugin_parser_lite/matchers/__init__.py
+++ b/src/nonebot_plugin_parser_lite/matchers/__init__.py
@@ -92,13 +92,15 @@ def _get_enabled_parser_classes() -> list[type[BaseParser]]:
 
 
 # 关键词 -> Parser 映射
-KEYWORD_PARSER_MAP: dict[str, BaseParser] = {}
 T = TypeVar("T", bound=BaseParser)
+
+_ALL_PARSERS: list[BaseParser] = []
+_KEYWORD_PARSER_MAP: dict[str, BaseParser] = {}
 
 
 def get_parser(keyword: str) -> BaseParser:
     """根据注册的关键字获取对应的解析器实例。"""
-    parser = KEYWORD_PARSER_MAP.get(keyword)
+    parser = _KEYWORD_PARSER_MAP.get(keyword)
     if parser is None:
         raise KeyError(f"未找到关键字 {keyword!r} 对应的 parser")
     return parser
@@ -106,7 +108,7 @@ def get_parser(keyword: str) -> BaseParser:
 
 def get_parser_by_type(parser_type: type[T]) -> T:
     """根据解析器类型获取已注册的解析器实例。"""
-    for parser in KEYWORD_PARSER_MAP.values():
+    for parser in _ALL_PARSERS:
         if isinstance(parser, parser_type):
             return parser
     raise ValueError(f"未找到类型为 {parser_type.__name__} 的 parser 实例")
@@ -114,23 +116,19 @@ def get_parser_by_type(parser_type: type[T]) -> T:
 
 driver = get_driver()
 
-ENABLED_PLATFORM: list[BaseParser] = []
-
 
 @driver.on_startup
 def register_parser_matcher() -> None:
     """在启动时注册各平台解析器及其匹配规则。"""
-    global ENABLED_PLATFORM
     enabled_classes = _get_enabled_parser_classes()
 
     enabled_platforms: list[str] = []
     for parser_cls in enabled_classes:
         parser = parser_cls()
-        ENABLED_PLATFORM.append(parser)
+        _ALL_PARSERS.append(parser)
         enabled_platforms.append(parser.platform.display_name)
         for keyword, _ in parser_cls._key_patterns:
-            KEYWORD_PARSER_MAP[keyword] = parser
-
+            _KEYWORD_PARSER_MAP[keyword] = parser
     logger.info(f"启用平台: {', '.join(sorted(enabled_platforms))}")
 
     patterns = [pattern for cls_ in enabled_classes for pattern in cls_._key_patterns]
@@ -140,10 +138,10 @@ def register_parser_matcher() -> None:
 
 @driver.on_shutdown
 async def close_httpx() -> None:
-    if not ENABLED_PLATFORM:
+    if not _ALL_PARSERS:
         return
 
-    await asyncio.gather(*(parser.aclose() for parser in ENABLED_PLATFORM))
+    await asyncio.gather(*(parser.aclose() for parser in _ALL_PARSERS))
 
 
 # 缓存结果
@@ -207,7 +205,7 @@ async def _(bv: Match[str]):
         await UniMessage("请发送正确的 BV 号").finish()
 
     bvid, page_num = matched[1], matched[2]
-    page_idx = int(page_num) if page_num else 0
+    page_idx = int(page_num) - 1 if page_num else 0
 
     parser = get_parser_by_type(BilibiliParser)
 
@@ -216,12 +214,12 @@ async def _(bv: Match[str]):
         await UniMessage("未找到可下载的音频").finish()
 
     audio_path = await DOWNLOADER.download_audio(
-        audio_url, audio_name=f"{bvid}-{page_idx}.mp3"
+        audio_url, audio_name=f"{bvid}-{page_idx}.mp3", ext_headers=parser.headers
     )
-    await UniMessage(UniHelper.record_seg(audio_path)).send()
-
     if pconfig.need_upload_audio:
         await UniMessage(UniHelper.file_seg(audio_path)).send()
+    else:
+        await UniMessage(UniHelper.record_seg(audio_path)).send()
 
 
 @on_alconna(Alconna("blogin"), block=True, permission=SUPERUSER, rule=to_me()).handle()

--- a/src/nonebot_plugin_parser_lite/render/__init__.py
+++ b/src/nonebot_plugin_parser_lite/render/__init__.py
@@ -115,7 +115,7 @@ class Renderer:
                 continue
             except DurationLimitException as e:
                 yield UniMessage(
-                    f"设定的最大时长大小为 {pconfig.duration_maximum}s\n当前解析到的媒体时长为 {e.duration}s\n"
+                    f"设定的最大时长为 {pconfig.duration_maximum}s\n当前解析到的媒体时长为 {e.duration}s\n"
                     "媒体太长了~"
                 )
             except DownloadLimitException as e:

--- a/src/nonebot_plugin_parser_lite/render/__init__.py
+++ b/src/nonebot_plugin_parser_lite/render/__init__.py
@@ -13,7 +13,7 @@ from nonebot import logger
 from nonebot_plugin_htmlrender import template_to_pic
 
 from ..config import _nickname, pconfig
-from ..exception import DownloadException, DownloadLimitException
+from ..exception import DownloadException, DownloadLimitException, DurationLimitException, SizeLimitException
 from ..helper import ForwardNodeInner, UniHelper, UniMessage
 from ..parsers.data import (
     AudioContent,
@@ -107,6 +107,17 @@ class Renderer:
             try:
                 async for msg in self.__handle_immediate_media(cont):
                     yield msg
+            except SizeLimitException as e:
+                yield UniMessage(
+                    f"设定的最大上传大小为 {pconfig.max_size}MB\n当前解析到的媒体大小为 {e.size}MB\n"
+                    "媒体太大了~"
+                )
+                continue
+            except DurationLimitException as e:
+                yield UniMessage(
+                    f"设定的最大时长大小为 {pconfig.duration_maximum}s\n当前解析到的媒体时长为 {e.duration}s\n"
+                    "媒体太长了~"
+                )
             except DownloadLimitException as e:
                 yield UniMessage(str(e))
                 continue


### PR DESCRIPTION
在 `Renderer` 类中，更新了异常处理逻辑，使其能够处理 `SizeLimitException` 和 `DurationLimitException`，并输出具体的大小和时长信息。

## Summary by Sourcery

优化媒体解析、下载和渲染行为，更好地遵守大小/时长限制，并改进对 Bilibili 音频的处理。

新功能：
- 当超出大小或时长限制时，在面向用户的消息中暴露精确的媒体大小和时长信息。

错误修复：
- 修正 Bilibili BV 页面索引计算，并在根据配置在文件和语音消息之间进行选择时，确保音频上传遵守解析器特定的请求头。

增强改进：
- 将所有解析器实例与关键字到解析器的映射分离跟踪，以简化生命周期管理和关闭时的清理。
- 为大小和时长限制相关的异常补充实际测量值，以便获得更具信息量的日志记录和错误处理。
- 明确配置属性的文档字符串，为最大大小和时长限制添加单位说明。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine media parsing, downloading, and rendering behavior to better respect size/duration limits and improve Bilibili audio handling.

New Features:
- Expose exact media size and duration details in user-facing messages when size or duration limits are exceeded.

Bug Fixes:
- Correct Bilibili BV page index calculation and ensure audio uploads respect parser-specific request headers while choosing between file or voice message based on configuration.

Enhancements:
- Track all parser instances separately from the keyword-to-parser map to simplify lifecycle management and shutdown cleanup.
- Augment size and duration limit exceptions with the actual measured values for more informative logging and error handling.
- Clarify configuration property docstrings to include units for maximum size and duration limits.

</details>