### PR TITLE
feat(matchers): 将bm/blogin命令注册逻辑移到驱动启动时

### DIFF
--- a/src/nonebot_plugin_parser_lite/matchers/__init__.py
+++ b/src/nonebot_plugin_parser_lite/matchers/__init__.py
@@ -5,7 +5,7 @@ from typing import ClassVar, TypeVar
 
 from nonebot import get_driver, logger
 from nonebot.permission import SUPERUSER
-from nonebot.rule import to_me
+from nonebot.rule import Rule, to_me
 from nonebot_plugin_alconna import Alconna, Args, Match, on_alconna
 from nonebot_plugin_uninfo import Uninfo
 
@@ -242,26 +242,27 @@ async def register_bili_matcher():
             async for msg in bilip.check_qr_state():
                 await UniMessage(msg).send()
 
-    if pconfig.lazy_download:
 
-        def has_lazy(session: Uninfo) -> bool:
-            return LazyManager.has(session.user.id)
+if pconfig.lazy_download:
 
-        lazy_matcher = on_alconna(
-            Alconna(pconfig.download_command[0]),
-            block=True,
-            aliases=set(pconfig.download_command[1:]),
-            rule=has_lazy,
-        )
+    async def has_lazy(session: Uninfo) -> bool:
+        return LazyManager.has(session.user.id)
 
-        @lazy_matcher.handle()
-        @UniHelper.with_reaction
-        async def _(session: Uninfo):
-            """懒下载命令：发送上次解析结果中的媒体内容。"""
-            user_id = session.user.id
-            result = LazyManager.get(user_id)
-            try:
-                async for message in RENDERER.send_content(result):
-                    await message.send()
-            finally:
-                LazyManager.remove(user_id)
+    lazy_matcher = on_alconna(
+        Alconna(pconfig.download_command[0]),
+        block=True,
+        aliases=set(pconfig.download_command[1:]),
+        rule=Rule(has_lazy),
+    )
+
+    @lazy_matcher.handle()
+    @UniHelper.with_reaction
+    async def _(session: Uninfo):
+        """懒下载命令：发送上次解析结果中的媒体内容。"""
+        user_id = session.user.id
+        result = LazyManager.get(user_id)
+        try:
+            async for message in RENDERER.send_content(result):
+                await message.send()
+        finally:
+            LazyManager.remove(user_id)

--- a/src/nonebot_plugin_parser_lite/matchers/__init__.py
+++ b/src/nonebot_plugin_parser_lite/matchers/__init__.py
@@ -196,71 +196,72 @@ async def parser_handler(
     await _send_parse_result(session, result)
 
 
-bilip: BilibiliParser | None
-try:
-    bilip = get_parser_by_type(BilibiliParser)
-except ValueError:
-    bilip = None
+@driver.on_startup
+async def register_bili_matcher():
 
-if bilip is not None:
-    _bilip: BilibiliParser = bilip
+    bilip: BilibiliParser | None
+    try:
+        bilip = get_parser_by_type(BilibiliParser)
+    except ValueError:
+        bilip = None
 
-    @on_alconna(
-        Alconna("bm", Args["bv", r"re:(BV[A-Za-z0-9]{10})"]["page?", int, 0]),
-        priority=3,
-        block=True,
-    ).handle()
-    @UniHelper.with_reaction
-    async def _(bv: Match[str], page: Match[int]):
-        bvid = bv.result
-        page_idx = page.result - 1 if page.result > 0 else 0
-        _, audio_url = await _bilip.extract_download_urls(
-            bvid=bvid, page_index=page_idx
+    if bilip is not None:
+
+        @on_alconna(
+            Alconna("bm", Args["bv", r"re:(BV[A-Za-z0-9]{10})"]["page?", int, 0]),
+            priority=3,
+            block=True,
+        ).handle()
+        @UniHelper.with_reaction
+        async def _(bv: Match[str], page: Match[int]):
+            bvid = bv.result
+            page_idx = page.result - 1 if page.result > 0 else 0
+            _, audio_url = await bilip.extract_download_urls(
+                bvid=bvid, page_index=page_idx
+            )
+            if not audio_url:
+                await UniMessage("未找到可下载的音频").finish()
+
+            audio_path = await DOWNLOADER.download_audio(
+                url=audio_url,
+                audio_name=f"{bvid}-{page_idx}.m4s",
+                ext_headers=bilip.headers,
+            )
+
+            if pconfig.need_upload_audio:
+                await UniMessage(await UniHelper.file_seg(audio_path)).send()
+            else:
+                await UniMessage(await UniHelper.record_seg(audio_path)).send()
+
+        @on_alconna(
+            Alconna("blogin"), block=True, permission=SUPERUSER, rule=to_me()
+        ).handle()
+        async def _():
+            qrcode = await bilip.login_with_qrcode()
+            await UniMessage(await UniHelper.img_seg(qrcode)).send()
+            async for msg in bilip.check_qr_state():
+                await UniMessage(msg).send()
+
+    if pconfig.lazy_download:
+
+        def has_lazy(session: Uninfo) -> bool:
+            return LazyManager.has(session.user.id)
+
+        lazy_matcher = on_alconna(
+            Alconna(pconfig.download_command[0]),
+            block=True,
+            aliases=set(pconfig.download_command[1:]),
+            rule=has_lazy,
         )
-        if not audio_url:
-            await UniMessage("未找到可下载的音频").finish()
 
-        audio_path = await DOWNLOADER.download_audio(
-            url=audio_url,
-            audio_name=f"{bvid}-{page_idx}.mp3",
-            ext_headers=_bilip.headers,
-        )
-
-        if pconfig.need_upload_audio:
-            await UniMessage(await UniHelper.file_seg(audio_path)).send()
-        else:
-            await UniMessage(await UniHelper.record_seg(audio_path)).send()
-
-    @on_alconna(
-        Alconna("blogin"), block=True, permission=SUPERUSER, rule=to_me()
-    ).handle()
-    async def _():
-        qrcode = await _bilip.login_with_qrcode()
-        await UniMessage(await UniHelper.img_seg(qrcode)).send()
-        async for msg in _bilip.check_qr_state():
-            await UniMessage(msg).send()
-
-
-if pconfig.lazy_download:
-
-    def has_lazy(session: Uninfo) -> bool:
-        return LazyManager.has(session.user.id)
-
-    lazy_matcher = on_alconna(
-        Alconna(pconfig.download_command[0]),
-        block=True,
-        aliases=set(pconfig.download_command[1:]),
-        rule=has_lazy,
-    )
-
-    @lazy_matcher.handle()
-    @UniHelper.with_reaction
-    async def _(session: Uninfo):
-        """懒下载命令：发送上次解析结果中的媒体内容。"""
-        user_id = session.user.id
-        result = LazyManager.get(user_id)
-        try:
-            async for message in RENDERER.send_content(result):
-                await message.send()
-        finally:
-            LazyManager.remove(user_id)
+        @lazy_matcher.handle()
+        @UniHelper.with_reaction
+        async def _(session: Uninfo):
+            """懒下载命令：发送上次解析结果中的媒体内容。"""
+            user_id = session.user.id
+            result = LazyManager.get(user_id)
+            try:
+                async for message in RENDERER.send_content(result):
+                    await message.send()
+            finally:
+                LazyManager.remove(user_id)


### PR DESCRIPTION
- 将B站匹配器的注册逻辑从模块级别移到 driver.on_startup 事件中
- 重构了B站解析器的初始化和匹配器注册流程
- 优化了懒下载功能的实现结构
- 修复了音频文件扩展名从 .mp3 改为 .m4s 的问题

## Sourcery 总结

在驱动启动阶段而不是模块导入时注册与 B 站相关的匹配器和惰性下载处理器，并调整音频下载行为。

Bug 修复：
- 将下载的 B 站音频文件扩展名从 `.mp3` 改为 `.m4s`，以匹配实际格式。

功能增强：
- 将 B 站解析器查找和匹配器注册推迟到驱动启动阶段，以实现更安全的初始化流程。
- 将惰性下载命令的匹配器限定在启动时注册范围内，并复用已解析得到的 B 站解析器实例用于下载请求头。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Register Bilibili-related matchers and lazy download handlers during driver startup instead of at module import, and adjust audio download behavior.

Bug Fixes:
- Change downloaded Bilibili audio file extension from .mp3 to .m4s to match actual format.

Enhancements:
- Defer Bilibili parser lookup and matcher registration to the driver startup phase for safer initialization.
- Scope the lazy download command matcher under startup-time registration and reuse the resolved Bilibili parser instance for download headers.

</details>