### PR TITLE
refactor(bilibili): 调整B站解析器中音频质量枚举定义位置

### DIFF
--- a/src/nonebot_plugin_parser_lite/__init__.py
+++ b/src/nonebot_plugin_parser_lite/__init__.py
@@ -1,4 +1,5 @@
 import asyncio
+from enum import Enum
 import traceback
 
 from nonebot import logger, require
@@ -13,7 +14,30 @@ require("nonebot_plugin_localstore")
 import time
 
 from anyio import Path
+import bilibili_api.video
 from nonebot_plugin_apscheduler import scheduler
+
+
+class HookAudioQuality(Enum):
+    """
+    视频的音频流清晰度枚举
+
+    - _64K: 64K
+    - _132K: 132K
+    - _192K: 192K
+    - HI_RES: Hi-Res 无损
+    - DOLBY: 杜比全景声
+    """
+
+    _64K = 30216
+    _132K = 30232
+    DOLBY = 30250
+    HI_RES = 30251
+    _192K = 30280
+
+
+bilibili_api.video.AudioQuality = HookAudioQuality
+
 
 from .config import Config, pconfig
 from .matchers import clear_result_cache

--- a/src/nonebot_plugin_parser_lite/parsers/bilibili/__init__.py
+++ b/src/nonebot_plugin_parser_lite/parsers/bilibili/__init__.py
@@ -1,7 +1,6 @@
 import asyncio
 from collections.abc import AsyncGenerator
 import contextlib
-from enum import Enum
 import json
 import re
 from re import Match
@@ -9,29 +8,6 @@ from typing import Any, ClassVar
 
 import aiofiles
 from anyio import Path
-import bilibili_api.video
-
-
-class HookAudioQuality(Enum):
-    """
-    视频的音频流清晰度枚举
-
-    - _64K: 64K
-    - _132K: 132K
-    - _192K: 192K
-    - HI_RES: Hi-Res 无损
-    - DOLBY: 杜比全景声
-    """
-
-    _64K = 30216
-    _132K = 30232
-    DOLBY = 30250
-    HI_RES = 30251
-    _192K = 30280
-
-
-bilibili_api.video.AudioQuality = HookAudioQuality
-
 from bilibili_api import HEADERS, Credential, request_settings, select_client
 from bilibili_api.article import Article
 from bilibili_api.dynamic import Dynamic


### PR DESCRIPTION
将HookAudioQuality枚举类从bilibili子模块移至主模块， 统一在__init__.py中定义并覆盖bilibili_api.video.AudioQuality， 便于全局使用和维护音频清晰度配置

## Summary by Sourcery

增强内容：
- 将 `HookAudioQuality` 枚举从 Bilibili 解析器子模块移动到包根目录，并使其与 `bilibili_api.video.AudioQuality` 对齐，以在整个插件中实现一致的音频质量配置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Move the HookAudioQuality enum from the Bilibili parser submodule to the package root and align it with bilibili_api.video.AudioQuality for consistent audio quality configuration across the plugin.

</details>