### PR TITLE
feat(bilibili): 添加 MCDN 视频流代理支持

### DIFF
--- a/src/nonebot_plugin_parser_lite/parsers/bilibili/__init__.py
+++ b/src/nonebot_plugin_parser_lite/parsers/bilibili/__init__.py
@@ -5,6 +5,7 @@ import json
 import re
 from re import Match
 from typing import Any, ClassVar
+from urllib.parse import quote
 
 import aiofiles
 from anyio import Path
@@ -55,6 +56,18 @@ select_client("curl_cffi")
 # 模拟浏览器，第二参数数值参考 curl_cffi 文档
 # https://curl-cffi.readthedocs.io/en/latest/impersonate.html
 request_settings.set("impersonate", "chrome131")
+
+MCDN_PATTERN = re.compile(
+    r"((([0-9]{1,3}\.){3}[0-9]{1,3})|(.*\.mcdn\.bilivideo\.(com|cn|net))):[0-9]{1,5}/v1/resource"
+)
+
+
+def _encode_mcdn_url(raw_url: str) -> str:
+    """将原始 mcdn URL 做 URL 编码并拼接到代理前缀上."""
+    # 使用 quote 对整条 URL 做编码，safe="" 表示不保留任何字符
+    encoded = quote(raw_url, safe="")
+    # 补全协议头
+    return f"https://proxy-tf-all-ws.bilivideo.com/url={encoded}"
 
 
 class BilibiliParser(BaseParser):
@@ -970,6 +983,10 @@ class BilibiliParser(BaseParser):
         video_stream = streams[0]
         if not isinstance(video_stream, VideoStreamDownloadURL):
             raise DownloadException("未找到可下载的视频流")
+        if MCDN_PATTERN.search(video_stream.url):
+            logger.warning("检测到 PCDN 视频链接，正在进行代理替换...")
+            video_stream.url = _encode_mcdn_url(video_stream.url)
+
         logger.debug(
             f"视频流质量: {video_stream.video_quality.name}, 编码: {video_stream.video_codecs}"  # noqa: E501
         )
@@ -977,6 +994,9 @@ class BilibiliParser(BaseParser):
         audio_stream = streams[1]
         if not isinstance(audio_stream, AudioStreamDownloadURL):
             return video_stream.url, None
+        if MCDN_PATTERN.search(audio_stream.url):
+            logger.warning("检测到 PCDN 音频链接，正在进行代理替换...")
+            audio_stream.url = _encode_mcdn_url(audio_stream.url)
         logger.debug(f"音频流质量: {audio_stream.audio_quality.name}")
         return video_stream.url, audio_stream.url
 


### PR DESCRIPTION
- 引入 urllib.parse.quote 用于 URL 编码
- 新增 MCDN_PATTERN 正则表达式匹配 MCDN 地址
- 实现 _encode_mcdn_url 函数对 MCDN URL 进行编码和代理转换
- 在视频和音频流下载时检测并替换 MCDN 链接为代理地址
- 添加日志记录 MCDN 检测和替换过程

## 由 Sourcery 生成的摘要

在视频和音频流提取中，为 Bilibili MCDN 媒体 URL 添加代理处理。

新功能：
- 在提取的视频和音频流中检测 Bilibili MCDN 媒体 URL，并将其重写为使用代理端点。

增强改进：
- 添加一个辅助工具，在组成代理 URL 之前对原始 MCDN URL 进行 URL 编码，并记录 MCDN 检测和替换事件。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add proxy handling for Bilibili MCDN media URLs in video and audio stream extraction.

New Features:
- Detect Bilibili MCDN media URLs in extracted video and audio streams and rewrite them to use a proxy endpoint.

Enhancements:
- Add a helper to URL-encode raw MCDN URLs before composing the proxy URL and log MCDN detection and replacement events.

</details>