### PR TITLE
refactor(kuwo): 重构酷我音乐解析功能

### DIFF
--- a/src/nonebot_plugin_parser_lite/parsers/kuwo.py
+++ b/src/nonebot_plugin_parser_lite/parsers/kuwo.py
@@ -1,8 +1,5 @@
-import contextlib
 from re import Match
 from typing import ClassVar
-
-from nonebot import logger
 
 from .base import (
     BaseParser,
@@ -13,68 +10,61 @@ from .base import (
 from .data import MediaContent, Platform
 
 
+# ref https://kw-api.cenguigui.cn/
 class KuWoParser(BaseParser):
     # 平台信息
     platform: ClassVar[Platform] = Platform(
         name=PlatformEnum.KUWO, display_name="酷我音乐"
     )
 
-    @handle("kuwo.cn", r"https?://[^\s]*?kuwo\.cn/play_detail/\d+")
+    @handle("kuwo.cn", r"https?://[^\s]*?kuwo\.cn/play_detail/(\d+)")
     async def _parse_kuwo_share(self, searched: Match[str]):
         """解析酷我音乐分享链接"""
-        share_url = searched[0]
-        logger.debug(f"触发酷我音乐解析: {share_url}")
+        rid = searched[1]
 
         # 使用API解析
         resp = await self.httpx.get(
-            "https://api.bugpk.com/api/kuwo", params={"url": share_url}
+            "https://kw-api.cenguigui.cn/",
+            params={"id": rid, "type": "song", "level": "exhigh", "format": "json"},
         )
         resp.raise_for_status()
         data = resp.json()
 
         # 检查接口返回状态
-        if data.get("code") != 200:
+        if data["code"] != 200:
             raise ParseException(f"酷我音乐接口返回错误: {data.get('msg', '未知错误')}")
 
         music_data = data["data"]
-        logger.info(f"酷我音乐解析成功: {music_data['title']} - {music_data['artist']}")
-
-        # 创建音频内容
-        audio_url = music_data["music_url"]
+        audio_url = music_data["url"]
         if not audio_url.startswith("http"):
             raise ParseException("无效音乐URL")
-
-        # 解析时长
-        duration = 0.0
-        if music_data.get("songTimeMinutes"):
-            # 格式为 "mm:ss"
-            with contextlib.suppress(ValueError):
-                minutes, seconds = map(int, music_data["songTimeMinutes"].split(":"))
-                duration = minutes * 60 + seconds
-        # 创建有意义的音频文件名
-        audio_name = f"{music_data['title']}-{music_data['artist']}.mp3"
-        # 创建音频内容
+        duration = music_data["duration"]
+        audio_name = f"{music_data['name']}-{music_data['artist']}.mp3"
         audio_content = self.create_audio(audio_url, duration, audio_name=audio_name)
-        # 构建文本内容
-        text = (
-            f"专辑: {music_data['album']}\n发行时间: {music_data['releaseDate']}"
-            f"\n时长: {music_data['songTimeMinutes']}"
-        )
-        if music_data.get("lyrics_url"):
-            text += f"\n歌词:\n{music_data['lyrics_url']}"
+        try:
+            total_seconds = duration
+            if total_seconds <= 0:
+                display_duration = "0:00"
 
-        # 创建封面图片内容
+            minutes, seconds = divmod(total_seconds, 60)
+            if minutes < 60:
+                display_duration = f"{minutes}:{seconds:02d}"
+
+            hours, minutes = divmod(minutes, 60)
+            display_duration = f"{hours}:{minutes:02d}:{seconds:02d}"
+        except (TypeError, ValueError):
+            display_duration = "NaN"
+        text = f"专辑: {music_data['album']}\n时长: {display_duration}"
+        if lyric := music_data.get("lyric"):
+            text += f"\n歌词:\n{lyric}"
         contents: list[MediaContent] = []
-
         if cover_url := music_data.get("pic"):
             contents.append(self.create_image(cover_url, need_send=False))
 
-        # 添加音频内容到列表
         contents.append(audio_content)
 
-        # 构建额外信息
         extra = {
-            "info": f"时长: {music_data['songTimeMinutes']} | "
+            "info": f"时长: {music_data['display_duration']} | "
             f"专辑: {music_data['album']}",
             "lyric": text,
             "type": "audio",
@@ -85,7 +75,7 @@ class KuWoParser(BaseParser):
         return self.result(
             title=music_data["title"],
             author=self.create_author(name=music_data["artist"]),
-            url=share_url,
+            url=f"https://www.kuwo.cn/play_detail/{rid}",
             content=contents,
             extra=extra,
         )

--- a/src/nonebot_plugin_parser_lite/parsers/kuwo.py
+++ b/src/nonebot_plugin_parser_lite/parsers/kuwo.py
@@ -10,6 +10,22 @@ from .base import (
 from .data import MediaContent, Platform
 
 
+def display_duration(duration: int) -> str:
+    try:
+        total_seconds = duration
+        if total_seconds <= 0:
+            return "0:00"
+
+        minutes, seconds = divmod(total_seconds, 60)
+        if minutes < 60:
+            return f"{minutes}:{seconds:02d}"
+
+        hours, minutes = divmod(minutes, 60)
+        return f"{hours}:{minutes:02d}:{seconds:02d}"
+    except (TypeError, ValueError):
+        return "NaN"
+
+
 # ref https://kw-api.cenguigui.cn/
 class KuWoParser(BaseParser):
     # 平台信息
@@ -41,20 +57,9 @@ class KuWoParser(BaseParser):
         duration = music_data["duration"]
         audio_name = f"{music_data['name']}-{music_data['artist']}.mp3"
         audio_content = self.create_audio(audio_url, duration, audio_name=audio_name)
-        try:
-            total_seconds = duration
-            if total_seconds <= 0:
-                display_duration = "0:00"
+        dis_dura = display_duration(music_data["duration"])
 
-            minutes, seconds = divmod(total_seconds, 60)
-            if minutes < 60:
-                display_duration = f"{minutes}:{seconds:02d}"
-
-            hours, minutes = divmod(minutes, 60)
-            display_duration = f"{hours}:{minutes:02d}:{seconds:02d}"
-        except (TypeError, ValueError):
-            display_duration = "NaN"
-        text = f"专辑: {music_data['album']}\n时长: {display_duration}"
+        text = f"专辑: {music_data['album']}\n时长: {dis_dura}"
         if lyric := music_data.get("lyric"):
             text += f"\n歌词:\n{lyric}"
         contents: list[MediaContent] = []
@@ -64,8 +69,7 @@ class KuWoParser(BaseParser):
         contents.append(audio_content)
 
         extra = {
-            "info": f"时长: {music_data['display_duration']} | "
-            f"专辑: {music_data['album']}",
+            "info": f"时长: {dis_dura} | 专辑: {music_data['album']}",
             "lyric": text,
             "type": "audio",
             "type_tag": "音乐",


### PR DESCRIPTION
resolve #60

## Summary by Sourcery

重构 KuWo 音乐解析逻辑，以使用新的 API 和更新后的歌曲详情响应结构。

增强内容：
- 将 KuWo 解析器切换到新的 API endpoint，并适配其用于音频 URL、元数据和歌词的响应字段。
- 改进 KuWo 歌曲解析中的时长处理和显示格式，在构建更丰富的文本和额外元数据时提供更好的呈现。
- 更新 KuWo 分享链接的处理逻辑，从 `play_detail` 链接中提取歌曲 ID，并在结果中重建规范化的 URL。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor KuWo music parsing to use a new API and updated response schema for song details.

Enhancements:
- Switch KuWo parser to a new API endpoint and adapt to its response fields for audio URL, metadata, and lyrics.
- Improve duration handling and display formatting in KuWo song parsing while constructing richer text and extra metadata.
- Update KuWo share URL handling to extract the song ID from play_detail links and reconstruct the canonical URL in results.

</details>