### PR TITLE
feat(render): 添加文本转发阈值限制

### DIFF
--- a/src/nonebot_plugin_parser_lite/config.py
+++ b/src/nonebot_plugin_parser_lite/config.py
@@ -59,7 +59,7 @@ class Config(BaseModel):
     plite_forward_text_threshold: int = 300
     """纯文本文本长度阈值，超过此长度的文本将会强制转发"""
     plite_forward_text_max_length: int = 4000
-    """单段文本长度阈值，超过此长度的文本将会强制分割"""
+    """单批转发文本总长度上限，超过此长度将拆分为多条合并转发"""
 
     @property
     def nickname(self) -> str:
@@ -193,7 +193,7 @@ class Config(BaseModel):
 
     @property
     def forward_text_max_length(self) -> int:
-        """单段文本长度阈值，超过此长度的文本将会强制分割"""
+        """单批转发文本总长度上限，超过此长度将拆分为多条合并转发"""
         return self.plite_forward_text_max_length
 
 

--- a/src/nonebot_plugin_parser_lite/config.py
+++ b/src/nonebot_plugin_parser_lite/config.py
@@ -56,6 +56,10 @@ class Config(BaseModel):
     """是否使用无头浏览器"""
     plite_max_comments: int = 5
     """最大评论数量"""
+    plite_forward_text_threshold: int = 300
+    """纯文本文本长度阈值，超过此长度的文本将会强制转发"""
+    plite_forward_text_max_length: int = 4000
+    """单段文本长度阈值，超过此长度的文本将会强制分割"""
 
     @property
     def nickname(self) -> str:
@@ -181,6 +185,16 @@ class Config(BaseModel):
     def max_comments(self) -> int:
         """最大评论数量"""
         return self.plite_max_comments
+
+    @property
+    def forward_text_threshold(self) -> int:
+        """纯文本文本长度阈值，超过此长度的文本将会强制转发"""
+        return self.plite_forward_text_threshold
+
+    @property
+    def forward_text_max_length(self) -> int:
+        """单段文本长度阈值，超过此长度的文本将会强制分割"""
+        return self.plite_forward_text_max_length
 
 
 # 初始化配置实例

--- a/src/nonebot_plugin_parser_lite/render/__init__.py
+++ b/src/nonebot_plugin_parser_lite/render/__init__.py
@@ -185,12 +185,26 @@ class Renderer:
                     for seg in ordered_segs:
                         seg_plain = len(seg) if isinstance(seg, str) else 0
 
-                        # 如果当前 batch 再加上这个 seg 就超过上限，则先发出当前 batch
+                        # 情况 1：
+                        # 当前 batch 非空，且再加上这个 seg 会超过上限 -> 先发出当前批次
                         if batch and batch_plain_len + seg_plain > max_plain_len:
                             msg = flush_batch()
                             if msg is not None:
                                 yield msg
 
+                        # 情况 2：
+                        # 该 seg 自身就超过上限 -> 独立成一个批次发送
+                        if isinstance(seg, str) and seg_plain > max_plain_len:
+                            for start in range(0, seg_plain, max_plain_len):
+                                part = seg[start : start + max_plain_len]
+                                yield UniMessage(
+                                    UniHelper.construct_forward_message([part])
+                                )
+                            # 不把这个 seg 放入后续 batch
+                            continue
+
+                        # 情况 3：
+                        # 正常累加到当前批次
                         batch.append(seg)
                         batch_plain_len += seg_plain
 

--- a/src/nonebot_plugin_parser_lite/render/__init__.py
+++ b/src/nonebot_plugin_parser_lite/render/__init__.py
@@ -132,14 +132,72 @@ class Renderer:
                 failed_count += 1
                 continue
 
-        # 2构建图文 / 图片的转发列表（含主帖 + 转发，按顺序）
+        # 2 构建图文 / 图片的转发列表（含主帖 + 转发，按顺序）
         ordered_segs = await self.__build_forward_segs(result)
         if ordered_segs:
-            if pconfig.need_forward_contents or len(ordered_segs) > 4:
-                forward_msg = UniHelper.construct_forward_message(ordered_segs)
-                yield UniMessage(forward_msg)
-            else:
+            # 配置阈值（提供默认值，避免旧配置缺失时报错）
+            text_threshold = pconfig.forward_text_threshold
+            max_plain_len = pconfig.forward_text_max_length
+
+            # 先决定是否需要走“合并转发”路径
+            # 这里用一次遍历同时统计：
+            # - 总纯文字长度
+            # - 节点数量
+            total_plain_len = 0
+            node_count = 0
+            for seg in ordered_segs:
+                node_count += 1
+                if isinstance(seg, str):
+                    total_plain_len += len(seg)
+
+            # 是否需要合并转发：
+            # 1) 配置项 need_forward_contents
+            # 2) 纯文字部分超过阈值
+            # 3) 节点数较多（兼容原来的 len > 4 逻辑）
+            need_forward = (
+                pconfig.need_forward_contents
+                or total_plain_len > text_threshold
+                or node_count > 4
+            )
+
+            if not need_forward:
+                # 直接一次性发出普通消息列表
                 yield UniMessage(ordered_segs)
+            else:
+                # 需要合并转发；如果纯文字总长度不大，直接构造一个转发即可
+                if total_plain_len <= max_plain_len:
+                    forward_msg = UniHelper.construct_forward_message(ordered_segs)
+                    yield UniMessage(forward_msg)
+                else:
+                    # 纯文字太长：按纯文字长度分批构造多个转发消息
+                    batch: list[ForwardNodeInner] = []
+                    batch_plain_len = 0
+
+                    def flush_batch() -> UniMessage[Any] | None:
+                        nonlocal batch, batch_plain_len
+                        if not batch:
+                            return None
+                        msg = UniMessage(UniHelper.construct_forward_message(batch))
+                        batch = []
+                        batch_plain_len = 0
+                        return msg
+
+                    for seg in ordered_segs:
+                        seg_plain = len(seg) if isinstance(seg, str) else 0
+
+                        # 如果当前 batch 再加上这个 seg 就超过上限，则先发出当前 batch
+                        if batch and batch_plain_len + seg_plain > max_plain_len:
+                            msg = flush_batch()
+                            if msg is not None:
+                                yield msg
+
+                        batch.append(seg)
+                        batch_plain_len += seg_plain
+
+                    # 收尾
+                    last_msg = flush_batch()
+                    if last_msg is not None:
+                        yield last_msg
 
         # 汇总下载失败信息
         if failed_count > 0:


### PR DESCRIPTION
- resolve #89 

## Summary by Sourcery

添加可配置阈值，用于控制在何种情况下将解析后的内容作为合并转发发送，或作为普通消息发送，并且将过长的转发拆分为多个批次。

New Features:
- 引入配置项，用于设置纯文本长度阈值（以强制走转发）以及每个转发批次的最⼤文本长度。
- 暴露新的配置属性，使渲染管线能够访问转发文本长度阈值。

Enhancements:
- 优化渲染逻辑，根据文本长度、节点数量和配置标志来决定是直接发送消息还是使用合并转发，并在转发内容过长时将其拆分为多个消息，以确保保持在限制范围内。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add configurable thresholds to control when parsed content is sent as merged forwards versus plain messages, and split overly long forwards into multiple batches.

New Features:
- Introduce configuration options for pure-text length threshold to force forwarding and maximum text length per forward batch.
- Expose new config properties to access forward text length thresholds from the render pipeline.

Enhancements:
- Refine render logic to decide between direct message sending and merged forwards based on text length, node count, and config flags, and to chunk long forwards into multiple messages to stay within limits.

</details>