### PR TITLE
feat(download): 添加HEAD请求失败时自动回退到GET请求机制

### DIFF
--- a/src/nonebot_plugin_parser_lite/download/__init__.py
+++ b/src/nonebot_plugin_parser_lite/download/__init__.py
@@ -41,13 +41,14 @@ class StreamDownloader:
         """
         发送 HEAD 请求并返回响应对象。
 
-        对部分站点（如禁止 HEAD 或对 HEAD 做额外校验导致 405/412 等）
-        会自动回退为 GET 请求，只获取头部信息。
+        对部分站点（如禁止 HEAD 或对 HEAD 做额外校验）会自动回退为 GET，
+        但在回退 GET 时仅获取头部信息，不主动读取响应体，并返回一个“瘦身”的 Response：
+        仅保留 headers / cookies / url / status_code。
 
         :param url: 目标资源地址
         :param ext_headers: 额外请求头
         :return: httpx.Response 对象
-        :raise httpx.HTTPStatusError: 状态码非 2xx 时抛出（在 GET 回退也失败时）
+        :raise httpx.HTTPStatusError: HEAD 与 GET 均非 2xx 时抛出
         """
         headers = {**self.headers, **(ext_headers or {})}
         resp = await self.client.head(
@@ -58,15 +59,19 @@ class StreamDownloader:
         if 200 <= resp.status_code < 300:
             return resp
         logger.debug(
-            f"[StreamDownloader] HEAD {url} returned {resp.status_code}, fallback to GET"  # noqa: E501
+            f"[StreamDownloader] HEAD {url} returned {resp.status_code}, fallback to streamed GET"  # noqa: E501
         )
-        resp = await self.client.get(
-            url=url,
-            headers=headers,
-            follow_redirects=True,
-        )
-        resp.raise_for_status()
-        return resp
+        async with self.client.stream(
+            "GET", url, headers=headers, follow_redirects=True
+        ) as stream_resp:
+            stream_resp.raise_for_status()
+            slim_resp = Response(
+                status_code=stream_resp.status_code,
+                headers=stream_resp.headers,
+                request=stream_resp.request,
+            )
+            slim_resp.cookies.update(stream_resp.cookies)
+            return slim_resp
 
     async def head_size(
         self, url: str, ext_headers: dict[str, str] | None = None

--- a/src/nonebot_plugin_parser_lite/download/__init__.py
+++ b/src/nonebot_plugin_parser_lite/download/__init__.py
@@ -41,13 +41,26 @@ class StreamDownloader:
         """
         发送 HEAD 请求并返回响应对象。
 
+        对部分站点（如禁止 HEAD 或对 HEAD 做额外校验导致 405/412 等）
+        会自动回退为 GET 请求，只获取头部信息。
+
         :param url: 目标资源地址
         :param ext_headers: 额外请求头
         :return: httpx.Response 对象
-        :raise httpx.HTTPStatusError: 状态码非 2xx 时抛出
+        :raise httpx.HTTPStatusError: 状态码非 2xx 时抛出（在 GET 回退也失败时）
         """
         headers = {**self.headers, **(ext_headers or {})}
         resp = await self.client.head(
+            url=url,
+            headers=headers,
+            follow_redirects=True,
+        )
+        if 200 <= resp.status_code < 300:
+            return resp
+        logger.debug(
+            f"[StreamDownloader] HEAD {url} returned {resp.status_code}, fallback to GET"  # noqa: E501
+        )
+        resp = await self.client.get(
             url=url,
             headers=headers,
             follow_redirects=True,


### PR DESCRIPTION
当HEAD请求返回非2xx状态码时（如405/412等），自动使用GET请求获取头部信息， 以应对部分站点禁止HEAD请求或对HEAD进行额外校验的情况。同时更新了文档说明 和错误处理逻辑，在GET回退也失败时才会抛出HTTPStatusError异常。

## Summary by Sourcery

在流式下载器的 HEAD 请求中添加回退机制：当 HEAD 响应为非 2xx 状态码时，自动改用 GET 请求，从而提升对限制或特殊校验 HEAD 请求的网站的兼容性。

新特性：
- 引入从 HEAD 请求自动回退到 GET 请求的机制：当 HEAD 返回非 2xx 状态码时触发，仅在回退的 GET 请求同样失败时才抛出 `HTTPStatusError`。

文档：
- 更新下载器中与 HEAD 请求相关的文档字符串，描述新的 GET 回退行为以及调整后的错误抛出条件。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a fallback mechanism in the stream downloader HEAD request to use GET when HEAD responses are non-2xx, improving compatibility with sites that restrict or specially validate HEAD requests.

New Features:
- Introduce automatic fallback from HEAD to GET requests when HEAD returns non-2xx status codes, only raising HTTPStatusError if the fallback GET also fails.

Documentation:
- Update downloader HEAD request docstring to describe the new GET fallback behavior and adjusted error-raising conditions.

</details>