### PR TITLE
feat(parser): 添加作者位置信息支持

### DIFF
--- a/src/nonebot_plugin_parser_lite/parsers/base.py
+++ b/src/nonebot_plugin_parser_lite/parsers/base.py
@@ -246,6 +246,7 @@ class BaseParser:
         avatar_url: str | None = None,
         description: str | None = None,
         id: str | None = None,
+        location: str | None = None,
     ):
         """
         创建作者对象
@@ -254,17 +255,20 @@ class BaseParser:
         :param avatar_url: 作者头像 URL
         :param description: 作者描述
         :param id: 作者 ID
+        :param location: 位置信息
         """
 
         return create_author(
-            name=name, avatar_url=avatar_url, description=description, id=id
+            name=name,
+            avatar_url=avatar_url,
+            description=description,
+            id=id,
+            location=location,
         )
 
     def create_video(
         self,
-        url_or_task: str
-        | DownloadTaskWrapper[Path]
-        | VideoDownloadFunc,
+        url_or_task: str | DownloadTaskWrapper[Path] | VideoDownloadFunc,
         cover_url: str | None = None,
         duration: float = 0.0,
         video_name: str | None = None,
@@ -470,7 +474,6 @@ class BaseParser:
         content: Sequence[MediaContent | str | None],
         timestamp: int | None = None,
         stats: Stats | None = None,
-        location: str | None = None,
         replies: list[Comment] | None = None,
         parent_author: Author | None = None,
     ):
@@ -481,7 +484,6 @@ class BaseParser:
         :param content: 评论内容
         :param timestamp: 评论时间戳
         :param stats: 评论统计信息
-        :param location: 评论位置
         :param replies: 评论回复
         :param parent_author: 评论的父级作者
         """
@@ -491,7 +493,6 @@ class BaseParser:
             content=content,
             timestamp=timestamp,
             stats=stats,
-            location=location,
             replies=replies,
             parent_author=parent_author,
         )

--- a/src/nonebot_plugin_parser_lite/parsers/bilibili/__init__.py
+++ b/src/nonebot_plugin_parser_lite/parsers/bilibili/__init__.py
@@ -1206,11 +1206,11 @@ class BilibiliParser(BaseParser):
                 author=self.create_author(
                     name=member.get("uname", ""),
                     avatar_url=member.get("avatar"),
+                    location=reply_control.get("location"),
                 ),
                 content=processed_content,
                 timestamp=raw.get("ctime", 0),
                 stats=self.create_stats(like_count=raw.get("like", 0)),
-                location=reply_control.get("location"),
                 parent_author=parent_author,
             )
 

--- a/src/nonebot_plugin_parser_lite/parsers/buff/__init__.py
+++ b/src/nonebot_plugin_parser_lite/parsers/buff/__init__.py
@@ -36,6 +36,7 @@ class BuffParser(BaseParser):
                     name=sc.author.nickname,
                     avatar_url=sc.author.avatar,
                     id=sc.author.user_id,
+                    location=sc.author.ip_location,
                 ),
                 content=sc.content,
                 timestamp=sc.created_at,
@@ -43,7 +44,6 @@ class BuffParser(BaseParser):
                     like_count=format_num(sc.ups_num),
                     comment_count=format_num(len(sc.replies)),
                 ),
-                location=sc.author.ip_location,
             )
             for sc in c.replies
         ]
@@ -52,6 +52,7 @@ class BuffParser(BaseParser):
                 name=c.author.nickname,
                 avatar_url=c.author.avatar,
                 id=c.author.user_id,
+                location=c.author.ip_location,
             ),
             content=c.content,
             timestamp=c.created_at,
@@ -60,7 +61,6 @@ class BuffParser(BaseParser):
                 comment_count=format_num(len(c.replies)),
             ),
             replies=sub_comments,
-            location=c.author.ip_location,
         )
 
     async def fetch_comments(self, comment_type: int, type_id: str) -> list[Comment]:

--- a/src/nonebot_plugin_parser_lite/parsers/creator.py
+++ b/src/nonebot_plugin_parser_lite/parsers/creator.py
@@ -40,6 +40,7 @@ def create_author(
     avatar_url: str | None = None,
     description: str | None = None,
     id: str | None = None,
+    location: str | None = None,
 ):
     """
     创建作者对象
@@ -48,10 +49,13 @@ def create_author(
     :param avatar_url: 作者头像 URL
     :param description: 作者描述
     :param id: 作者 ID
+    :param location: 位置信息
     """
 
     avatar_task = DOWNLOADER.download_img(url=avatar_url) if avatar_url else None
-    return Author(name=name, id=id, avatar=avatar_task, description=description)
+    return Author(
+        name=name, id=id, avatar=avatar_task, description=description, location=location
+    )
 
 
 def create_video(
@@ -293,7 +297,6 @@ def create_comment(
     content: Sequence[MediaContent | str | None],
     timestamp: int | None = None,
     stats: Stats | None = None,
-    location: str | None = None,
     replies: list[Comment] | None = None,
     parent_author: Author | None = None,
 ):
@@ -317,7 +320,6 @@ def create_comment(
         content=content,
         timestamp=timestamp,
         stats=stats or Stats(),
-        location=location,
         replies=replies,
         parent_author=parent_author,
     )

--- a/src/nonebot_plugin_parser_lite/parsers/data.py
+++ b/src/nonebot_plugin_parser_lite/parsers/data.py
@@ -168,7 +168,7 @@ class Platform:
         )
 
 
-@dataclass(repr=False, slots=True)
+@dataclass(slots=True)
 class Author:
     """作者信息"""
 
@@ -177,15 +177,17 @@ class Author:
     id: str | None = None
     """作者id"""
     avatar: DownloadTaskWrapper[Path] | None = None
-    """作者头像 URL 或本地路径"""
+    """作者头像"""
     description: str | None = None
     """作者个性签名等"""
+    location: str | None = None
+    """位置信息"""
 
     async def get_avatar_path(self) -> Path | None:
         return None if self.avatar is None else await self.avatar
 
 
-@dataclass(repr=False, slots=True)
+@dataclass(slots=True)
 class Stats:
     """统计信息"""
 
@@ -202,14 +204,6 @@ class Stats:
     extra: dict[str, Any] = field(default_factory=dict)
     """额外信息, 比如弹幕数/硬币数"""
 
-    def __repr__(self) -> str:
-        prefix = self.__class__.__name__
-        return (
-            f"{prefix}(view_count={self.view_count}, like_count={self.like_count}, "
-            f"collect_count={self.collect_count}, share_count={self.share_count}, "
-            f"comment_count={self.comment_count}, extra={self.extra})"
-        )
-
 
 @dataclass(repr=False, slots=True)
 class Comment:
@@ -223,8 +217,6 @@ class Comment:
     """发布时间戳，单位秒"""
     stats: Stats = field(default_factory=Stats)
     """统计信息"""
-    location: str | None = None
-    """位置信息，可选"""
     replies: list["Comment"] = field(default_factory=list)
     """子评论列表"""
     parent_author: Author | None = None

--- a/src/nonebot_plugin_parser_lite/parsers/douyin/__init__.py
+++ b/src/nonebot_plugin_parser_lite/parsers/douyin/__init__.py
@@ -93,7 +93,9 @@ class DouyinParser(BaseParser):
         comments = [
             self.create_comment(
                 author=self.create_author(
-                    name=comment.user.nickname, avatar_url=comment.user.avatarUri
+                    name=comment.user.nickname,
+                    avatar_url=comment.user.avatarUri,
+                    location=comment.ipLabel,
                 ),
                 content=comment.content,
                 timestamp=comment.createTime,
@@ -101,7 +103,6 @@ class DouyinParser(BaseParser):
                     like_count=format_num(comment.diggCount),
                     comment_count=format_num(comment.replyTotal),
                 ),
-                location=comment.ipLabel,
             )
             for comment in data.comment.comments
         ]
@@ -145,7 +146,9 @@ class DouyinParser(BaseParser):
         comments = [
             self.create_comment(
                 author=self.create_author(
-                    name=comment.user.nickname, avatar_url=comment.user.avatar_url
+                    name=comment.user.nickname,
+                    avatar_url=comment.user.avatar_url,
+                    location=comment.ip_label,
                 ),
                 content=[comment.text],
                 timestamp=comment.createTime,
@@ -153,7 +156,6 @@ class DouyinParser(BaseParser):
                     like_count=format_num(comment.digg_count),
                     comment_count=format_num(comment.reply_comment_total),
                 ),
-                location=comment.ip_label,
             )
             for comment in data.comment_list.comments
         ]

--- a/src/nonebot_plugin_parser_lite/parsers/duitang/__init__.py
+++ b/src/nonebot_plugin_parser_lite/parsers/duitang/__init__.py
@@ -175,6 +175,7 @@ class DuiTangParser(BaseParser):
                     name=root_comment.sender.username,
                     avatar_url=root_comment.sender.avatar,
                     id=str(root_comment.sender.id),
+                    location=root_comment.ipaddr,
                 ),
                 content=root_content,
                 timestamp=root_comment.create_time // 1000,
@@ -182,7 +183,6 @@ class DuiTangParser(BaseParser):
                     like_count=format_num(root_comment.like_count),
                     comment_count=format_num(root_comment.reply_count),
                 ),
-                location=root_comment.ipaddr,
             )
 
             for sub_comment in root_comment.replies:
@@ -191,10 +191,10 @@ class DuiTangParser(BaseParser):
                         author=self.create_author(
                             name=sub_comment.sender.username,
                             avatar_url=sub_comment.sender.avatar,
+                            location=sub_comment.ipaddr,
                         ),
                         content=[sub_comment.content],
                         timestamp=sub_comment.add_datetime_ts // 1000,
-                        location=sub_comment.ipaddr,
                     )
                 )
 

--- a/src/nonebot_plugin_parser_lite/parsers/heybox/__init__.py
+++ b/src/nonebot_plugin_parser_lite/parsers/heybox/__init__.py
@@ -95,6 +95,7 @@ class HeyBoxParser(BaseParser):
                 author=self.create_author(
                     name=root.user.username,
                     avatar_url=root.user.avatar_url,
+                    location=root.ip_location,
                 ),
                 content=root.content,
                 timestamp=root.create_at,
@@ -102,7 +103,6 @@ class HeyBoxParser(BaseParser):
                     like_count=format_num(root.up),
                     comment_count=format_num(root.child_num),
                 ),
-                location=root.ip_location,
             )
 
             for child in comment_list[1:]:
@@ -111,6 +111,7 @@ class HeyBoxParser(BaseParser):
                         author=self.create_author(
                             name=child.user.username,
                             avatar_url=child.user.avatar_url,
+                            location=child.ip_location,
                         ),
                         content=child.content,
                         timestamp=child.create_at,
@@ -118,7 +119,6 @@ class HeyBoxParser(BaseParser):
                             like_count=format_num(child.up),
                             comment_count=format_num(child.child_num),
                         ),
-                        location=child.ip_location,
                     )
                 )
 

--- a/src/nonebot_plugin_parser_lite/parsers/kuaishou/__init__.py
+++ b/src/nonebot_plugin_parser_lite/parsers/kuaishou/__init__.py
@@ -82,7 +82,6 @@ class KuaiShouParser(BaseParser):
         if not video_url and not img_urls and cover_url:
             contents.append(self.create_image(url=cover_url))
 
-
         # 构建作者
         author = self.create_author(name=photo.name, avatar_url=photo.headUrl)
         comments = self.format_comments(data_map.comments)
@@ -106,8 +105,7 @@ class KuaiShouParser(BaseParser):
         for rc in parent_comments:
             rootComment = self.create_comment(
                 author=self.create_author(
-                    name=rc.author_name,
-                    avatar_url=rc.headurl,
+                    name=rc.author_name, avatar_url=rc.headurl, location=rc.authorArea
                 ),
                 content=replace_placeholder_to_sticker(
                     rc.content, KUAISHOU_PATTERN, "kuaishou"
@@ -117,7 +115,6 @@ class KuaiShouParser(BaseParser):
                     like_count=format_num(rc.likedCount),
                     comment_count=format_num(rc.subCommentCount),
                 ),
-                location=rc.authorArea,
             )
 
             for sc in comments.subCommentsMap.get(str(rc.comment_id), [])[:3]:
@@ -127,6 +124,7 @@ class KuaiShouParser(BaseParser):
                         author=self.create_author(
                             name=sc.author_name,
                             avatar_url=sc.headurl,
+                            location=sc.authorArea,
                         ),
                         content=replace_placeholder_to_sticker(
                             sc.content, KUAISHOU_PATTERN, "kuaishou"
@@ -135,7 +133,6 @@ class KuaiShouParser(BaseParser):
                         stats=self.create_stats(
                             like_count=format_num(sc.likedCount),
                         ),
-                        location=sc.authorArea,
                     )
                 )
             result.append(rootComment)

--- a/src/nonebot_plugin_parser_lite/parsers/lofter/__init__.py
+++ b/src/nonebot_plugin_parser_lite/parsers/lofter/__init__.py
@@ -89,6 +89,7 @@ class LofterParser(BaseParser):
                     name=c.publisherBlogInfo.blogNickName,
                     avatar_url=c.publisherBlogInfo.bigAvaImg,
                     id=c.publisherBlogInfo.blogName,
+                    location=c.ipLocation,
                 ),
                 content=c.content,
                 timestamp=c.publishTime // 1000,
@@ -102,17 +103,16 @@ class LofterParser(BaseParser):
                             name=s.publisherBlogInfo.blogNickName,
                             avatar_url=s.publisherBlogInfo.bigAvaImg,
                             id=s.publisherBlogInfo.blogName,
+                            location=s.ipLocation,
                         ),
                         content=s.content,
                         timestamp=s.publishTime // 1000,
                         stats=self.create_stats(
                             like_count=format_num(s.likeCount),
                         ),
-                        location=s.ipLocation,
                     )
                     for s in c.l2Comments
                 ],
-                location=c.ipLocation,
             )
             for c in comment_list.comments
         ]

--- a/src/nonebot_plugin_parser_lite/parsers/tieba/utils.py
+++ b/src/nonebot_plugin_parser_lite/parsers/tieba/utils.py
@@ -220,6 +220,7 @@ def build_comments(posts: list[Post], poster_id: int) -> list[Comment]:
             name=post.user.show_name,
             avatar_url=f"http://tb.himg.baidu.com/sys/portraith/item/{post.user.portrait}",
             id=post.user.portrait,
+            location=post.user.ip,
         )
         # 处理楼中楼评论
         child_posts = []
@@ -230,13 +231,13 @@ def build_comments(posts: list[Post], poster_id: int) -> list[Comment]:
                         name=comment.user.show_name,
                         avatar_url=f"http://tb.himg.baidu.com/sys/portraith/item/{comment.user.portrait}",
                         id=comment.user.portrait,
+                        location=comment.user.ip,
                     ),
                     content=build_comment(comment.contents),
                     timestamp=comment.create_time,
                     stats=create_stats(
                         like_count=str(comment.agree) if comment.agree else None
                     ),
-                    location=comment.user.ip,
                     parent_author=comment_author,
                 )
                 for comment in post.comments[:3]
@@ -249,7 +250,6 @@ def build_comments(posts: list[Post], poster_id: int) -> list[Comment]:
                 stats=create_stats(
                     like_count=str(post.agree), comment_count=str(post.reply_num)
                 ),
-                location=post.user.ip,
                 replies=child_posts,
             )
         )

--- a/src/nonebot_plugin_parser_lite/render/templates/macros.jinja
+++ b/src/nonebot_plugin_parser_lite/render/templates/macros.jinja
@@ -59,10 +59,15 @@
                         <div class="text-sm text-gray-700 leading-relaxed">{{ render_content_items(comment.content) }}</div>
                         <div class="flex items-center space-x-2 text-xs text-gray-400 uppercase tracking-tight">
                             <span>{{ comment.formatted_datetime }}</span>
-                            {% if comment.location %}<span>{{ comment.location }}</span>{% endif %}
+                            {% if comment.author.location %}<span>{{ comment.author.location }}</span>{% endif %}
                             {% if comment.stats.like_count %}
                                 <span class="flex items-center">
                                     <i class="fa-icon fa-heart mr-1 mt-0.5"></i> {{ comment.stats.like_count }}
+                                </span>
+                            {% endif %}
+                            {% if comment.stats.comment_count %}
+                                <span class="flex items-center">
+                                    <i class="fa-icon fa-comment-dots mr-1 mt-0.5"></i> {{ comment.stats.comment_count }}
                                 </span>
                             {% endif %}
                         </div>
@@ -77,10 +82,15 @@
                                             <div class="text-sm text-gray-600 leading-snug">{{ render_content_items(reply.content) }}</div>
                                             <div class="flex items-center space-x-3 text-xs text-gray-400 uppercase">
                                                 <span>{{ reply.formatted_datetime }}</span>
-                                                {% if reply.location %}<span>{{ reply.location }}</span>{% endif %}
+                                                {% if reply.author.location %}<span>{{ reply.author.location }}</span>{% endif %}
                                                 {% if reply.stats.like_count %}
                                                     <span class="flex items-center">
                                                         <i class="fa-icon fa-heart mr-1 mt-0.5"></i> {{ reply.stats.like_count }}
+                                                    </span>
+                                                {% endif %}
+                                                {% if reply.stats.comment_count %}
+                                                    <span class="flex items-center">
+                                                        <i class="fa-icon fa-comment-dots mr-1 mt-0.5"></i> {{ reply.stats.comment_count }}
                                                     </span>
                                                 {% endif %}
                                             </div>
@@ -274,7 +284,7 @@
                     </div>
                     <p class="text-xs text-slate-500 mt-2 font-medium space-x-2">
                         <span>{{ result.formatted_datetime }}</span>
-                        {% if result.extra and result.extra.ip %}<span>IP {{ result.extra.ip }}</span>{% endif %}
+                        {% if result.author.location %}<span>{{ result.author.location }}</span>{% endif %}
                     </p>
                 </div>
             </div>


### PR DESCRIPTION
- 在BaseParser的create_author方法中添加location参数
- 将位置信息从评论对象移动到作者对象中存储
- 更新各平台解析器以将IP位置信息存储在作者对象中
- 修改数据模型，将location字段从Comment移到Author类
- 更新渲染模板以显示作者位置信息而非评论位置信息
- 移除不再使用的Comment.location字段

## Summary by Sourcery

在各个解析器和模板中添加对作者级别位置信息的存储和渲染支持。

新功能：
- 在 Author 模型上存储位置信息元数据，并通过 parser helpers 和平台解析器对其进行暴露，从而能够一致地捕获作者的 IP/位置信息。
- 在评论和结果模板中渲染作者位置信息，以取代评论级别或额外的 IP 字段，并在 UI 中显示每条评论的回复数量。

改进：
- 通过将位置信息从 Comment 移动到 Author、简化 dataclass 配置以及移除自定义的 Stats `__repr__` 实现来优化核心数据模型。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for storing and rendering author-level location information across parsers and templates.

New Features:
- Store location metadata on the Author model and expose it from parser helpers and platform parsers so author IP/location can be captured consistently.
- Render author location information in comment and result templates instead of comment-level or extra IP fields, and show per-comment reply counts in the UI.

Enhancements:
- Refine core data models by moving location from Comment to Author, simplifying dataclass configurations, and removing the custom Stats __repr__ implementation.

</details>