### PR TITLE
feat(render): 为模板增加二维码显示区域

### DIFF
--- a/src/nonebot_plugin_parser_lite/parsers/data.py
+++ b/src/nonebot_plugin_parser_lite/parsers/data.py
@@ -278,10 +278,6 @@ class ParseResult:
     def repost_display_url(self) -> str | None:
         return f"原帖: {self.repost.url}" if self.repost and self.repost.url else None
 
-    @property
-    def extra_info(self) -> str | None:
-        return self.extra.get("info")
-
     async def get_cover_path(self) -> Path | None:
         """获取封面路径"""
         # 先检查视频内容

--- a/src/nonebot_plugin_parser_lite/render/__init__.py
+++ b/src/nonebot_plugin_parser_lite/render/__init__.py
@@ -1,3 +1,4 @@
+import base64
 from collections.abc import AsyncGenerator, Awaitable
 import datetime
 from io import BytesIO
@@ -280,10 +281,6 @@ class Renderer:
     def append_url(self) -> bool:
         return pconfig.append_url
 
-    @property
-    def append_qrcode(self) -> bool:
-        return pconfig.append_qrcode
-
     async def render_image(self, result: ParseResult) -> bytes:
         """使用 HTML 绘制通用社交媒体帖子卡片"""
         # 准备模板数据
@@ -344,7 +341,6 @@ class Renderer:
         data: dict[str, Any] = {
             "title": result.title,
             "formatted_datetime": result.formatted_datetime,
-            "extra_info": result.extra_info,
             "extra": result.extra,
             "platform": {
                 "display_name": result.platform.display_name,
@@ -368,29 +364,21 @@ class Renderer:
         if result.repost:
             data["repost"] = await self.resolve_parse_result(result.repost)
 
-        # 添加二维码支持
         if pconfig.append_qrcode and result.url:
-            # 生成二维码
             qr = qrcode.QRCode(
                 version=1,
                 error_correction=1,
                 box_size=10,
-                border=4,
+                border=1,
             )
             qr.add_data(result.url)
             qr.make(fit=True)
             img = qr.make_image(fill_color="black", back_color="white")
-
-            # 将二维码转换为 base64 编码
             buffer = BytesIO()
-            img.save(buffer, format="PNG")  # type: ignore
+            img.save(buffer, format="PNG")  # pyright: ignore[reportCallIssue]
             buffer.seek(0)
-            import base64
-
             img_base64 = base64.b64encode(buffer.getvalue()).decode("utf-8")
-
-            # 添加 base64 编码的图片数据到模板数据
-            data["qr_code_path"] = f"data:image/png;base64,{img_base64}"
+            data["qrcode_path"] = f"data:image/png;base64,{img_base64}"
 
         return data
 

--- a/src/nonebot_plugin_parser_lite/render/templates/macros.jinja
+++ b/src/nonebot_plugin_parser_lite/render/templates/macros.jinja
@@ -332,7 +332,7 @@
             <footer class="px-8 py-6 bg-gray-50 border-t border-gray-100 flex justify-between items-center text-[10px] font-black text-gray-300 uppercase tracking-widest antialiased">
                 <span>{{ result.bot_name }} Parser · Design negichan</span>
                 {% if result.qrcode_path %}
-                    <img src="{{ result.qrcode_path }}" width="50px" />
+                    <img src="{{ result.qrcode_path }}" style="width:50px;" />
                 {% else %}
                     <span>Rendering at {{ result.rendering_time }}</span>
                 {% endif %}

--- a/src/nonebot_plugin_parser_lite/render/templates/macros.jinja
+++ b/src/nonebot_plugin_parser_lite/render/templates/macros.jinja
@@ -331,7 +331,11 @@
         {% if not is_repost %}
             <footer class="px-8 py-6 bg-gray-50 border-t border-gray-100 flex justify-between items-center text-[10px] font-black text-gray-300 uppercase tracking-widest antialiased">
                 <span>{{ result.bot_name }} Parser · Design negichan</span>
-                <span>Rendering at {{ result.rendering_time }}</span>
+                {% if result.qrcode_path %}
+                    <img src="{{ result.qrcode_path }}" width="50px" />
+                {% else %}
+                    <span>Rendering at {{ result.rendering_time }}</span>
+                {% endif %}
             </footer>
         {% endif %}
     </div>


### PR DESCRIPTION
resolve #64

## Summary by Sourcery

为渲染后的帖子模板添加二维码支持，并清理未使用的 `extra_info` 字段。

New Features:
- 当启用了二维码生成且有可用 URL 时，在渲染帖子的页脚显示二维码图片。

Enhancements:
- 通过 `qrcode_path` 字段将生成的二维码数据暴露给模板，并调整二维码的外观。
- 为简化数据模型，从解析结果中移除 `extra_info` 字段及其相关属性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add QR code support to rendered post templates and clean up unused extra info field.

New Features:
- Display a QR code image in the footer of rendered posts when QR code generation is enabled and a URL is available.

Enhancements:
- Expose generated QR code data to templates via a qrcode_path field and adjust QR code appearance.
- Remove the extra_info field and its associated property from parse results as part of simplifying the data model.

</details>