### PR TITLE
feat(render): 添加媒体大小展示

### DIFF
--- a/src/nonebot_plugin_parser_lite/download/__init__.py
+++ b/src/nonebot_plugin_parser_lite/download/__init__.py
@@ -43,15 +43,12 @@ class StreamDownloader:
         - 不做大小限制校验，只用于展示/预估
         """
         headers = {**self.headers, **(ext_headers or {})}
-        try:
-            resp = await self.client.head(
-                url=url,
-                headers=headers,
-                follow_redirects=True,
-            )
-            resp.raise_for_status()
-        except Exception:  # noqa: BLE001
-            return None
+        resp = await self.client.head(
+            url=url,
+            headers=headers,
+            follow_redirects=True,
+        )
+        resp.raise_for_status()
 
         raw_len = resp.headers.get("Content-Length")
         if not raw_len:

--- a/src/nonebot_plugin_parser_lite/download/__init__.py
+++ b/src/nonebot_plugin_parser_lite/download/__init__.py
@@ -34,9 +34,37 @@ class StreamDownloader:
         self.cache_dir: Path = pconfig.cache_dir
         self.client: AsyncClient = AsyncClient(timeout=DOWNLOAD_TIMEOUT, verify=False)
 
+    async def head_size(
+        self, url: str, ext_headers: dict[str, str] | None = None
+    ) -> int | None:
+        """对给定 url 发送 HEAD 请求，返回 Content-Length（字节数）。
+
+        - 请求失败或无 Content-Length 时返回 None
+        - 不做大小限制校验，只用于展示/预估
+        """
+        headers = {**self.headers, **(ext_headers or {})}
+        try:
+            resp = await self.client.head(
+                url=url,
+                headers=headers,
+                follow_redirects=True,
+            )
+            resp.raise_for_status()
+        except Exception:  # noqa: BLE001
+            return None
+
+        raw_len = resp.headers.get("Content-Length")
+        if not raw_len:
+            return None
+        try:
+            return int(raw_len)
+        except ValueError:
+            return None
+
     @auto_task
     async def streamd(
         self,
+        *,
         url: str,
         file_name: str | None = None,
         ext_headers: dict[str, str] | None = None,
@@ -148,6 +176,7 @@ class StreamDownloader:
     @auto_task
     async def download_video(
         self,
+        *,
         url: str,
         video_name: str | None = None,
         ext_headers: dict[str, str] | None = None,
@@ -167,12 +196,15 @@ class StreamDownloader:
         if video_name is None:
             video_name = generate_file_name(url, ".mp4")
 
-        return await self.streamd(url, file_name=video_name, ext_headers=ext_headers)
+        return await self.streamd(
+            url=url, file_name=video_name, ext_headers=ext_headers
+        )
 
     @auto_task
     async def download_m3u8_video(
         self,
-        m3u8_url: str,
+        *,
+        url: str,
         video_name: str | None = None,
         ext_headers: dict[str, str] | None = None,
     ) -> Path:
@@ -187,7 +219,7 @@ class StreamDownloader:
         :raises SizeLimitException: 资源大小超过配置的最大限制时抛出
         :raises DownloadException: m3u8 解析、下载或转封装失败时抛出
         """
-        file_id = hashlib.md5(m3u8_url.encode()).hexdigest()[:16]
+        file_id = hashlib.md5(url.encode()).hexdigest()[:16]
 
         if video_name is None:
             video_name = f"{file_id}.mp4"
@@ -202,7 +234,7 @@ class StreamDownloader:
 
         try:
             # 1. 智能解析 m3u8 (自动处理嵌套列表)
-            ts_urls = await self._smart_parse_m3u8(m3u8_url)
+            ts_urls = await self._smart_parse_m3u8(url)
             if not ts_urls:
                 raise DownloadException("m3u8 解析结果为空")
 
@@ -434,6 +466,7 @@ class StreamDownloader:
     @auto_task
     async def download_audio(
         self,
+        *,
         url: str,
         audio_name: str | None = None,
         ext_headers: dict[str, str] | None = None,
@@ -449,11 +482,14 @@ class StreamDownloader:
         """
         if audio_name is None:
             audio_name = generate_file_name(url, ".mp3")
-        return await self.streamd(url, file_name=audio_name, ext_headers=ext_headers)
+        return await self.streamd(
+            url=url, file_name=audio_name, ext_headers=ext_headers
+        )
 
     @auto_task
     async def download_img(
         self,
+        *,
         url: str,
         img_name: str | None = None,
         ext_headers: dict[str, str] | None = None,
@@ -470,7 +506,7 @@ class StreamDownloader:
         """
         if img_name is None:
             img_name = generate_file_name(url, ".jpg")
-        return await self.streamd(url, file_name=img_name, ext_headers=ext_headers)
+        return await self.streamd(url=url, file_name=img_name, ext_headers=ext_headers)
 
     async def download_av_and_merge(
         self,

--- a/src/nonebot_plugin_parser_lite/download/task.py
+++ b/src/nonebot_plugin_parser_lite/download/task.py
@@ -12,7 +12,7 @@ class DownloadTaskWrapper(Generic[T], Awaitable[T]):
     - 在被 await 时才真正执行协程
     """
 
-    __slots__ = ("url", "_func", "_args", "_kwargs")
+    __slots__ = ("url", "ext_headers", "_func", "_args", "_kwargs")
 
     def __init__(
         self,
@@ -20,11 +20,13 @@ class DownloadTaskWrapper(Generic[T], Awaitable[T]):
         args: tuple[Any, ...],
         kwargs: dict[str, Any],
         url: str,
+        ext_headers: dict[str, str] | None = None,
     ):
         self._func = func
         self._args = args
         self._kwargs = kwargs
         self.url: str = url
+        self.ext_headers: dict[str, str] | None = ext_headers
 
     def __await__(self) -> Generator[Any, Any, T]:
         # 每次 await 都直接执行原始协程
@@ -35,39 +37,55 @@ class DownloadTaskWrapper(Generic[T], Awaitable[T]):
 def auto_task(
     func: Callable[P, Coroutine[Any, Any, T]],
 ) -> Callable[P, DownloadTaskWrapper[T]]:
-    """装饰器：返回惰性的下载包装器，并挂载 url 属性
+    """装饰器：返回惰性的下载包装器，并挂载 url / ext_headers 属性。
 
-    约定：
-    - 被修饰函数的签名类似：
-        async def fn(self, url: str, *..., **...)
-      即 args[0] 是 self/cls，args[1] 或 kwargs["url"] 为 url: str
+    强约束（运行时检查）：
+    - 被修饰函数签名必须包含：
+        url: str
+        ext_headers: dict[str, str] | None = None
+    - 调用方必须使用关键字传参：
+        fn(url=..., ext_headers=..., 其他参数...)
     """
 
     @wraps(func)
     def wrapper(*args: P.args, **kwargs: P.kwargs) -> DownloadTaskWrapper[T]:
-        # 优先从关键字参数中获取 url，其次才从位置参数中取
-        if "url" in kwargs:
-            raw_url = kwargs["url"]
-        else:
-            if len(args) < 2:
-                raise RuntimeError(
-                    f"@auto_task 要求 {func.__qualname__} 的第二个参数为 url: str"
-                )
-            raw_url = args[1]
+        # 1) 强制要求 url / ext_headers 通过关键字参数传入
+        #    不限制其它参数的传参方式（可以继续用位置参数）
+        if "url" not in kwargs:
+            raise RuntimeError(
+                f"@auto_task 要求 {func.__qualname__} 必须有关键字参数 url: str，"
+                f"请使用 {func.__name__}(url=..., ...) 的形式调用"
+            )
+        if "ext_headers" not in kwargs:
+            raise RuntimeError(
+                f"@auto_task 要求 {func.__qualname__} 必须有关键字参数 ext_headers: dict[str, str] | None，"
+                f"请使用 {func.__name__}(ext_headers=..., ...) 的形式调用"
+            )
 
+        raw_url = kwargs["url"]
+        ext_headers = kwargs["ext_headers"]
+
+        # 2) 运行时类型校验（防御性）
         if not isinstance(raw_url, str):
             raise TypeError(
                 f"@auto_task 要求 {func.__qualname__} 的 url 参数为 str, "
                 f"但实际是 {type(raw_url)!r}"
             )
+        if ext_headers is not None and not isinstance(ext_headers, dict):
+            raise TypeError(
+                f"@auto_task 要求 {func.__qualname__} 的 ext_headers 类型为 dict[str, str] | None, "
+                f"但实际是 {type(ext_headers)!r}"
+            )
+
         url: str = raw_url
 
-        # 这里把 args/kwargs 转为简单类型传给 DownloadTaskWrapper
+        # 3) 构造惰性下载包装器（保留原始 args/kwargs，不影响其它参数）
         return DownloadTaskWrapper(
-            func,
-            tuple(args),  # 保证 *args 全部原样保留
-            dict(kwargs),  # 保证 **kwargs 全部原样保留
-            url,
+            func=func,
+            args=tuple(args),
+            kwargs=dict(kwargs),
+            url=url,
+            ext_headers=ext_headers,
         )
 
     return wrapper

--- a/src/nonebot_plugin_parser_lite/download/task.py
+++ b/src/nonebot_plugin_parser_lite/download/task.py
@@ -39,33 +39,28 @@ def auto_task(
 ) -> Callable[P, DownloadTaskWrapper[T]]:
     """装饰器：返回惰性的下载包装器，并挂载 url / ext_headers 属性。
 
-    强约束（运行时检查）：
+    约束（运行时检查）：
     - 被修饰函数签名必须包含：
         url: str
         ext_headers: dict[str, str] | None = None
-    - 调用方必须使用关键字传参：
-        fn(url=..., ext_headers=..., 其他参数...)
+    - 调用方必须使用关键字传参 url=...
+    - ext_headers 可以省略，不传时等价于 None（使用默认 headers）
     """
 
     @wraps(func)
     def wrapper(*args: P.args, **kwargs: P.kwargs) -> DownloadTaskWrapper[T]:
-        # 1) 强制要求 url / ext_headers 通过关键字参数传入
-        #    不限制其它参数的传参方式（可以继续用位置参数）
+        # 1) 强制要求 url 通过关键字参数传入
         if "url" not in kwargs:
             raise RuntimeError(
                 f"@auto_task 要求 {func.__qualname__} 必须有关键字参数 url: str，"
                 f"请使用 {func.__name__}(url=..., ...) 的形式调用"
             )
-        if "ext_headers" not in kwargs:
-            raise RuntimeError(
-                f"@auto_task 要求 {func.__qualname__} 必须有关键字参数 ext_headers: dict[str, str] | None，"
-                f"请使用 {func.__name__}(ext_headers=..., ...) 的形式调用"
-            )
 
         raw_url = kwargs["url"]
-        ext_headers = kwargs["ext_headers"]
+        # 2) ext_headers 允许缺省，默认为 None
+        ext_headers = kwargs.get("ext_headers", None)
 
-        # 2) 运行时类型校验（防御性）
+        # 3) 运行时类型校验（防御性）
         if not isinstance(raw_url, str):
             raise TypeError(
                 f"@auto_task 要求 {func.__qualname__} 的 url 参数为 str, "
@@ -79,7 +74,7 @@ def auto_task(
 
         url: str = raw_url
 
-        # 3) 构造惰性下载包装器（保留原始 args/kwargs，不影响其它参数）
+        # 4) 构造惰性下载包装器（保留原始 args/kwargs，不影响其它参数）
         return DownloadTaskWrapper(
             func=func,
             args=tuple(args),

--- a/src/nonebot_plugin_parser_lite/matchers/__init__.py
+++ b/src/nonebot_plugin_parser_lite/matchers/__init__.py
@@ -220,7 +220,9 @@ if bilip is not None:
             await UniMessage("未找到可下载的音频").finish()
 
         audio_path = await DOWNLOADER.download_audio(
-            audio_url, audio_name=f"{bvid}-{page_idx}.mp3", ext_headers=_bilip.headers
+            url=audio_url,
+            audio_name=f"{bvid}-{page_idx}.mp3",
+            ext_headers=_bilip.headers,
         )
 
         if pconfig.need_upload_audio:

--- a/src/nonebot_plugin_parser_lite/parsers/acfun/__init__.py
+++ b/src/nonebot_plugin_parser_lite/parsers/acfun/__init__.py
@@ -34,7 +34,7 @@ class AcfunParser(BaseParser):
 
         video_content = self.create_video(
             url_or_task=DOWNLOADER.download_m3u8_video(
-                m3u8_url=video_info.m3u8_url, video_name=f"acfun_{acid}.mp4"
+                url=video_info.m3u8_url, video_name=f"acfun_{acid}.mp4"
             ),
             cover_url=video_info.coverUrl,
             duration=video_info.duration,

--- a/src/nonebot_plugin_parser_lite/parsers/bilibili/__init__.py
+++ b/src/nonebot_plugin_parser_lite/parsers/bilibili/__init__.py
@@ -329,7 +329,7 @@ class BilibiliParser(BaseParser):
             ):
                 self.video_url = video_url
                 self._audio_url = audio_url
-                self._ext_headers = ext_headers
+                self.ext_headers = ext_headers
 
             async def __call__(self) -> Path:
                 file_base = f"{video_info.bvid}-{page_num}"
@@ -339,13 +339,13 @@ class BilibiliParser(BaseParser):
                         self.video_url,
                         self._audio_url,
                         file_name=file_base,
-                        ext_headers=self._ext_headers,
+                        ext_headers=self.ext_headers,
                     )
                 # 否则直接用流式下载
                 return await DOWNLOADER.streamd(
-                    self.video_url,
+                    url=self.video_url,
                     file_name=f"{file_base}.mp4",
-                    ext_headers=self._ext_headers,
+                    ext_headers=self.ext_headers,
                 )
 
         downloader = BiliVideoDownloader(v_url, a_url, self.headers)

--- a/src/nonebot_plugin_parser_lite/parsers/creator.py
+++ b/src/nonebot_plugin_parser_lite/parsers/creator.py
@@ -23,6 +23,7 @@ class VideoDownloadFunc(Protocol):
     """自定义视频下载函数协议：必须暴露真实视频 URL。"""
 
     video_url: str
+    ext_headers: dict[str, str] | None = None
 
     def __call__(self) -> Coroutine[Any, Any, Path]: ...
 
@@ -47,7 +48,7 @@ def create_author(
     :param id: 作者 ID
     """
 
-    avatar_task = DOWNLOADER.download_img(avatar_url) if avatar_url else None
+    avatar_task = DOWNLOADER.download_img(url=avatar_url) if avatar_url else None
     return Author(name=name, id=id, avatar=avatar_task, description=description)
 
 
@@ -75,7 +76,7 @@ def create_video(
     if isinstance(url_or_task, str):
         # 1) 传入 URL: 使用默认下载逻辑
         video_task = DOWNLOADER.download_video(
-            url_or_task, video_name=video_name, ext_headers=ext_headers
+            url=url_or_task, video_name=video_name, ext_headers=ext_headers
         )
     elif isinstance(url_or_task, DownloadTaskWrapper):
         # 2) 传入 DownloadTaskWrapper: 保持原样
@@ -83,7 +84,6 @@ def create_video(
     elif isinstance(url_or_task, VideoDownloadFunc):
         # 3) 传入下载函数: 自定义下载逻辑（不走 auto_task）
         download_func = url_or_task
-        video_url = download_func.video_url
 
         async def _runner() -> Path:
             return await download_func()
@@ -93,7 +93,7 @@ def create_video(
             func=_runner,
             args=(),
             kwargs={},
-            url=video_url,
+            url=download_func.video_url,
         )
     else:
         # 4) 传入了不受支持的类型：立即报错，避免 AttributeError
@@ -138,7 +138,7 @@ def create_image(
     :param ext_headers: 额外请求头
     """
 
-    task = DOWNLOADER.download_img(url, img_name=img_name, ext_headers=ext_headers)
+    task = DOWNLOADER.download_img(url=url, img_name=img_name, ext_headers=ext_headers)
 
     return _with_need_send(ImageContent(path_task=task), need_send)
 
@@ -175,7 +175,7 @@ def create_audio(
     """
 
     task = DOWNLOADER.download_audio(
-        url, audio_name=audio_name, ext_headers=ext_headers
+        url=url, audio_name=audio_name, ext_headers=ext_headers
     )
 
     return _with_need_send(AudioContent(path_task=task, duration=duration), need_send)
@@ -199,7 +199,7 @@ def create_graphic(
     """
 
     image_task = DOWNLOADER.download_img(
-        image_url, img_name=img_name, ext_headers=ext_headers
+        url=image_url, img_name=img_name, ext_headers=ext_headers
     )
     return _with_need_send(GraphicContent(path_task=image_task, alt=alt), need_send)
 
@@ -221,7 +221,7 @@ def create_sticker(
     :param ext_headers: 额外请求头
     """
 
-    image_task = DOWNLOADER.download_img(url, ext_headers=ext_headers)
+    image_task = DOWNLOADER.download_img(url=url, ext_headers=ext_headers)
     return StickerContent(path_task=image_task, size=size, desc=desc)
 
 
@@ -242,10 +242,10 @@ def create_live_photo(
     :param ext_headers: 额外请求头
     """
 
-    video_task = DOWNLOADER.download_video(video_url, ext_headers=ext_headers)
-    image_task = DOWNLOADER.download_img(image_url, ext_headers=ext_headers)
+    video_task = DOWNLOADER.download_video(url=video_url, ext_headers=ext_headers)
+    image_task = DOWNLOADER.download_img(url=image_url, ext_headers=ext_headers)
     if bgm_url:
-        bgm_task = DOWNLOADER.download_audio(bgm_url, ext_headers=ext_headers)
+        bgm_task = DOWNLOADER.download_audio(url=bgm_url, ext_headers=ext_headers)
     else:
         bgm_task = None
     return _with_need_send(

--- a/src/nonebot_plugin_parser_lite/parsers/creator.py
+++ b/src/nonebot_plugin_parser_lite/parsers/creator.py
@@ -94,6 +94,7 @@ def create_video(
             args=(),
             kwargs={},
             url=download_func.video_url,
+            ext_headers=download_func.ext_headers,
         )
     else:
         # 4) 传入了不受支持的类型：立即报错，避免 AttributeError

--- a/src/nonebot_plugin_parser_lite/parsers/data.py
+++ b/src/nonebot_plugin_parser_lite/parsers/data.py
@@ -20,8 +20,39 @@ class MediaContent:
     need_send: bool = field(default=True, init=False)
     """是否发送"""
 
+    # 以字节为单位的文件大小缓存
+    _size_bytes: int | None = field(default=None, init=False, repr=False)
+
     async def get_path(self) -> Path:
         return await self.path_task
+
+    @staticmethod
+    def _format_size(size_bytes: int | None) -> str:
+        """将字节大小格式化为可读字符串（KB / MB / GB）。"""
+        if not size_bytes or size_bytes <= 0:
+            return "未知大小"
+
+        units = ["B", "KB", "MB", "GB", "TB"]
+        size = float(size_bytes)
+        idx = 0
+        while size >= 1024 and idx < len(units) - 1:
+            size /= 1024.0
+            idx += 1
+        # 保留 2 位小数
+        return f"{size:.2f}{units[idx]}"
+
+    async def display_size(self) -> str:
+        """获取媒体文件大小"""
+        if self._size_bytes is None:
+            try:
+                self._size_bytes = await DOWNLOADER.head_size(
+                    url=self.path_task.url, ext_headers=self.path_task.ext_headers
+                )
+            except Exception:
+                # HEAD 失败时不抛出，避免影响主流程
+                self._size_bytes = None
+
+        return self._format_size(self._size_bytes)
 
     def __repr__(self) -> str:
         prefix = self.__class__.__name__
@@ -133,7 +164,7 @@ class Platform:
     async def get_logo_path(self) -> Path:
         return await DOWNLOADER.download_img(
             url=f"https://emoji.awkchan.top/assets/logo/{self.name}.webp",
-            img_name=f"{self.name}.webp"
+            img_name=f"{self.name}.webp",
         )
 
 

--- a/src/nonebot_plugin_parser_lite/parsers/data.py
+++ b/src/nonebot_plugin_parser_lite/parsers/data.py
@@ -41,9 +41,9 @@ class MediaContent:
         # 保留 2 位小数
         return f"{size:.2f}{units[idx]}"
 
-    @property
-    async def display_size(self) -> str:
+    async def get_display_size(self) -> str:
         """获取媒体文件大小"""
+        print("get_size...")
         if self._size_bytes is None:
             try:
                 self._size_bytes = await DOWNLOADER.head_size(

--- a/src/nonebot_plugin_parser_lite/parsers/data.py
+++ b/src/nonebot_plugin_parser_lite/parsers/data.py
@@ -41,6 +41,7 @@ class MediaContent:
         # 保留 2 位小数
         return f"{size:.2f}{units[idx]}"
 
+    @property
     async def display_size(self) -> str:
         """获取媒体文件大小"""
         if self._size_bytes is None:

--- a/src/nonebot_plugin_parser_lite/render/templates/macros.jinja
+++ b/src/nonebot_plugin_parser_lite/render/templates/macros.jinja
@@ -250,7 +250,7 @@
                             '<i class="fa-icon fa-play ml-1"></i>'
                             '</div>'
                             '</div>'
-                            '<div class="absolute bottom-2 left-2 flex items-center bg-black/60 text-white h-[19px] px-1.5 rounded-[2px] text-[10px] font-mono">' ~ cont.display_size ~ '</div>'
+                            '<div class="absolute bottom-2 left-2 flex items-center bg-black/60 text-white h-[19px] px-1.5 rounded-[2px] text-[10px] font-mono">' ~ cont.get_display_size()  ~ '</div>'
                             '<div class="absolute bottom-2 right-2 flex items-center bg-black/60 text-white h-[19px] px-1.5 rounded-[2px] text-[10px] font-mono">' ~ cont.display_duration ~ '</div>'
                             '</div>'
                         ) %}

--- a/src/nonebot_plugin_parser_lite/render/templates/macros.jinja
+++ b/src/nonebot_plugin_parser_lite/render/templates/macros.jinja
@@ -250,6 +250,7 @@
                             '<i class="fa-icon fa-play ml-1"></i>'
                             '</div>'
                             '</div>'
+                            '<div class="absolute bottom-2 left-2 flex items-center bg-black/60 text-white h-[19px] px-1.5 rounded-[2px] text-[10px] font-mono">' ~ cont.display_size ~ '</div>'
                             '<div class="absolute bottom-2 right-2 flex items-center bg-black/60 text-white h-[19px] px-1.5 rounded-[2px] text-[10px] font-mono">' ~ cont.display_duration ~ '</div>'
                             '</div>'
                         ) %}
@@ -308,9 +309,7 @@
         {% endif %}
         {# 转发内容：嵌套一层卡片，用 is_repost=True #}
         {% if result.repost %}
-            <div class="shadow-sm m-8 mt-0 rounded-xl outline-1 outline-slate-200">
-                {{ render_content(result.repost, True) }}
-            </div>
+            <div class="shadow-sm m-8 mt-0 rounded-xl outline-1 outline-slate-200">{{ render_content(result.repost, True) }}</div>
         {% endif %}
         {# 主体内容和评论之间的间隔 #}
         {% if comments and comments|length > 0 %}

--- a/src/nonebot_plugin_parser_lite/render/templates/tailwind.css
+++ b/src/nonebot_plugin_parser_lite/render/templates/tailwind.css
@@ -286,6 +286,9 @@
   .inset-0 {
     inset: calc(var(--spacing) * 0);
   }
+  .left-2 {
+    left: calc(var(--spacing) * 2);
+  }
   .right-2 {
     right: calc(var(--spacing) * 2);
   }


### PR DESCRIPTION
- resolve [FEAT] 把视频大小渲染到图上
Fixes [#79](https://github.com/molanp/nonebot-plugin-parser-lite/issues/79)

## Summary by Sourcery

通过在下载过程中获取内容长度，并将其暴露给渲染模板，添加媒体大小显示支持。

新功能：
- 在渲染的视频卡片中显示人类可读的媒体文件大小，使用 HEAD 请求获取 `Content-Length` 元数据。

错误修复：
- 确保 `ext_headers` 在下载流程中被正确传递，包括 m3u8 和自定义下载器路径，防止请求过程中头信息丢失。

增强改进：
- 扩展下载任务包装器和创建工具，以便在 URL 之外同时携带可选的额外请求头，包括用于自定义视频下载函数的场景。
- 在基于 `auto_task` 的下载方法中强制 URL 参数仅使用关键字传参，并进行运行时验证，以提高使用的健壮性。
- 在下载器上添加可复用的基于 HEAD 的大小探测功能，并在 `MediaContent` 上添加大小格式化辅助方法，以实现一致的大小处理。
- 调整 Tailwind 工具类以及少量模板/布局标记，以便在视频覆盖层中正确定位新的大小标签。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add media size display support by fetching content length during download and exposing it to rendering templates.

New Features:
- Display human-readable media file size in rendered video cards using HEAD requests to obtain Content-Length metadata.

Bug Fixes:
- Ensure ext_headers are correctly propagated through download flows, including m3u8 and custom downloader paths, preventing header loss in requests.

Enhancements:
- Extend download task wrappers and creator utilities to carry optional extra request headers alongside URLs, including for custom video download functions.
- Enforce keyword-only URL parameters and runtime validation in auto_task-based download methods for more robust usage.
- Add a reusable HEAD-based size probe on the downloader and a size formatting helper on MediaContent for consistent size handling.
- Adjust Tailwind utility classes and minor template/layout markup for positioning the new size label in the video overlay.

</details>