### PR TITLE
feat(renderer): 添加跨重启图片缓存功能

### DIFF
--- a/src/nonebot_plugin_parser_lite/parsers/acfun/__init__.py
+++ b/src/nonebot_plugin_parser_lite/parsers/acfun/__init__.py
@@ -47,6 +47,7 @@ class AcfunParser(BaseParser):
             author=author,
             timestamp=video_info.timestamp,
             content=[video_info.text or "", video_content],
+            url=url,
         )
 
     async def parse_video_info(self, url: str):

--- a/src/nonebot_plugin_parser_lite/parsers/base.py
+++ b/src/nonebot_plugin_parser_lite/parsers/base.py
@@ -203,9 +203,17 @@ class BaseParser:
         raise ParseException(f"无法匹配 {url}")
 
     @classmethod
-    def result(cls, **kwargs: Unpack[ParseResultKwargs]) -> ParseResult:
+    def result(
+        cls,
+        author: Author,
+        url: str,
+        content: Sequence[MediaContent | str | None],
+        **kwargs: Unpack[ParseResultKwargs],
+    ) -> ParseResult:
         """构建解析结果"""
-        return ParseResult(platform=cls.platform, **kwargs)
+        return ParseResult(
+            platform=cls.platform, author=author, url=url, content=content, **kwargs
+        )
 
     @staticmethod
     @retry(max_retries=3)

--- a/src/nonebot_plugin_parser_lite/parsers/bilibili/__init__.py
+++ b/src/nonebot_plugin_parser_lite/parsers/bilibili/__init__.py
@@ -933,6 +933,7 @@ class BilibiliParser(BaseParser):
             content=[
                 self.create_graphic(fav.cover, fav.desc) for fav in favdata.medias
             ],
+            url=f"https://space.bilibili.com/{favdata.info.upper.mid}/favlist?fid={fav_id}",
         )
 
     async def _get_video(

--- a/src/nonebot_plugin_parser_lite/parsers/data.py
+++ b/src/nonebot_plugin_parser_lite/parsers/data.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from collections.abc import Sequence
 from dataclasses import dataclass, field
 from datetime import datetime
@@ -249,34 +251,34 @@ class ParseResult:
     """平台信息"""
     author: Author
     """作者信息"""
-    title: str | None = None
-    """标题"""
-    timestamp: int | None = None
-    """发布时间戳, 秒"""
-    url: str | None = None
+    url: str
     """来源链接"""
-    content: Sequence[MediaContent | str | None] = field(default_factory=list)
+    content: Sequence[MediaContent | str | None]
     """资源/文本内容"""
+    title: str | None = field(default=None)
+    """标题"""
+    timestamp: int | None = field(default=None)
+    """发布时间戳, 秒"""
     stats: Stats = field(default_factory=Stats)
     """统计信息"""
     comments: list[Comment] = field(default_factory=list)
     """评论列表"""
-    ai_summary: str | None = None
+    ai_summary: str | None = field(default=None)
     """AI摘要"""
     extra: dict[str, Any] = field(default_factory=dict)
     """额外信息"""
-    repost: "ParseResult | None" = None
+    repost: ParseResult | None = field(default=None)
     """转发的内容"""
-    render_image: Path | None = None
+    render_image: Path | None = field(default=None)
     """渲染图片"""
 
     @property
     def display_url(self) -> str | None:
-        return f"链接: {self.url}" if self.url else None
+        return f"链接: {self.url}"
 
     @property
     def repost_display_url(self) -> str | None:
-        return f"引帖: {self.repost.url}" if self.repost and self.repost.url else None
+        return f"引帖: {self.repost.url}" if self.repost else None
 
     async def get_cover_path(self) -> Path | None:
         """获取封面路径"""
@@ -314,13 +316,8 @@ class ParseResult:
 class ParseResultKwargs(TypedDict, total=False):
     title: str | None
     """标题"""
-    content: Sequence[MediaContent | str | None]
-    """资源/文本内容"""
     timestamp: int | None
     """发布时间戳, 秒"""
-    url: str | None
-    """来源链接"""
-    author: Author
     """作者信息"""
     extra: dict[str, Any]
     """额外信息"""

--- a/src/nonebot_plugin_parser_lite/parsers/data.py
+++ b/src/nonebot_plugin_parser_lite/parsers/data.py
@@ -318,7 +318,6 @@ class ParseResultKwargs(TypedDict, total=False):
     """标题"""
     timestamp: int | None
     """发布时间戳, 秒"""
-    """作者信息"""
     extra: dict[str, Any]
     """额外信息"""
     repost: ParseResult | None

--- a/src/nonebot_plugin_parser_lite/parsers/douyin/__init__.py
+++ b/src/nonebot_plugin_parser_lite/parsers/douyin/__init__.py
@@ -120,6 +120,7 @@ class DouyinParser(BaseParser):
             ),
             timestamp=data.aweme.detail.createTime,
             comments=comments,
+            url=f"https://www.douyin.com/note/{vid}",
         )
 
     async def parse_video_or_article(self, url: str):
@@ -172,4 +173,5 @@ class DouyinParser(BaseParser):
             ),
             timestamp=video_data.create_time,
             comments=comments,
+            url=url,
         )

--- a/src/nonebot_plugin_parser_lite/parsers/duitang/__init__.py
+++ b/src/nonebot_plugin_parser_lite/parsers/duitang/__init__.py
@@ -42,6 +42,7 @@ class DuiTangParser(BaseParser):
             ),
             timestamp=blog_data.add_datetime_ts,
             comments=comments,
+            url=f"https://m.duitang.com/blog?id={blog_id}",
         )
 
     @handle("duitang.com/atlas", r"id=(?P<atlas_id>\d+)")
@@ -74,6 +75,7 @@ class DuiTangParser(BaseParser):
             ),
             timestamp=atlas_data.created_at // 1000,
             comments=comments,
+            url=f"https://www.duitang.com/atlas?id={atlas_id}",
         )
 
     async def _fetch_atlas_detail(

--- a/src/nonebot_plugin_parser_lite/parsers/kuaishou/__init__.py
+++ b/src/nonebot_plugin_parser_lite/parsers/kuaishou/__init__.py
@@ -96,6 +96,7 @@ class KuaiShouParser(BaseParser):
             ),
             timestamp=photo.timestamp // 1000,
             comments=comments,
+            url=url,
         )
 
     def format_comments(self, comments: CommentList) -> list[Comment]:

--- a/src/nonebot_plugin_parser_lite/parsers/rednote/__init__.py
+++ b/src/nonebot_plugin_parser_lite/parsers/rednote/__init__.py
@@ -84,7 +84,6 @@ class RedNoteParser(BaseParser):
         note_data = init_state.note.noteDetailMap[init_state.note.currentNoteId]
 
         result = self._build_result(note_data)
-        result.url = f"https://www.xiaohongshu.com/discovery/item/{note_id}?xsec_token={xsec_token}"
         return result
 
     def _build_result(self, note_data: NoteDetailMap):
@@ -112,4 +111,5 @@ class RedNoteParser(BaseParser):
             ),
             content=contents,
             timestamp=note_detail.lastUpdateTime // 1000,
+            url=f"https://www.xiaohongshu.com/discovery/item/{note_detail.noteId}?xsec_token={note_detail.xsecToken}",
         )

--- a/src/nonebot_plugin_parser_lite/parsers/rednote/__init__.py
+++ b/src/nonebot_plugin_parser_lite/parsers/rednote/__init__.py
@@ -83,8 +83,7 @@ class RedNoteParser(BaseParser):
         init_state = exploreDecoder.decode(raw)
         note_data = init_state.note.noteDetailMap[init_state.note.currentNoteId]
 
-        result = self._build_result(note_data)
-        return result
+        return self._build_result(note_data)
 
     def _build_result(self, note_data: NoteDetailMap):
         """从 note_data 构建最终解析结果"""

--- a/src/nonebot_plugin_parser_lite/parsers/rednote/explore.py
+++ b/src/nonebot_plugin_parser_lite/parsers/rednote/explore.py
@@ -129,6 +129,8 @@ class NoteDetail(Struct):
     user: User
     lastUpdateTime: int
     interactInfo: InteractInfo
+    xsecToken: str
+    noteId: str
     imageList: list[Image] = field(default_factory=list)
     """图片列表，包括普通图片和 Live Photo"""
     video: Video | None = field(default=None)

--- a/src/nonebot_plugin_parser_lite/parsers/weibo/__init__.py
+++ b/src/nonebot_plugin_parser_lite/parsers/weibo/__init__.py
@@ -163,6 +163,7 @@ class WeiBoParser(BaseParser):
             author=author,
             content=[play_info.text, video_content],
             timestamp=play_info.real_date,
+            url=f"https://h5.video.weibo.com/show/{fid}",
         )
 
     async def parse_weibo_id(self, weibo_id: str):

--- a/src/nonebot_plugin_parser_lite/parsers/x/__init__.py
+++ b/src/nonebot_plugin_parser_lite/parsers/x/__init__.py
@@ -73,8 +73,8 @@ class XParser(BaseParser):
         )
         try:
             response.raise_for_status()
-        except Exception:
-            raise ParseException(response.text)
+        except Exception as e:
+            raise ParseException(response.text) from e
         res = response.json()
 
         if res["code"] != 100000:

--- a/src/nonebot_plugin_parser_lite/render/__init__.py
+++ b/src/nonebot_plugin_parser_lite/render/__init__.py
@@ -385,7 +385,7 @@ class Renderer:
         - 若文件已存在：直接使用，不再重新渲染
         - 若不存在：渲染并写入该文件
         """
-        cache_key = result.url or (f"{result.platform.name}:{result.title}")
+        cache_key = result.url
         file_name = f"{uuid.uuid5(uuid.NAMESPACE_URL, cache_key)}.jpeg"
         image_path = pconfig.cache_dir / file_name
         if await image_path.exists():

--- a/src/nonebot_plugin_parser_lite/render/__init__.py
+++ b/src/nonebot_plugin_parser_lite/render/__init__.py
@@ -379,32 +379,27 @@ class Renderer:
         return data
 
     async def cache_or_render_image(self, result: ParseResult):
-        """获取缓存图片
+        """获取缓存图片（支持跨重启复用）
 
-        :param result: 解析结果
+        以解析结果的 URL（或其他稳定字段）为 key，在 cache_dir 下生成稳定文件名：
+        - 若文件已存在：直接使用，不再重新渲染
+        - 若不存在：渲染并写入该文件
         """
-        if result.render_image is None:
+        cache_key = result.url or (f"{result.platform.name}:{result.title}")
+        file_name = f"{uuid.uuid5(uuid.NAMESPACE_URL, cache_key)}.jpeg"
+        image_path = pconfig.cache_dir / file_name
+        if await image_path.exists():
+            result.render_image = image_path
+        else:
             image_raw = await self.render_image(result)
-            image_path = await self.save_img(image_raw)
+            await image_path.write_bytes(image_raw)
             result.render_image = image_path
             if pconfig.use_base64:
                 return await UniHelper.img_seg(image_raw)
-        if (await result.render_image.stat()).st_size >= 5 * 1024 * 1024:
-            return await UniHelper.file_seg(result.render_image)
+        if (await image_path.stat()).st_size >= 5 * 1024 * 1024:
+            return await UniHelper.file_seg(image_path)
 
-        return await UniHelper.img_seg(result.render_image)
-
-    @classmethod
-    async def save_img(cls, raw: bytes) -> Path:
-        """保存图片
-
-        :param raw: 图片字节
-        """
-
-        file_name = f"{uuid.uuid4().hex}.jpeg"
-        image_path = pconfig.cache_dir / file_name
-        await image_path.write_bytes(raw)
-        return image_path
+        return await UniHelper.img_seg(image_path)
 
 
 RENDERER = Renderer()


### PR DESCRIPTION
支持以解析结果的URL或平台名称加标题作为缓存键值， 在cache_dir下生成稳定文件名实现持久化缓存：
- 文件存在时直接使用缓存，避免重复渲染
- 文件不存在时渲染并写入缓存 移除原有的save_img方法，简化缓存逻辑

## Summary by Sourcery

为渲染的图像添加可在重启后仍然有效的持久化缓存，并使用稳定的缓存键。

新功能：
- 引入基于文件名的确定性图像缓存机制，以解析结果的 URL 或平台加标题作为键，从而在重启之间复用缓存。

改进：
- 通过内联图像保存逻辑并移除单独的 `save_img` 辅助方法，简化图像渲染和缓存流程。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add persistent, cross-restart image caching for rendered images using stable cache keys.

New Features:
- Introduce deterministic filename-based image caching keyed by parse result URL or platform and title to allow cache reuse across restarts.

Enhancements:
- Simplify image rendering and caching flow by inlining image saving logic and removing the separate save_img helper method.

</details>