### PR TITLE
fix(parser): 修复音频质量枚举值映射问题

### DIFF
--- a/src/nonebot_plugin_parser_lite/__init__.py
+++ b/src/nonebot_plugin_parser_lite/__init__.py
@@ -18,7 +18,9 @@ from nonebot_plugin_apscheduler import scheduler
 
 aq = bilibili_api.video.AudioQuality
 if aq.DOLBY.value == 30255:
-    object.__setattr__(aq.DOLBY, "_value_", 30250)
+    aq.DOLBY._value_ = 30250
+    aq._value2member_map_.pop(30255, None)
+    aq._value2member_map_[30250] = aq.DOLBY
 
 
 from .config import Config, pconfig


### PR DESCRIPTION
当 Dolby 音频质量值为 30255 时，更新其内部值为 30250， 并相应地更新枚举的值到成员映射表，确保枚举的一致性。

## Summary by Sourcery

Bug Fixes:
- 更正 Dolby 音频质量值 30255 的内部映射，使其使用 30250，并调整枚举到成员的映射表以保持一致。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Correct the internal mapping for Dolby audio quality value 30255 to use 30250 and align the enum-to-member mapping table.

</details>