### PR TITLE
refactor(bilibili): 修改哔哩哔哩下载实现以暴露视频地址

### DIFF
--- a/src/nonebot_plugin_parser_lite/parsers/acfun/__init__.py
+++ b/src/nonebot_plugin_parser_lite/parsers/acfun/__init__.py
@@ -32,12 +32,10 @@ class AcfunParser(BaseParser):
             name=video_info.name, avatar_url=video_info.avatar_url
         )
 
-        video_task = DOWNLOADER.download_m3u8_video(
-            video_info.m3u8_url,
-        )
-
         video_content = self.create_video(
-            video_task,
+            url_or_task=DOWNLOADER.download_m3u8_video(
+                m3u8_url=video_info.m3u8_url, video_name=f"acfun_{acid}.mp4"
+            ),
             cover_url=video_info.coverUrl,
             duration=video_info.duration,
             video_name=f"acfun_{acid}.mp4",

--- a/src/nonebot_plugin_parser_lite/parsers/base.py
+++ b/src/nonebot_plugin_parser_lite/parsers/base.py
@@ -22,6 +22,7 @@ from ..exception import SizeLimitException as SizeLimitException
 from ..exception import TipException as TipException
 from ..exception import ZeroSizeException as ZeroSizeException
 from .creator import (
+    VideoDownloadFunc,
     create_audio,
     create_author,
     create_comment,
@@ -263,7 +264,7 @@ class BaseParser:
         self,
         url_or_task: str
         | DownloadTaskWrapper[Path]
-        | Callable[[], Coroutine[Any, Any, Path]],
+        | VideoDownloadFunc,
         cover_url: str | None = None,
         duration: float = 0.0,
         video_name: str | None = None,

--- a/src/nonebot_plugin_parser_lite/parsers/bilibili/__init__.py
+++ b/src/nonebot_plugin_parser_lite/parsers/bilibili/__init__.py
@@ -1,6 +1,7 @@
 import asyncio
 import contextlib
 import json
+from pathlib import Path
 import re
 import aiofiles
 from collections.abc import AsyncGenerator
@@ -312,30 +313,46 @@ class BilibiliParser(BaseParser):
         url = f"https://bilibili.com/{video_info.bvid}"
         url += f"?p={page_info.index + 1}" if page_info.index > 0 else ""
 
-        # 视频下载任务
-        async def download_video():
-            v_url, a_url = await self.extract_download_urls(
-                video=video, page_index=page_info.index
-            )
-            if page_info.duration > pconfig.duration_maximum:
-                raise DurationLimitException(page_info.duration)
-            if a_url is not None:
-                return await DOWNLOADER.download_av_and_merge(
-                    v_url,
-                    a_url,
-                    file_name=f"{video_info.bvid}-{page_num}",
-                    ext_headers=self.headers,
-                )
-            else:
+        # 获取真实视频 / 音频 URL
+        v_url, a_url = await self.extract_download_urls(
+            video=video, page_index=page_info.index
+        )
+        if page_info.duration > pconfig.duration_maximum:
+            raise DurationLimitException(page_info.duration)
+
+        class BiliVideoDownloader:
+            def __init__(
+                self,
+                video_url: str,
+                audio_url: str | None,
+                ext_headers: dict[str, str] | None,
+            ):
+                self.video_url = video_url
+                self._audio_url = audio_url
+                self._ext_headers = ext_headers
+
+            async def __call__(self) -> Path:
+                file_base = f"{video_info.bvid}-{page_num}"
+                # 有单独音频流时，走 av 合并
+                if self._audio_url:
+                    return await DOWNLOADER.download_av_and_merge(
+                        self.video_url,
+                        self._audio_url,
+                        file_name=file_base,
+                        ext_headers=self._ext_headers,
+                    )
+                # 否则直接用流式下载
                 return await DOWNLOADER.streamd(
-                    v_url,
-                    file_name=f"{video_info.bvid}-{page_num}.mp4",
-                    ext_headers=self.headers,
+                    self.video_url,
+                    file_name=f"{file_base}.mp4",
+                    ext_headers=self._ext_headers,
                 )
 
-        # 创建视频下载内容（传递下载函数而非立即执行）
+        downloader = BiliVideoDownloader(v_url, a_url, self.headers)
+
+        # 创建视频下载内容（传递自定义下载器，而非立即执行）
         video_content = self.create_video(
-            url_or_task=download_video,
+            url_or_task=downloader,
             cover_url=page_info.cover,
             duration=page_info.duration,
             ext_headers=self.headers,

--- a/src/nonebot_plugin_parser_lite/parsers/creator.py
+++ b/src/nonebot_plugin_parser_lite/parsers/creator.py
@@ -1,6 +1,5 @@
-from collections.abc import Callable, Coroutine
 from pathlib import Path
-from typing import Any, Literal, Sequence
+from typing import Any, Literal, Protocol, Sequence, Coroutine
 
 from ..config import pconfig as pconfig
 from ..download import DOWNLOADER
@@ -17,6 +16,14 @@ from .data import (
     StickerContent,
     VideoContent,
 )
+
+
+class VideoDownloadFunc(Protocol):
+    """自定义视频下载函数协议：必须暴露真实视频 URL。"""
+
+    video_url: str
+
+    def __call__(self) -> Coroutine[Any, Any, Path]: ...
 
 
 def _with_need_send(obj: MediaContent, need_send: bool) -> MediaContent:
@@ -46,7 +53,7 @@ def create_author(
 def create_video(
     url_or_task: str
     | DownloadTaskWrapper[Path]
-    | Callable[[], Coroutine[Any, Any, Path]],
+    | VideoDownloadFunc,
     cover_url: str | None = None,
     duration: float = 0.0,
     video_name: str | None = None,
@@ -66,26 +73,28 @@ def create_video(
     cover_task = None
     if cover_url:
         cover_task = DOWNLOADER.download_img(url=cover_url, ext_headers=ext_headers)
-    # 1) 传入 URL: 使用默认下载逻辑
     if isinstance(url_or_task, str):
+    # 1) 传入 URL: 使用默认下载逻辑
         video_task = DOWNLOADER.download_video(
             url_or_task, video_name=video_name, ext_headers=ext_headers
         )
-    # 2) 传入 DownloadTaskWrapper: 保持原样
     elif isinstance(url_or_task, DownloadTaskWrapper):
+        # 2) 传入 DownloadTaskWrapper: 保持原样
         video_task = url_or_task
-    # 3) 传入下载函数: 自定义下载逻辑（不走 auto_task）
     else:
+        # 3) 传入下载函数: 自定义下载逻辑（不走 auto_task）
+        download_func = url_or_task
+        video_url = download_func.video_url
 
         async def _runner() -> Path:
-            return await url_or_task()
+            return await download_func()
 
         # 这里手动构造一个 DownloadTaskWrapper，url 塞个占位描述字符串
         video_task = DownloadTaskWrapper(
             func=_runner,
             args=(),
             kwargs={},
-            url=f"<custom-download:{video_name or 'video'}>",
+            url=video_url,
         )
     return _with_need_send(
         VideoContent(path_task=video_task, cover=cover_task, duration=duration),

--- a/src/nonebot_plugin_parser_lite/parsers/creator.py
+++ b/src/nonebot_plugin_parser_lite/parsers/creator.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Any, Literal, Protocol, Sequence, Coroutine
+from typing import Any, Literal, Protocol, Sequence, Coroutine, runtime_checkable
 
 from ..config import pconfig as pconfig
 from ..download import DOWNLOADER
@@ -18,6 +18,7 @@ from .data import (
 )
 
 
+@runtime_checkable
 class VideoDownloadFunc(Protocol):
     """自定义视频下载函数协议：必须暴露真实视频 URL。"""
 
@@ -51,9 +52,7 @@ def create_author(
 
 
 def create_video(
-    url_or_task: str
-    | DownloadTaskWrapper[Path]
-    | VideoDownloadFunc,
+    url_or_task: str | DownloadTaskWrapper[Path] | VideoDownloadFunc,
     cover_url: str | None = None,
     duration: float = 0.0,
     video_name: str | None = None,
@@ -74,14 +73,14 @@ def create_video(
     if cover_url:
         cover_task = DOWNLOADER.download_img(url=cover_url, ext_headers=ext_headers)
     if isinstance(url_or_task, str):
-    # 1) 传入 URL: 使用默认下载逻辑
+        # 1) 传入 URL: 使用默认下载逻辑
         video_task = DOWNLOADER.download_video(
             url_or_task, video_name=video_name, ext_headers=ext_headers
         )
     elif isinstance(url_or_task, DownloadTaskWrapper):
         # 2) 传入 DownloadTaskWrapper: 保持原样
         video_task = url_or_task
-    else:
+    elif isinstance(url_or_task, VideoDownloadFunc):
         # 3) 传入下载函数: 自定义下载逻辑（不走 auto_task）
         download_func = url_or_task
         video_url = download_func.video_url
@@ -95,6 +94,12 @@ def create_video(
             args=(),
             kwargs={},
             url=video_url,
+        )
+    else:
+        # 4) 传入了不受支持的类型：立即报错，避免 AttributeError
+        raise TypeError(
+            f"create_video 的 url_or_task 类型不受支持: {type(url_or_task)!r}，"
+            "期望 str / DownloadTaskWrapper / VideoDownloadFunc 协议对象"
         )
     return _with_need_send(
         VideoContent(path_task=video_task, cover=cover_task, duration=duration),


### PR DESCRIPTION
## Sourcery 总结

重构视频创建和下载处理逻辑，在保持各站点解析器兼容的前提下，为自定义下载器暴露真实视频 URL。

新功能：
- 引入 `VideoDownloadFunc` 协议，要求自定义视频下载器必须暴露其底层的真实视频 URL。

增强与改进：
- 重构 Bilibili 解析器，使用独立的下载器对象，该对象既能暴露真实视频 URL，又能封装 AV 合并或流式播放相关逻辑。
- 更新通用的 `create_video` 辅助函数，使其接受新的 `VideoDownloadFunc` 类型，并将真实视频 URL 传播到 `DownloadTaskWrapper` 的元数据中。
- 调整 AcFun 解析器，使用配置好的 m3u8 下载任务和显式的视频命名方式来调用 `create_video`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor video creation and download handling to expose real video URLs for custom downloaders while keeping per-site parsers compatible.

New Features:
- Introduce a VideoDownloadFunc protocol that requires custom video downloaders to expose the underlying video URL.

Enhancements:
- Refactor the Bilibili parser to use a dedicated downloader object that both exposes the real video URL and encapsulates AV merging or streaming logic.
- Update the generic create_video helper to accept the new VideoDownloadFunc type and propagate the real video URL into DownloadTaskWrapper metadata.
- Adjust the AcFun parser to use create_video with a configured m3u8 download task and explicit video naming.

</details>