### PR TITLE
feat(render): 添加按标点符号优先的文本切分功能

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,9 +167,6 @@ plite_max_comments=5
 
 # [可选] 纯文本文本长度阈值，超过此长度的文本将会强制转发
 plite_forward_text_threshold=300
-
-# [可选] 单批转发文本总长度上限，超过此长度将拆分为多条合并转发
-plite_forward_text_max_length=4000
 ```
 
 </details>

--- a/src/nonebot_plugin_parser_lite/config.py
+++ b/src/nonebot_plugin_parser_lite/config.py
@@ -57,8 +57,6 @@ class Config(BaseModel):
     """最大评论数量"""
     plite_forward_text_threshold: int = 300
     """纯文本文本长度阈值，超过此长度的文本将会强制转发"""
-    plite_forward_text_max_length: int = 4000
-    """单批转发文本总长度上限，超过此长度将拆分为多条合并转发"""
 
     @property
     def nickname(self) -> str:
@@ -189,11 +187,6 @@ class Config(BaseModel):
     def forward_text_threshold(self) -> int:
         """纯文本文本长度阈值，超过此长度的文本将会强制转发"""
         return self.plite_forward_text_threshold
-
-    @property
-    def forward_text_max_length(self) -> int:
-        """单批转发文本总长度上限，超过此长度将拆分为多条合并转发"""
-        return self.plite_forward_text_max_length
 
 
 # 初始化配置实例

--- a/src/nonebot_plugin_parser_lite/render/__init__.py
+++ b/src/nonebot_plugin_parser_lite/render/__init__.py
@@ -35,6 +35,54 @@ PLACEHOLDER_IMAGE = (
 )
 
 
+def split_text_by_length_with_punct(text: str, max_len: int) -> list[str]:
+    """按长度切分文本，优先在标点符号处断句。
+
+    规则：
+    1. 遍历文本，当前段长度超过 max_len 时：
+       - 尝试在当前段中最后一个标点符号后断句；
+       - 若找不到合适标点，则在 max_len 处硬切。
+    2. 支持中英文常用标点。
+
+    :param text: 原始文本
+    :param max_len: 每段最大长度
+    :return: 切分后的文本段列表
+    """
+    if max_len <= 0 or len(text) <= max_len:
+        return [text]
+
+    # 常见句末/停顿标点（中英文）
+    puncts = "。！？!?；;，,、…"
+    result: list[str] = []
+    start = 0
+    length = len(text)
+
+    while start < length:
+        # 预算本段的理论结束位置
+        end = min(start + max_len, length)
+        segment = text[start:end]
+
+        if end == length:
+            # 已到末尾，直接收尾
+            result.append(segment)
+            break
+
+        cut_pos = next(
+            (i + 1 for i in range(len(segment) - 1, -1, -1) if segment[i] in puncts),
+            -1,
+        )
+        if cut_pos <= 0:
+            # 没找到合适标点，直接在 max_len 处切
+            result.append(segment)
+            start = end
+        else:
+            # 在标点后断句
+            result.append(segment[:cut_pos])
+            start += cut_pos
+
+    return [seg for seg in result if seg]
+
+
 async def safe_src(obj: Any, method: str = "get_path") -> str:
     """
     通用安全资源获取过滤器
@@ -189,10 +237,12 @@ class Renderer:
                                 yield msg
 
                         # 情况 2：
-                        # 该 seg 自身就超过上限 -> 独立成一个批次发送
+                        # 该 seg 自身就超过上限 -> 按标点优先的规则拆分为多段
                         if isinstance(seg, str) and seg_plain > max_plain_len:
-                            for start in range(0, seg_plain, max_plain_len):
-                                part = seg[start : start + max_plain_len]
+                            parts = split_text_by_length_with_punct(seg, max_plain_len)
+                            for part in parts:
+                                if not part:
+                                    continue
                                 yield UniMessage(
                                     UniHelper.construct_forward_message([part])
                                 )

--- a/src/nonebot_plugin_parser_lite/render/__init__.py
+++ b/src/nonebot_plugin_parser_lite/render/__init__.py
@@ -33,6 +33,12 @@ from ..parsers.data import (
 PLACEHOLDER_IMAGE = (
     "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
 )
+SPLIT_THRESHOLD = pconfig.forward_text_threshold
+"""单段文本拆分阈值"""
+MAX_FORWARD_TEXT_LEN = 4500
+"""单个 forward 文本总长上限"""
+MAX_FORWARD_NODES = 90
+"""单个 forward 节点数上限"""
 
 
 def split_text_by_length_with_punct(text: str, max_len: int) -> list[str]:
@@ -179,42 +185,76 @@ class Renderer:
         # 2 构建图文 / 图片的转发列表（含主帖 + 转发，按顺序）
         ordered_segs = await self.__build_forward_segs(result)
         if ordered_segs:
-            text_threshold = pconfig.forward_text_threshold
-
-            # 先决定是否需要走“合并转发”路径
+            # 一次遍历：统计+长文本拆分
+            processed_segs: list[ForwardNodeInner] = []
             total_plain_len = 0
             node_count = 0
+
             for seg in ordered_segs:
                 node_count += 1
                 if isinstance(seg, str):
-                    total_plain_len += len(seg)
+                    seg_len = len(seg)
+                    total_plain_len += seg_len
+                    if seg_len > SPLIT_THRESHOLD:
+                        parts = split_text_by_length_with_punct(seg, SPLIT_THRESHOLD)
+                        for part in parts:
+                            if not part:
+                                continue
+                            processed_segs.append(part)
+                    else:
+                        processed_segs.append(seg)
+                else:
+                    processed_segs.append(seg)
 
             # 是否需要合并转发：
             # 1) 配置项 need_forward_contents
             # 2) 纯文字部分超过阈值
-            # 3) 节点数较多（兼容原来的 len > 4 逻辑）
+            # 3) 节点数较多
             need_forward = (
                 pconfig.need_forward_contents
-                or total_plain_len > text_threshold
+                or total_plain_len > SPLIT_THRESHOLD
                 or node_count > 4
             )
 
-            # 文本拆分预处理：短文本原样保留，超限文本按标点切成多段
-            processed_segs: list[ForwardNodeInner] = []
-            for seg in ordered_segs:
-                if isinstance(seg, str) and len(seg) > text_threshold:
-                    parts = split_text_by_length_with_punct(seg, text_threshold)
-                    processed_segs.extend(part for part in parts if part)
-                else:
-                    processed_segs.append(seg)
-
             if not need_forward:
-                # 不走合并转发：直接按节点顺序发出（文本 + 媒体）
+                # 不走合并转发：直接按节点顺序发出
                 yield UniMessage(processed_segs)
             else:
-                # 需要合并转发：构造一个 forward，内容为 processed_segs
-                forward_msg = UniHelper.construct_forward_message(processed_segs)
-                yield UniMessage(forward_msg)
+                # 需要合并转发：根据平台限制按文本长度 / 节点数分批构造 forward
+                current_chunk: list[ForwardNodeInner] = []
+                current_text_len = 0
+                current_nodes = 0
+
+                def flush_chunk() -> UniMessage[Any] | None:
+                    nonlocal current_chunk, current_text_len, current_nodes
+                    if not current_chunk:
+                        return None
+                    msg = UniMessage(UniHelper.construct_forward_message(current_chunk))
+                    current_chunk.clear()
+                    current_text_len = 0
+                    current_nodes = 0
+                    return msg
+
+                for seg in processed_segs:
+                    seg_text_len = len(seg) if isinstance(seg, str) else 0
+
+                    # 如果加上当前节点会超出单个 forward 限制，则先 flush 当前 chunk
+                    if current_chunk and (
+                        current_text_len + seg_text_len > MAX_FORWARD_TEXT_LEN
+                        or current_nodes + 1 > MAX_FORWARD_NODES
+                    ):
+                        msg = flush_chunk()
+                        if msg is not None:
+                            yield msg
+
+                    current_chunk.append(seg)
+                    current_text_len += seg_text_len
+                    current_nodes += 1
+
+                # 收尾：还有未发送的 chunk
+                last_msg = flush_chunk()
+                if last_msg is not None:
+                    yield last_msg
 
         # 汇总下载失败信息
         if failed_count > 0:

--- a/src/nonebot_plugin_parser_lite/render/__init__.py
+++ b/src/nonebot_plugin_parser_lite/render/__init__.py
@@ -179,14 +179,9 @@ class Renderer:
         # 2 构建图文 / 图片的转发列表（含主帖 + 转发，按顺序）
         ordered_segs = await self.__build_forward_segs(result)
         if ordered_segs:
-            # 配置阈值（提供默认值，避免旧配置缺失时报错）
             text_threshold = pconfig.forward_text_threshold
-            max_plain_len = pconfig.forward_text_max_length
 
             # 先决定是否需要走“合并转发”路径
-            # 这里用一次遍历同时统计：
-            # - 总纯文字长度
-            # - 节点数量
             total_plain_len = 0
             node_count = 0
             for seg in ordered_segs:
@@ -204,60 +199,22 @@ class Renderer:
                 or node_count > 4
             )
 
-            if not need_forward:
-                # 直接一次性发出普通消息列表
-                yield UniMessage(ordered_segs)
-            else:
-                # 需要合并转发；如果纯文字总长度不大，直接构造一个转发即可
-                if total_plain_len <= max_plain_len:
-                    forward_msg = UniHelper.construct_forward_message(ordered_segs)
-                    yield UniMessage(forward_msg)
+            # 文本拆分预处理：短文本原样保留，超限文本按标点切成多段
+            processed_segs: list[ForwardNodeInner] = []
+            for seg in ordered_segs:
+                if isinstance(seg, str) and len(seg) > text_threshold:
+                    parts = split_text_by_length_with_punct(seg, text_threshold)
+                    processed_segs.extend(part for part in parts if part)
                 else:
-                    # 纯文字太长：按纯文字长度分批构造多个转发消息
-                    batch: list[ForwardNodeInner] = []
-                    batch_plain_len = 0
+                    processed_segs.append(seg)
 
-                    def flush_batch() -> UniMessage[Any] | None:
-                        nonlocal batch, batch_plain_len
-                        if not batch:
-                            return None
-                        msg = UniMessage(UniHelper.construct_forward_message(batch))
-                        batch = []
-                        batch_plain_len = 0
-                        return msg
-
-                    for seg in ordered_segs:
-                        seg_plain = len(seg) if isinstance(seg, str) else 0
-
-                        # 情况 1：
-                        # 当前 batch 非空，且再加上这个 seg 会超过上限 -> 先发出当前批次
-                        if batch and batch_plain_len + seg_plain > max_plain_len:
-                            msg = flush_batch()
-                            if msg is not None:
-                                yield msg
-
-                        # 情况 2：
-                        # 该 seg 自身就超过上限 -> 按标点优先的规则拆分为多段
-                        if isinstance(seg, str) and seg_plain > max_plain_len:
-                            parts = split_text_by_length_with_punct(seg, max_plain_len)
-                            for part in parts:
-                                if not part:
-                                    continue
-                                yield UniMessage(
-                                    UniHelper.construct_forward_message([part])
-                                )
-                            # 不把这个 seg 放入后续 batch
-                            continue
-
-                        # 情况 3：
-                        # 正常累加到当前批次
-                        batch.append(seg)
-                        batch_plain_len += seg_plain
-
-                    # 收尾
-                    last_msg = flush_batch()
-                    if last_msg is not None:
-                        yield last_msg
+            if not need_forward:
+                # 不走合并转发：直接按节点顺序发出（文本 + 媒体）
+                yield UniMessage(processed_segs)
+            else:
+                # 需要合并转发：构造一个 forward，内容为 processed_segs
+                forward_msg = UniHelper.construct_forward_message(processed_segs)
+                yield UniMessage(forward_msg)
 
         # 汇总下载失败信息
         if failed_count > 0:


### PR DESCRIPTION
新增 split_text_by_length_with_punct 函数，实现按长度切分文本时优先在标点 符号处断句的功能。支持中英文常用标点符号，当找不到合适标点时会在指定长 度处硬切。同时修改渲染器逻辑，将超长文本段按此规则拆分后再发送，提升用户体验。
resolve #89

## Summary by Sourcery

为过长的渲染消息添加支持标点感知的文本拆分。

New Features:
- 引入文本拆分辅助工具，在强制限制片段最大长度时，优先在常见的中英文标点处进行断句拆分。

Enhancements:
- 更新渲染器，在发送为多条消息之前，使用标点感知拆分器对超长字符串片段进行拆分，以提升可读性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add punctuation-aware text splitting for overlong rendered messages.

New Features:
- Introduce a text splitting helper that prioritizes breaking at common Chinese and English punctuation when enforcing a maximum segment length.

Enhancements:
- Update the renderer to split oversized string segments using the punctuation-aware splitter before sending them as multiple messages to improve readability.

</details>