### PR TITLE
 refactor(bilibili): 重构PCDN处理逻辑

### DIFF
--- a/src/nonebot_plugin_parser_lite/__init__.py
+++ b/src/nonebot_plugin_parser_lite/__init__.py
@@ -13,15 +13,7 @@ require("nonebot_plugin_localstore")
 import time
 
 from anyio import Path
-import bilibili_api.video
 from nonebot_plugin_apscheduler import scheduler
-
-aq = bilibili_api.video.AudioQuality
-if aq.DOLBY.value == 30255:
-    aq.DOLBY._value_ = 30250
-    aq._value2member_map_.pop(30255, None)
-    aq._value2member_map_[30250] = aq.DOLBY
-
 
 from .config import Config, pconfig
 from .matchers import clear_result_cache

--- a/src/nonebot_plugin_parser_lite/config.py
+++ b/src/nonebot_plugin_parser_lite/config.py
@@ -3,8 +3,7 @@ from nonebot import get_driver, get_plugin_config
 import nonebot_plugin_localstore as _store
 from pydantic import BaseModel
 
-from .constants import PlatformEnum
-from .parsers.bilibili.utils import VideoCodecs, VideoQuality
+from .constants import BiliVideoCodecs, BiliVideoQuality, PlatformEnum
 
 
 class Config(BaseModel):
@@ -32,13 +31,13 @@ class Config(BaseModel):
     """禁用的解析器"""
     plite_blacklist_users: list[str] = []
     """黑名单用户列表，这些用户触发的解析将被忽略"""
-    plite_bili_video_codes: list[VideoCodecs] = [
-        VideoCodecs.AVC,
-        VideoCodecs.AV1,
-        VideoCodecs.HEV,
+    plite_bili_video_codes: list[BiliVideoCodecs] = [
+        BiliVideoCodecs.AVC,
+        BiliVideoCodecs.AV1,
+        BiliVideoCodecs.HEV,
     ]
     """B站视频编码"""
-    plite_bili_video_quality: VideoQuality = VideoQuality._1080P
+    plite_bili_video_quality: BiliVideoQuality = BiliVideoQuality._1080P
     """B站视频清晰度"""
     plite_need_forward_contents: bool = True
     """是否需要合并转发内容(大于四项时始终转发)"""
@@ -97,12 +96,12 @@ class Config(BaseModel):
         return self.plite_disabled_platforms
 
     @property
-    def bili_video_codes(self) -> list[VideoCodecs]:
+    def bili_video_codes(self) -> list[BiliVideoCodecs]:
         """B站视频编码"""
         return self.plite_bili_video_codes
 
     @property
-    def bili_video_quality(self) -> VideoQuality:
+    def bili_video_quality(self) -> BiliVideoQuality:
         """B站视频清晰度"""
         return self.plite_bili_video_quality
 

--- a/src/nonebot_plugin_parser_lite/config.py
+++ b/src/nonebot_plugin_parser_lite/config.py
@@ -1,10 +1,10 @@
 from anyio import Path
-from bilibili_api.video import VideoCodecs, VideoQuality
 from nonebot import get_driver, get_plugin_config
 import nonebot_plugin_localstore as _store
 from pydantic import BaseModel
 
 from .constants import PlatformEnum
+from .parsers.bilibili.utils import VideoCodecs, VideoQuality
 
 
 class Config(BaseModel):

--- a/src/nonebot_plugin_parser_lite/constants.py
+++ b/src/nonebot_plugin_parser_lite/constants.py
@@ -65,3 +65,65 @@ EMOJI_MAP: Final[dict[str, tuple[str, str]]] = {
     "resolving": ("38", "🔨"),
     "done": ("148", "🍼"),
 }
+
+
+class BiliVideoQuality(Enum):
+    """
+    视频的视频流分辨率枚举
+
+    :cvar _360P: 流畅 360P
+    :cvar _480P: 清晰 480P
+    :cvar _720P: 高清 720P60
+    :cvar _1080P: 高清 1080P
+    :cvar AI_REPAIR: 智能修复（人工智能修复画质）
+    :cvar _1080P_PLUS: 高清 1080P 高码率
+    :cvar _1080P_60: 高清 1080P 60 帧码率
+    :cvar _4K: 超清 4K
+    :cvar HDR: 真彩 HDR
+    :cvar DOLBY: 杜比视界
+    :cvar _8K: 超高清 8K
+    """
+
+    _360P = 16
+    _480P = 32
+    _720P = 64
+    _1080P = 80
+    AI_REPAIR = 100
+    _1080P_PLUS = 112
+    _1080P_60 = 116
+    _4K = 120
+    HDR = 125
+    DOLBY = 126
+    _8K = 127
+
+
+class BiliVideoCodecs(Enum):
+    """
+    视频的视频流编码枚举
+
+    :cvar HEV: HEVC(H.265)
+    :cvar AVC: AVC(H.264)
+    :cvar AV1: AV1
+    """
+
+    HEV = "hev"
+    AVC = "avc"
+    AV1 = "av01"
+
+
+class BiliAudioQuality(Enum):
+    """
+    视频的音频流清晰度枚举
+
+    :cvar _64K: 64K
+    :cvar _132K: 132K
+    :cvar _192K: 192K
+    :cvar HI_RES: Hi-Res 无损
+    :cvar DOLBY: 杜比全景声
+    """
+
+    _64K = 30216
+    _132K = 30232
+    DOLBY = 30250
+    HI_RES = 30251
+    _192K = 30280

--- a/src/nonebot_plugin_parser_lite/parsers/bilibili/__init__.py
+++ b/src/nonebot_plugin_parser_lite/parsers/bilibili/__init__.py
@@ -5,7 +5,6 @@ import json
 import re
 from re import Match
 from typing import Any, ClassVar
-from urllib.parse import quote
 
 import aiofiles
 from anyio import Path
@@ -18,12 +17,7 @@ from bilibili_api.live import LiveRoom
 from bilibili_api.login_v2 import QrCodeLogin, QrCodeLoginEvents
 from bilibili_api.opus import Opus
 from bilibili_api.utils.network import get_buvid
-from bilibili_api.video import (
-    AudioStreamDownloadURL,
-    Video,
-    VideoDownloadURLDataDetecter,
-    VideoStreamDownloadURL,
-)
+from bilibili_api.video import Video
 from msgspec import convert
 from nonebot import logger
 
@@ -48,6 +42,11 @@ from .dynamic import DynamicData, DynamicInfo
 from .favlist import FavData
 from .live import RoomData
 from .opus import ImageNode, OpusItem, TextNode
+from .utils import (
+    AudioStreamDownloadURL,
+    VideoDownloadURLDataDetecter,
+    VideoStreamDownloadURL,
+)
 from .video import AIConclusion, VideoInfo
 
 # 选择客户端
@@ -55,18 +54,6 @@ select_client("curl_cffi")
 # 模拟浏览器，第二参数数值参考 curl_cffi 文档
 # https://curl-cffi.readthedocs.io/en/latest/impersonate.html
 request_settings.set("impersonate", "chrome131")
-
-MCDN_PATTERN = re.compile(
-    r"((([0-9]{1,3}\.){3}[0-9]{1,3})|(.*\.mcdn\.bilivideo\.(com|cn|net))):[0-9]{1,5}/v1/resource"
-)
-
-
-def _encode_mcdn_url(raw_url: str) -> str:
-    """将原始 mcdn URL 做 URL 编码并拼接到代理前缀上."""
-    # 使用 quote 对整条 URL 做编码，safe="" 表示不保留任何字符
-    encoded = quote(raw_url, safe="")
-    # 补全协议头
-    return f"https://proxy-tf-all-ws.bilivideo.com/url={encoded}"
 
 
 class BilibiliParser(BaseParser):
@@ -981,20 +968,12 @@ class BilibiliParser(BaseParser):
         video_stream = streams[0]
         if not isinstance(video_stream, VideoStreamDownloadURL):
             raise DownloadException("未找到可下载的视频流")
-        if MCDN_PATTERN.search(video_stream.url):
-            logger.warning("检测到 PCDN 视频链接，正在进行代理替换...")
-            video_stream.url = _encode_mcdn_url(video_stream.url)
-
         logger.debug(
             f"视频流质量: {video_stream.video_quality.name}, 编码: {video_stream.video_codecs}"  # noqa: E501
         )
-
         audio_stream = streams[1]
         if not isinstance(audio_stream, AudioStreamDownloadURL):
             return video_stream.url, None
-        if MCDN_PATTERN.search(audio_stream.url):
-            logger.warning("检测到 PCDN 音频链接，正在进行代理替换...")
-            audio_stream.url = _encode_mcdn_url(audio_stream.url)
         logger.debug(f"音频流质量: {audio_stream.audio_quality.name}")
         return video_stream.url, audio_stream.url
 

--- a/src/nonebot_plugin_parser_lite/parsers/bilibili/utils.py
+++ b/src/nonebot_plugin_parser_lite/parsers/bilibili/utils.py
@@ -1,7 +1,8 @@
 from dataclasses import dataclass
-from enum import Enum
 from functools import cmp_to_key
 import re
+
+from ...constants import BiliAudioQuality, BiliVideoCodecs, BiliVideoQuality
 
 RE_PCDN_HOST = re.compile(
     r"\.mcdn\.bilivideo\.cn|szbdyd\.com|cos\.bilibili\.com/.+pcdn", re.IGNORECASE
@@ -26,68 +27,6 @@ def is_pcdn_url(url: str | None) -> bool:
     )
 
 
-class VideoQuality(Enum):
-    """
-    视频的视频流分辨率枚举
-
-    :cvar _360P: 流畅 360P
-    :cvar _480P: 清晰 480P
-    :cvar _720P: 高清 720P60
-    :cvar _1080P: 高清 1080P
-    :cvar AI_REPAIR: 智能修复（人工智能修复画质）
-    :cvar _1080P_PLUS: 高清 1080P 高码率
-    :cvar _1080P_60: 高清 1080P 60 帧码率
-    :cvar _4K: 超清 4K
-    :cvar HDR: 真彩 HDR
-    :cvar DOLBY: 杜比视界
-    :cvar _8K: 超高清 8K
-    """
-
-    _360P = 16
-    _480P = 32
-    _720P = 64
-    _1080P = 80
-    AI_REPAIR = 100
-    _1080P_PLUS = 112
-    _1080P_60 = 116
-    _4K = 120
-    HDR = 125
-    DOLBY = 126
-    _8K = 127
-
-
-class VideoCodecs(Enum):
-    """
-    视频的视频流编码枚举
-
-    :cvar HEV: HEVC(H.265)
-    :cvar AVC: AVC(H.264)
-    :cvar AV1: AV1
-    """
-
-    HEV = "hev"
-    AVC = "avc"
-    AV1 = "av01"
-
-
-class AudioQuality(Enum):
-    """
-    视频的音频流清晰度枚举
-
-    :cvar _64K: 64K
-    :cvar _132K: 132K
-    :cvar _192K: 192K
-    :cvar HI_RES: Hi-Res 无损
-    :cvar DOLBY: 杜比全景声
-    """
-
-    _64K = 30216
-    _132K = 30232
-    DOLBY = 30250
-    HI_RES = 30251
-    _192K = 30280
-
-
 @dataclass
 class VideoStreamDownloadURL:
     """
@@ -100,8 +39,8 @@ class VideoStreamDownloadURL:
     """
 
     url: str
-    video_quality: VideoQuality
-    video_codecs: VideoCodecs
+    video_quality: BiliVideoQuality
+    video_codecs: BiliVideoCodecs
     backup_url: list[str]
 
 
@@ -116,7 +55,7 @@ class AudioStreamDownloadURL:
     """
 
     url: str
-    audio_quality: AudioQuality
+    audio_quality: BiliAudioQuality
     backup_url: list[str]
 
 
@@ -243,21 +182,25 @@ class VideoDownloadURLDataDetecter:
 
     def detect_best_streams(
         self,
-        video_max_quality: VideoQuality = VideoQuality._8K,
-        audio_max_quality: AudioQuality = AudioQuality._192K,
-        video_min_quality: VideoQuality = VideoQuality._360P,
-        audio_min_quality: AudioQuality = AudioQuality._64K,
-        video_accepted_qualities: list[VideoQuality] = [
+        video_max_quality: BiliVideoQuality = BiliVideoQuality._8K,
+        audio_max_quality: BiliAudioQuality = BiliAudioQuality._192K,
+        video_min_quality: BiliVideoQuality = BiliVideoQuality._360P,
+        audio_min_quality: BiliAudioQuality = BiliAudioQuality._64K,
+        video_accepted_qualities: list[BiliVideoQuality] = [
             item
-            for _, item in VideoQuality.__dict__.items()
-            if isinstance(item, VideoQuality)
+            for _, item in BiliVideoQuality.__dict__.items()
+            if isinstance(item, BiliVideoQuality)
         ],
-        audio_accepted_qualities: list[AudioQuality] = [
+        audio_accepted_qualities: list[BiliAudioQuality] = [
             item
-            for _, item in AudioQuality.__dict__.items()
-            if isinstance(item, AudioQuality)
+            for _, item in BiliAudioQuality.__dict__.items()
+            if isinstance(item, BiliAudioQuality)
         ],
-        codecs: list[VideoCodecs] = [VideoCodecs.AV1, VideoCodecs.AVC, VideoCodecs.HEV],
+        codecs: list[BiliVideoCodecs] = [
+            BiliVideoCodecs.AV1,
+            BiliVideoCodecs.AVC,
+            BiliVideoCodecs.HEV,
+        ],
         no_dolby_video: bool = False,
         no_dolby_audio: bool = False,
         no_hdr: bool = False,
@@ -302,16 +245,16 @@ class VideoDownloadURLDataDetecter:
         # 收集所有候选视频流
         video_streams: list[VideoStreamDownloadURL] = []
         for video_data in videos_data:
-            vq = VideoQuality(video_data["id"])
+            vq = BiliVideoQuality(video_data["id"])
 
             # HDR / 杜比过滤
-            if (vq == VideoQuality.HDR and no_hdr) or (
-                vq == VideoQuality.DOLBY and no_dolby_video
+            if (vq == BiliVideoQuality.HDR and no_hdr) or (
+                vq == BiliVideoQuality.DOLBY and no_dolby_video
             ):
                 continue
 
             # 非 HDR / 杜比的视频质量范围过滤
-            if vq not in (VideoQuality.DOLBY, VideoQuality.HDR):
+            if vq not in (BiliVideoQuality.DOLBY, BiliVideoQuality.HDR):
                 if not (video_min_quality.value <= vq.value <= video_max_quality.value):
                     continue
                 if vq not in video_accepted_qualities:
@@ -319,8 +262,8 @@ class VideoDownloadURLDataDetecter:
 
             # 编码过滤
             codecs_str: str = video_data["codecs"]
-            video_stream_codecs: VideoCodecs | None = None
-            for val in VideoCodecs:
+            video_stream_codecs: BiliVideoCodecs | None = None
+            for val in BiliVideoCodecs:
                 if val.value in codecs_str:
                     video_stream_codecs = val
                     break
@@ -340,7 +283,7 @@ class VideoDownloadURLDataDetecter:
         audio_streams: list[AudioStreamDownloadURL] = []
         if audios_data:
             for audio_data in audios_data:
-                aq = AudioQuality(audio_data["id"])
+                aq = BiliAudioQuality(audio_data["id"])
                 if not (audio_min_quality.value <= aq.value <= audio_max_quality.value):
                     continue
                 if aq not in audio_accepted_qualities:
@@ -355,7 +298,7 @@ class VideoDownloadURLDataDetecter:
 
         if flac_data and (not no_hires) and flac_data["audio"]:
             audio = flac_data["audio"]
-            aq = AudioQuality(audio["id"])
+            aq = BiliAudioQuality(audio["id"])
             audio_streams.append(
                 AudioStreamDownloadURL(
                     url=audio["base_url"],
@@ -366,7 +309,7 @@ class VideoDownloadURLDataDetecter:
 
         if dolby_data and (not no_dolby_audio) and dolby_data["audio"]:
             audio = dolby_data["audio"][0]
-            aq = AudioQuality(audio["id"])
+            aq = BiliAudioQuality(audio["id"])
             audio_streams.append(
                 AudioStreamDownloadURL(
                     url=audio["base_url"],
@@ -380,13 +323,13 @@ class VideoDownloadURLDataDetecter:
             s1: VideoStreamDownloadURL, s2: VideoStreamDownloadURL
         ) -> int:
             # 杜比/HDR 优先
-            if s1.video_quality == VideoQuality.DOLBY and not no_dolby_video:
+            if s1.video_quality == BiliVideoQuality.DOLBY and not no_dolby_video:
                 return 1
-            if s2.video_quality == VideoQuality.DOLBY and not no_dolby_video:
+            if s2.video_quality == BiliVideoQuality.DOLBY and not no_dolby_video:
                 return -1
-            if s1.video_quality == VideoQuality.HDR and not no_hdr:
+            if s1.video_quality == BiliVideoQuality.HDR and not no_hdr:
                 return 1
-            if s2.video_quality == VideoQuality.HDR and not no_hdr:
+            if s2.video_quality == BiliVideoQuality.HDR and not no_hdr:
                 return -1
 
             # 其余按清晰度数值排序
@@ -404,13 +347,13 @@ class VideoDownloadURLDataDetecter:
             s1: AudioStreamDownloadURL, s2: AudioStreamDownloadURL
         ) -> int:
             # 杜比/Hi-Res 优先
-            if s1.audio_quality == AudioQuality.DOLBY and not no_dolby_audio:
+            if s1.audio_quality == BiliAudioQuality.DOLBY and not no_dolby_audio:
                 return 1
-            if s2.audio_quality == AudioQuality.DOLBY and not no_dolby_audio:
+            if s2.audio_quality == BiliAudioQuality.DOLBY and not no_dolby_audio:
                 return -1
-            if s1.audio_quality == AudioQuality.HI_RES and not no_hires:
+            if s1.audio_quality == BiliAudioQuality.HI_RES and not no_hires:
                 return 1
-            if s2.audio_quality == AudioQuality.HI_RES and not no_hires:
+            if s2.audio_quality == BiliAudioQuality.HI_RES and not no_hires:
                 return -1
 
             return s1.audio_quality.value - s2.audio_quality.value

--- a/src/nonebot_plugin_parser_lite/parsers/bilibili/utils.py
+++ b/src/nonebot_plugin_parser_lite/parsers/bilibili/utils.py
@@ -232,9 +232,21 @@ class VideoDownloadURLDataDetecter:
         if "durl" in self.__data.keys():
             url = self.__data["durl"][0]["url"]
             backup_url = self.__data["durl"][0]["backup_url"]
+
             if self.__data["format"].startswith("flv"):
-                return FLVStreamDownloadURL(url=url, backup_url=backup_url), None
-            return MP4StreamDownloadURL(url=url, backup_url=backup_url), None
+                video_stream: VideoStreamDownloadURL | None = FLVStreamDownloadURL(
+                    url=url,
+                    backup_url=backup_url,
+                )
+            else:
+                video_stream = MP4StreamDownloadURL(
+                    url=url,
+                    backup_url=backup_url,
+                )
+
+            # 统一对 FLV / MP4 流应用与 DASH 相同的 PCDN 过滤逻辑
+            video_stream, _ = sanitize_stream_urls(video_stream, None)
+            return video_stream, None
 
         # DASH 正常情况
         videos_data = self.__data["dash"]["video"]

--- a/src/nonebot_plugin_parser_lite/parsers/bilibili/utils.py
+++ b/src/nonebot_plugin_parser_lite/parsers/bilibili/utils.py
@@ -1,0 +1,437 @@
+from dataclasses import dataclass
+from enum import Enum
+from functools import cmp_to_key
+import re
+
+RE_PCDN_HOST = re.compile(
+    r"\.mcdn\.bilivideo\.cn|szbdyd\.com|cos\.bilibili\.com/.+pcdn", re.IGNORECASE
+)
+RE_PCDN_PATH = re.compile(r"xy\d+x\d+x\d+x\d+xy|/pcdn/|/mcdn/", re.IGNORECASE)
+RE_PRIVATE_IP = re.compile(
+    r"^https?://(10\.|172\.(1[6-9]|2\d|3[01])\.|192\.168\.|127\.)", re.IGNORECASE
+)
+
+
+def is_pcdn_url(url: str | None) -> bool:
+    """
+    检测给定 URL 是否为 PCDN / P2P 节点 URL
+
+    :param url: 待检测的 URL 字符串
+    :return: 若为 PCDN 地址则返回 True，否则 False
+    """
+    if not url:
+        return False
+    return bool(
+        RE_PCDN_HOST.search(url) or RE_PCDN_PATH.search(url) or RE_PRIVATE_IP.match(url)
+    )
+
+
+class VideoQuality(Enum):
+    """
+    视频的视频流分辨率枚举
+
+    :cvar _360P: 流畅 360P
+    :cvar _480P: 清晰 480P
+    :cvar _720P: 高清 720P60
+    :cvar _1080P: 高清 1080P
+    :cvar AI_REPAIR: 智能修复（人工智能修复画质）
+    :cvar _1080P_PLUS: 高清 1080P 高码率
+    :cvar _1080P_60: 高清 1080P 60 帧码率
+    :cvar _4K: 超清 4K
+    :cvar HDR: 真彩 HDR
+    :cvar DOLBY: 杜比视界
+    :cvar _8K: 超高清 8K
+    """
+
+    _360P = 16
+    _480P = 32
+    _720P = 64
+    _1080P = 80
+    AI_REPAIR = 100
+    _1080P_PLUS = 112
+    _1080P_60 = 116
+    _4K = 120
+    HDR = 125
+    DOLBY = 126
+    _8K = 127
+
+
+class VideoCodecs(Enum):
+    """
+    视频的视频流编码枚举
+
+    :cvar HEV: HEVC(H.265)
+    :cvar AVC: AVC(H.264)
+    :cvar AV1: AV1
+    """
+
+    HEV = "hev"
+    AVC = "avc"
+    AV1 = "av01"
+
+
+class AudioQuality(Enum):
+    """
+    视频的音频流清晰度枚举
+
+    :cvar _64K: 64K
+    :cvar _132K: 132K
+    :cvar _192K: 192K
+    :cvar HI_RES: Hi-Res 无损
+    :cvar DOLBY: 杜比全景声
+    """
+
+    _64K = 30216
+    _132K = 30232
+    DOLBY = 30250
+    HI_RES = 30251
+    _192K = 30280
+
+
+@dataclass
+class VideoStreamDownloadURL:
+    """
+    视频流 URL 信息
+
+    :param url: 视频流 URL
+    :param video_quality: 视频流清晰度
+    :param video_codecs: 视频流编码
+    :param backup_url: 备用视频流 URL 列表
+    """
+
+    url: str
+    video_quality: VideoQuality
+    video_codecs: VideoCodecs
+    backup_url: list[str]
+
+
+@dataclass
+class AudioStreamDownloadURL:
+    """
+    音频流 URL 信息
+
+    :param url: 音频流 URL
+    :param audio_quality: 音频流清晰度
+    :param backup_url: 备用音频流 URL 列表
+    """
+
+    url: str
+    audio_quality: AudioQuality
+    backup_url: list[str]
+
+
+@dataclass
+class FLVStreamDownloadURL:
+    """
+    FLV 视频流
+
+    :param url: FLV 流 URL
+    :param backup_url: 备用视频流 URL 列表
+    """
+
+    url: str
+    backup_url: list[str]
+
+
+@dataclass
+class MP4StreamDownloadURL:
+    """
+    MP4 视频流
+
+    :param url: HTML5 MP4 视频流 URL
+    :param backup_url: 备用视频流 URL 列表
+    """
+
+    url: str
+    backup_url: list[str]
+
+
+def sanitize_stream_urls(
+    video: VideoStreamDownloadURL | FLVStreamDownloadURL | MP4StreamDownloadURL | None,
+    audio: AudioStreamDownloadURL | None,
+) -> tuple[
+    VideoStreamDownloadURL | FLVStreamDownloadURL | MP4StreamDownloadURL | None,
+    AudioStreamDownloadURL | None,
+]:
+    """
+    基于 PCDN 规则清洗视频/音频流 URL，尽量避免使用 PCDN 节点。
+
+    逻辑：
+
+    1. 若 base_url 为 PCDN，则优先使用 backup_url 中第一个非 PCDN 链接；
+    2. 若 backup_url 里也没有非 PCDN，则保留原 base_url (真倒霉)
+
+    :param video: 视频流 URL 信息
+    :param audio: 音频流 URL 信息
+    :return: (清洗后的 video, audio)
+    """
+
+    def _sanitize_video(
+        v: VideoStreamDownloadURL | FLVStreamDownloadURL | MP4StreamDownloadURL | None,
+    ):
+        if v is None:
+            return None
+
+        base_url = v.url
+        backups = v.backup_url
+
+        # 如果主 URL 不是 PCDN，则优先使用它
+        if not is_pcdn_url(base_url):
+            return v
+
+        # 主 URL 是 PCDN，尝试从 backup_url 里找干净的替换
+        clean_backups = [u for u in backups if not is_pcdn_url(u)]
+        if clean_backups:
+            new_base = clean_backups[0]
+            rest_backups = clean_backups[1:]
+            if isinstance(v, VideoStreamDownloadURL):
+                return VideoStreamDownloadURL(
+                    url=new_base,
+                    video_quality=v.video_quality,
+                    video_codecs=v.video_codecs,
+                    backup_url=rest_backups,
+                )
+            if isinstance(v, FLVStreamDownloadURL):
+                return FLVStreamDownloadURL(url=new_base, backup_url=rest_backups)
+            return MP4StreamDownloadURL(url=new_base, backup_url=rest_backups)
+
+        return v
+
+    def _sanitize_audio(a: AudioStreamDownloadURL | None):
+        if a is None:
+            return None
+
+        base_url = a.url
+        backups = a.backup_url
+
+        if not is_pcdn_url(base_url):
+            return a
+
+        clean_backups = [u for u in backups if not is_pcdn_url(u)]
+        if clean_backups:
+            new_base = clean_backups[0]
+            rest_backups = clean_backups[1:]
+            return AudioStreamDownloadURL(
+                url=new_base,
+                audio_quality=a.audio_quality,
+                backup_url=rest_backups,
+            )
+
+        return a
+
+    return _sanitize_video(video), _sanitize_audio(audio)
+
+
+class VideoDownloadURLDataDetecter:
+    """
+    用于解析 `Video.get_download_url` 返回结果的解析器
+
+    该解析器会自动清洗 PCDN 链接
+    """
+
+    def __init__(self, data: dict):
+        """
+        用于解析 `Video.get_download_url` 返回结果的解析器
+
+        该解析器会自动清洗 PCDN 链接
+
+        :param data: `Video.get_download_url` 返回的原始数据
+        """
+        self.__data = data
+        if video_info := self.__data.get("video_info"):  # bangumi
+            self.__data = video_info
+
+    def detect_best_streams(
+        self,
+        video_max_quality: VideoQuality = VideoQuality._8K,
+        audio_max_quality: AudioQuality = AudioQuality._192K,
+        video_min_quality: VideoQuality = VideoQuality._360P,
+        audio_min_quality: AudioQuality = AudioQuality._64K,
+        video_accepted_qualities: list[VideoQuality] = [
+            item
+            for _, item in VideoQuality.__dict__.items()
+            if isinstance(item, VideoQuality)
+        ],
+        audio_accepted_qualities: list[AudioQuality] = [
+            item
+            for _, item in AudioQuality.__dict__.items()
+            if isinstance(item, AudioQuality)
+        ],
+        codecs: list[VideoCodecs] = [VideoCodecs.AV1, VideoCodecs.AVC, VideoCodecs.HEV],
+        no_dolby_video: bool = False,
+        no_dolby_audio: bool = False,
+        no_hdr: bool = False,
+        no_hires: bool = False,
+    ) -> tuple[
+        VideoStreamDownloadURL | FLVStreamDownloadURL | MP4StreamDownloadURL | None,
+        AudioStreamDownloadURL | None,
+    ]:
+        """
+        解析数据并返回“最优视频流 + 最优音频流”
+
+        - 对于 FLV/MP4/试看流：只返回一个 FLV/MP4 流作为视频，音频为 `None`
+        - 对于 DASH 流：在所有可用流中选出一条“质量最高”的视频流和音频流
+
+        :param video_max_quality: 可接受的视频最高清晰度
+        :param audio_max_quality: 可接受的音频最高清晰度
+        :param video_min_quality: 可接受的视频最低清晰度
+        :param audio_min_quality: 可接受的音频最低清晰度
+        :param video_accepted_qualities: 允许的视频清晰度列表
+        :param audio_accepted_qualities: 允许的音频清晰度列表
+        :param codecs: 允许的视频编码优先级列表（越靠前优先级越高）
+        :param no_dolby_video: 是否禁用杜比视频流
+        :param no_dolby_audio: 是否禁用杜比音频流
+        :param no_hdr: 是否禁用 HDR 视频流
+        :param no_hires: 是否禁用 Hi-Res 音频流
+        :return: (最佳视频流, 最佳音频流)，若不存在则对应位置为 `None`
+        """
+        # FLV / MP4 情况
+        if "durl" in self.__data.keys():
+            url = self.__data["durl"][0]["url"]
+            backup_url = self.__data["durl"][0]["backup_url"]
+            if self.__data["format"].startswith("flv"):
+                return FLVStreamDownloadURL(url=url, backup_url=backup_url), None
+            return MP4StreamDownloadURL(url=url, backup_url=backup_url), None
+
+        # DASH 正常情况
+        videos_data = self.__data["dash"]["video"]
+        audios_data = self.__data["dash"].get("audio")
+        flac_data = self.__data["dash"].get("flac")
+        dolby_data = self.__data["dash"].get("dolby")
+
+        # 收集所有候选视频流
+        video_streams: list[VideoStreamDownloadURL] = []
+        for video_data in videos_data:
+            vq = VideoQuality(video_data["id"])
+
+            # HDR / 杜比过滤
+            if (vq == VideoQuality.HDR and no_hdr) or (
+                vq == VideoQuality.DOLBY and no_dolby_video
+            ):
+                continue
+
+            # 非 HDR / 杜比的视频质量范围过滤
+            if vq not in (VideoQuality.DOLBY, VideoQuality.HDR):
+                if not (video_min_quality.value <= vq.value <= video_max_quality.value):
+                    continue
+                if vq not in video_accepted_qualities:
+                    continue
+
+            # 编码过滤
+            codecs_str: str = video_data["codecs"]
+            video_stream_codecs: VideoCodecs | None = None
+            for val in VideoCodecs:
+                if val.value in codecs_str:
+                    video_stream_codecs = val
+                    break
+            if video_stream_codecs is None or video_stream_codecs not in codecs:
+                continue
+
+            video_streams.append(
+                VideoStreamDownloadURL(
+                    url=video_data["base_url"],
+                    video_quality=vq,
+                    video_codecs=video_stream_codecs,
+                    backup_url=video_data["backup_url"],
+                )
+            )
+
+        # 收集所有候选音频流
+        audio_streams: list[AudioStreamDownloadURL] = []
+        if audios_data:
+            for audio_data in audios_data:
+                aq = AudioQuality(audio_data["id"])
+                if not (audio_min_quality.value <= aq.value <= audio_max_quality.value):
+                    continue
+                if aq not in audio_accepted_qualities:
+                    continue
+                audio_streams.append(
+                    AudioStreamDownloadURL(
+                        url=audio_data["base_url"],
+                        audio_quality=aq,
+                        backup_url=audio_data["backup_url"],
+                    )
+                )
+
+        if flac_data and (not no_hires) and flac_data["audio"]:
+            audio = flac_data["audio"]
+            aq = AudioQuality(audio["id"])
+            audio_streams.append(
+                AudioStreamDownloadURL(
+                    url=audio["base_url"],
+                    audio_quality=aq,
+                    backup_url=audio["backup_url"],
+                )
+            )
+
+        if dolby_data and (not no_dolby_audio) and dolby_data["audio"]:
+            audio = dolby_data["audio"][0]
+            aq = AudioQuality(audio["id"])
+            audio_streams.append(
+                AudioStreamDownloadURL(
+                    url=audio["base_url"],
+                    audio_quality=aq,
+                    backup_url=audio["backup_url"],
+                )
+            )
+
+        # 选择最优视频流
+        def video_stream_cmp(
+            s1: VideoStreamDownloadURL, s2: VideoStreamDownloadURL
+        ) -> int:
+            # 杜比/HDR 优先
+            if s1.video_quality == VideoQuality.DOLBY and not no_dolby_video:
+                return 1
+            if s2.video_quality == VideoQuality.DOLBY and not no_dolby_video:
+                return -1
+            if s1.video_quality == VideoQuality.HDR and not no_hdr:
+                return 1
+            if s2.video_quality == VideoQuality.HDR and not no_hdr:
+                return -1
+
+            # 其余按清晰度数值排序
+            if s1.video_quality.value != s2.video_quality.value:
+                return s1.video_quality.value - s2.video_quality.value
+
+            # 同清晰度下，按 codecs 顺序（codecs 列表越靠前越优先）
+            if s1.video_codecs != s2.video_codecs:
+                return codecs.index(s2.video_codecs) - codecs.index(s1.video_codecs)
+
+            return 0
+
+        # 选择最优音频流
+        def audio_stream_cmp(
+            s1: AudioStreamDownloadURL, s2: AudioStreamDownloadURL
+        ) -> int:
+            # 杜比/Hi-Res 优先
+            if s1.audio_quality == AudioQuality.DOLBY and not no_dolby_audio:
+                return 1
+            if s2.audio_quality == AudioQuality.DOLBY and not no_dolby_audio:
+                return -1
+            if s1.audio_quality == AudioQuality.HI_RES and not no_hires:
+                return 1
+            if s2.audio_quality == AudioQuality.HI_RES and not no_hires:
+                return -1
+
+            return s1.audio_quality.value - s2.audio_quality.value
+
+        # 排序 + 取最优
+        best_video: (
+            VideoStreamDownloadURL | FLVStreamDownloadURL | MP4StreamDownloadURL | None
+        ) = None
+        best_audio: AudioStreamDownloadURL | None = None
+
+        best_video = (
+            max(video_streams, key=cmp_to_key(video_stream_cmp))
+            if video_streams
+            else None
+        )
+        best_audio = (
+            max(audio_streams, key=cmp_to_key(audio_stream_cmp))
+            if audio_streams
+            else None
+        )
+
+        # 清洗 PCDN URL，尽量替换为正规 CDN
+        best_video, best_audio = sanitize_stream_urls(best_video, best_audio)
+        return best_video, best_audio

--- a/src/nonebot_plugin_parser_lite/parsers/bilibili/utils.py
+++ b/src/nonebot_plugin_parser_lite/parsers/bilibili/utils.py
@@ -11,6 +11,9 @@ RE_PCDN_PATH = re.compile(r"xy\d+x\d+x\d+x\d+xy|/pcdn/|/mcdn/", re.IGNORECASE)
 RE_PRIVATE_IP = re.compile(
     r"^https?://(10\.|172\.(1[6-9]|2\d|3[01])\.|192\.168\.|127\.)", re.IGNORECASE
 )
+# 枚举默认集合：用于 detect_best_streams 的默认允许清晰度列表
+DEFAULT_VIDEO_QUALITIES: list[BiliVideoQuality] = list(BiliVideoQuality)
+DEFAULT_AUDIO_QUALITIES: list[BiliAudioQuality] = list(BiliAudioQuality)
 
 
 def is_pcdn_url(url: str | None) -> bool:
@@ -176,9 +179,7 @@ class VideoDownloadURLDataDetecter:
 
         :param data: `Video.get_download_url` 返回的原始数据
         """
-        self.__data = data
-        if video_info := self.__data.get("video_info"):  # bangumi
-            self.__data = video_info
+        self.__data = data.get("video_info") or data
 
     def detect_best_streams(
         self,
@@ -186,21 +187,9 @@ class VideoDownloadURLDataDetecter:
         audio_max_quality: BiliAudioQuality = BiliAudioQuality._192K,
         video_min_quality: BiliVideoQuality = BiliVideoQuality._360P,
         audio_min_quality: BiliAudioQuality = BiliAudioQuality._64K,
-        video_accepted_qualities: list[BiliVideoQuality] = [
-            item
-            for _, item in BiliVideoQuality.__dict__.items()
-            if isinstance(item, BiliVideoQuality)
-        ],
-        audio_accepted_qualities: list[BiliAudioQuality] = [
-            item
-            for _, item in BiliAudioQuality.__dict__.items()
-            if isinstance(item, BiliAudioQuality)
-        ],
-        codecs: list[BiliVideoCodecs] = [
-            BiliVideoCodecs.AV1,
-            BiliVideoCodecs.AVC,
-            BiliVideoCodecs.HEV,
-        ],
+        video_accepted_qualities: list[BiliVideoQuality] | None = None,
+        audio_accepted_qualities: list[BiliAudioQuality] | None = None,
+        codecs: list[BiliVideoCodecs] | None = None,
         no_dolby_video: bool = False,
         no_dolby_audio: bool = False,
         no_hdr: bool = False,
@@ -219,22 +208,32 @@ class VideoDownloadURLDataDetecter:
         :param audio_max_quality: 可接受的音频最高清晰度
         :param video_min_quality: 可接受的视频最低清晰度
         :param audio_min_quality: 可接受的音频最低清晰度
-        :param video_accepted_qualities: 允许的视频清晰度列表
-        :param audio_accepted_qualities: 允许的音频清晰度列表
-        :param codecs: 允许的视频编码优先级列表（越靠前优先级越高）
+        :param video_accepted_qualities: 允许的视频清晰度列表，默认为所有值
+        :param audio_accepted_qualities: 允许的音频清晰度列表，默认为所有值
+        :param codecs: 允许的视频编码优先级列表（越靠前优先级越高），默认为 AV1 > AVC > HEV
         :param no_dolby_video: 是否禁用杜比视频流
         :param no_dolby_audio: 是否禁用杜比音频流
         :param no_hdr: 是否禁用 HDR 视频流
         :param no_hires: 是否禁用 Hi-Res 音频流
         :return: (最佳视频流, 最佳音频流)，若不存在则对应位置为 `None`
-        """
+        """  # noqa: E501
+        if video_accepted_qualities is None:
+            video_accepted_qualities = DEFAULT_VIDEO_QUALITIES
+        if audio_accepted_qualities is None:
+            audio_accepted_qualities = DEFAULT_AUDIO_QUALITIES
+        if codecs is None:
+            codecs = [
+                BiliVideoCodecs.AV1,
+                BiliVideoCodecs.AVC,
+                BiliVideoCodecs.HEV,
+            ]
         # FLV / MP4 情况
         if "durl" in self.__data.keys():
             url = self.__data["durl"][0]["url"]
             backup_url = self.__data["durl"][0]["backup_url"]
 
             if self.__data["format"].startswith("flv"):
-                video_stream: VideoStreamDownloadURL | None = FLVStreamDownloadURL(
+                video_stream = FLVStreamDownloadURL(
                     url=url,
                     backup_url=backup_url,
                 )
@@ -244,7 +243,6 @@ class VideoDownloadURLDataDetecter:
                     backup_url=backup_url,
                 )
 
-            # 统一对 FLV / MP4 流应用与 DASH 相同的 PCDN 过滤逻辑
             video_stream, _ = sanitize_stream_urls(video_stream, None)
             return video_stream, None
 
@@ -330,62 +328,51 @@ class VideoDownloadURLDataDetecter:
                 )
             )
 
-        # 选择最优视频流
-        def video_stream_cmp(
-            s1: VideoStreamDownloadURL, s2: VideoStreamDownloadURL
-        ) -> int:
-            # 杜比/HDR 优先
-            if s1.video_quality == BiliVideoQuality.DOLBY and not no_dolby_video:
-                return 1
-            if s2.video_quality == BiliVideoQuality.DOLBY and not no_dolby_video:
-                return -1
-            if s1.video_quality == BiliVideoQuality.HDR and not no_hdr:
-                return 1
-            if s2.video_quality == BiliVideoQuality.HDR and not no_hdr:
-                return -1
+        # 选择最优视频流：基于评分的 key 函数
+        def video_score(s: VideoStreamDownloadURL) -> tuple[int, int, int]:
+            """
+            :return: (杜比/HDR 优先级, 清晰度权重, 编码优先级)
+            """
+            # 杜比/HDR 优先级（越大越优先）
+            dolby_hdr_priority = 0
+            if not no_dolby_video and s.video_quality == BiliVideoQuality.DOLBY:
+                dolby_hdr_priority = 2
+            elif not no_hdr and s.video_quality == BiliVideoQuality.HDR:
+                dolby_hdr_priority = 1
 
-            # 其余按清晰度数值排序
-            if s1.video_quality.value != s2.video_quality.value:
-                return s1.video_quality.value - s2.video_quality.value
+            # 清晰度（越高越好）
+            quality_weight = s.video_quality.value
 
-            # 同清晰度下，按 codecs 顺序（codecs 列表越靠前越优先）
-            if s1.video_codecs != s2.video_codecs:
-                return codecs.index(s2.video_codecs) - codecs.index(s1.video_codecs)
+            # 编码优先级（codecs 列表越靠前越优先）
+            try:
+                codec_priority = len(codecs) - codecs.index(s.video_codecs)
+            except ValueError:
+                codec_priority = 0
 
-            return 0
+            return dolby_hdr_priority, quality_weight, codec_priority
 
-        # 选择最优音频流
-        def audio_stream_cmp(
-            s1: AudioStreamDownloadURL, s2: AudioStreamDownloadURL
-        ) -> int:
-            # 杜比/Hi-Res 优先
-            if s1.audio_quality == BiliAudioQuality.DOLBY and not no_dolby_audio:
-                return 1
-            if s2.audio_quality == BiliAudioQuality.DOLBY and not no_dolby_audio:
-                return -1
-            if s1.audio_quality == BiliAudioQuality.HI_RES and not no_hires:
-                return 1
-            if s2.audio_quality == BiliAudioQuality.HI_RES and not no_hires:
-                return -1
+        # 选择最优音频流：基于评分的 key 函数
+        def audio_score(s: AudioStreamDownloadURL) -> tuple[int, int]:
+            """
+            :return: (杜比/Hi-Res 优先级, 清晰度权重)
+            """
+            dolby_hires_priority = 0
+            if not no_dolby_audio and s.audio_quality == BiliAudioQuality.DOLBY:
+                dolby_hires_priority = 2
+            elif not no_hires and s.audio_quality == BiliAudioQuality.HI_RES:
+                dolby_hires_priority = 1
 
-            return s1.audio_quality.value - s2.audio_quality.value
+            quality_weight = s.audio_quality.value
+            return dolby_hires_priority, quality_weight
 
-        # 排序 + 取最优
+        # 取最优（线性扫描）
         best_video: (
             VideoStreamDownloadURL | FLVStreamDownloadURL | MP4StreamDownloadURL | None
-        ) = None
-        best_audio: AudioStreamDownloadURL | None = None
+        )
+        best_audio: AudioStreamDownloadURL | None
 
-        best_video = (
-            max(video_streams, key=cmp_to_key(video_stream_cmp))
-            if video_streams
-            else None
-        )
-        best_audio = (
-            max(audio_streams, key=cmp_to_key(audio_stream_cmp))
-            if audio_streams
-            else None
-        )
+        best_video = max(video_streams, key=video_score) if video_streams else None
+        best_audio = max(audio_streams, key=audio_score) if audio_streams else None
 
         # 清洗 PCDN URL，尽量替换为正规 CDN
         best_video, best_audio = sanitize_stream_urls(best_video, best_audio)


### PR DESCRIPTION
resolve #112

## Summary by Sourcery

重构 Bilibili 下载流处理逻辑，使用内部的清晰度/编码枚举，并集中管理支持 PCDN 感知的流选择与 URL 清理。

Enhancements:
- 引入用于表示 Bilibili 视频清晰度、音频清晰度和视频编码格式的内部枚举，并将其接入插件配置。
- 新增 Bilibili 工具模块，用于建模视频/音频流 URL、检测 PCDN 端点，并清理流 URL 以优先选择非 PCDN 的 CDN 地址。
- 实现 Bilibili 下载响应的数据检测器，根据清晰度、编码偏好以及功能开关（Dolby、HDR、Hi-Res）选择最优的视频和音频流。
- 简化 Bilibili 解析器，将 PCDN 处理和流选择逻辑委托给新的工具模块，而不是在解析器中直接重写 URL。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor Bilibili download stream handling to use internal quality/codec enums and centralized PCDN-aware stream selection and URL sanitization.

Enhancements:
- Introduce internal enums for Bilibili video quality, audio quality, and video codecs and wire them into plugin configuration.
- Add a Bilibili utilities module to model video/audio stream URLs, detect PCDN endpoints, and sanitize stream URLs to prefer non-PCDN CDN addresses.
- Implement a data detector for Bilibili download responses that selects the best available video and audio streams based on quality, codec preferences, and feature flags (Dolby, HDR, Hi-Res).
- Simplify the Bilibili parser by delegating PCDN handling and stream selection logic to the new utilities instead of in-place URL rewriting.

</details>