### PR TITLE
refactor(video): 修复杜比音效值

### DIFF
--- a/src/nonebot_plugin_parser_lite/__init__.py
+++ b/src/nonebot_plugin_parser_lite/__init__.py
@@ -1,5 +1,4 @@
 import asyncio
-from enum import Enum
 import traceback
 
 from nonebot import logger, require
@@ -17,26 +16,9 @@ from anyio import Path
 import bilibili_api.video
 from nonebot_plugin_apscheduler import scheduler
 
-
-class HookAudioQuality(Enum):
-    """
-    视频的音频流清晰度枚举
-
-    - _64K: 64K
-    - _132K: 132K
-    - _192K: 192K
-    - HI_RES: Hi-Res 无损
-    - DOLBY: 杜比全景声
-    """
-
-    _64K = 30216
-    _132K = 30232
-    DOLBY = 30250
-    HI_RES = 30251
-    _192K = 30280
-
-
-bilibili_api.video.AudioQuality = HookAudioQuality
+aq = bilibili_api.video.AudioQuality
+if aq.DOLBY.value == 30255:
+    object.__setattr__(aq.DOLBY, "_value_", 30250)
 
 
 from .config import Config, pconfig


### PR DESCRIPTION
移除了自定义的HookAudioQuality枚举类，改用bilibili_api.video.AudioQuality原生枚举， 同时修复了DOLBY音频质量值从30255到30250的映射问题

BREAKING CHANGE: 不再使用自定义的HookAudioQuality枚举

## Sourcery 总结

切换为上游的音频质量枚举，并修正 Dolby 音频质量的映射。

Bug 修复：
- 修复 Dolby 音频质量值从 30255 到 30250 的错误映射。

增强：
- 用原生的 `bilibili_api.video.AudioQuality` 枚举替换自定义的 `HookAudioQuality` 枚举，这对依赖自定义枚举的使用方来说是一次不兼容变更。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Switch to the upstream audio quality enum and correct the Dolby audio quality mapping.

Bug Fixes:
- Fix incorrect mapping of Dolby audio quality value from 30255 to 30250.

Enhancements:
- Replace the custom HookAudioQuality enum with the native bilibili_api.video.AudioQuality enum, introducing a breaking change for consumers depending on the custom enum.

</details>