### PR TITLE
feat(browser): 浏览器启动方式改为懒启动

### DIFF
--- a/sourcery.yaml
+++ b/sourcery.yaml
@@ -1,0 +1,2 @@
+rule_settings:
+  python_version: "3.10"

--- a/src/nonebot_plugin_parser_lite/parsers/douyin/__init__.py
+++ b/src/nonebot_plugin_parser_lite/parsers/douyin/__init__.py
@@ -72,7 +72,7 @@ class DouyinParser(BaseParser):
         raise ParseException("分享已删除或资源直链提取失败, 请稍后再试")
 
     async def parse_note(self, vid: str):
-        tab = BrowserManager.new_tab()
+        tab = await BrowserManager.new_tab()
         tab.set.load_mode.eager()
         tab.get(f"https://www.douyin.com/note/{vid}")
         text = tab.html

--- a/src/nonebot_plugin_parser_lite/parsers/heybox/__init__.py
+++ b/src/nonebot_plugin_parser_lite/parsers/heybox/__init__.py
@@ -38,7 +38,7 @@ class HeyBoxParser(BaseParser):
         link_id = searched["link_id"]
 
         if not self.x_xhh_tokenid:
-            tab = BrowserManager.new_tab(url="https://www.xiaoheihe.cn/")
+            tab = await BrowserManager.new_tab(url="https://www.xiaoheihe.cn/")
             self.x_xhh_tokenid = tab.run_js("window.SMSdk.getDeviceId()", as_expr=True)
             logger.info(f"成功获取到小黑盒tokenid: {self.x_xhh_tokenid[:5]}...")
             tab.close()

--- a/src/nonebot_plugin_parser_lite/parsers/zhihu/__init__.py
+++ b/src/nonebot_plugin_parser_lite/parsers/zhihu/__init__.py
@@ -56,7 +56,7 @@ class ZhiHuParser(BaseParser):
         )
 
     async def fetch_initial_state(self, url: str):
-        tab = BrowserManager.new_tab()
+        tab = await BrowserManager.new_tab()
         tab.set.load_mode.eager()
         tab.get(url)
         html = tab.html

--- a/src/nonebot_plugin_parser_lite/utils/browser.py
+++ b/src/nonebot_plugin_parser_lite/utils/browser.py
@@ -175,43 +175,34 @@ class BrowserManager:
     @classmethod
     def reconnect(cls):
         if getattr(cls, "BROWSER", None) is None:
-            logger.warning(
-                "BrowserManager.reconnect() called but BROWSER is not initialized."
-            )
             return
         cls.BROWSER.reconnect()
 
     @classmethod
     def clear_cache(cls):
         if getattr(cls, "BROWSER", None) is None:
-            logger.info(
-                "BrowserManager.clear_cache() called but BROWSER is not initialized."
-            )
             return
         cls.BROWSER.clear_cache(cookies=False)
 
     @classmethod
-    def new_tab(cls, *args, **kwargs):
+    async def ensure_started(cls) -> None:
+        """确保浏览器已启动，若未启动则启动（惰性初始化）"""
         if getattr(cls, "BROWSER", None) is None:
-            raise RuntimeError(
-                "BrowserManager.new_tab() called before browser initialization"
-            )
+            await cls.start()
+
+    @classmethod
+    async def new_tab(cls, *args, **kwargs):
+        await cls.ensure_started()
         return cls.BROWSER.new_tab(*args, **kwargs)
 
     @classmethod
     def quit(cls):
         if getattr(cls, "BROWSER", None) is None:
-            logger.info("BrowserManager.quit() called but BROWSER is not initialized.")
             return
+        logger.info("Closing browser launched by Parser Lite")
         cls.BROWSER.quit(del_data=True)
-
-
-@driver.on_startup
-async def start_browser():
-    await BrowserManager.start()
 
 
 @driver.on_shutdown
 def close_browser():
-    logger.info("Closing browser launched by Parser Lite")
     BrowserManager.quit()

--- a/src/nonebot_plugin_parser_lite/utils/browser.py
+++ b/src/nonebot_plugin_parser_lite/utils/browser.py
@@ -1,5 +1,6 @@
 """使用 DrissionPage 启动浏览器，优先使用系统/Playwright/Puppeteer 已安装的内核."""
 
+import asyncio
 import contextlib
 import os
 import platform
@@ -17,7 +18,8 @@ driver = get_driver()
 
 
 class BrowserManager:
-    BROWSER: Chromium
+    BROWSER: Chromium | None = None
+    _init_lock: asyncio.Lock = asyncio.Lock()
 
     @staticmethod
     async def _find_browser_from_system() -> str:
@@ -152,6 +154,8 @@ class BrowserManager:
 
     @classmethod
     async def start(cls):
+        if cls.BROWSER is not None:
+            return
         browser_path = await cls._resolve_browser_path()
 
         if system == "Linux":
@@ -174,30 +178,34 @@ class BrowserManager:
 
     @classmethod
     def reconnect(cls):
-        if getattr(cls, "BROWSER", None) is None:
+        if cls.BROWSER is None:
             return
         cls.BROWSER.reconnect()
 
     @classmethod
     def clear_cache(cls):
-        if getattr(cls, "BROWSER", None) is None:
+        if cls.BROWSER is None:
             return
         cls.BROWSER.clear_cache(cookies=False)
 
     @classmethod
     async def ensure_started(cls) -> None:
         """确保浏览器已启动，若未启动则启动（惰性初始化）"""
-        if getattr(cls, "BROWSER", None) is None:
-            await cls.start()
+        if cls.BROWSER is not None:
+            return
+        async with cls._init_lock:
+            if cls.BROWSER is None:
+                await cls.start()
 
     @classmethod
     async def new_tab(cls, *args, **kwargs):
         await cls.ensure_started()
+        assert cls.BROWSER
         return cls.BROWSER.new_tab(*args, **kwargs)
 
     @classmethod
     def quit(cls):
-        if getattr(cls, "BROWSER", None) is None:
+        if cls.BROWSER is None:
             return
         logger.info("Closing browser launched by Parser Lite")
         cls.BROWSER.quit(del_data=True)


### PR DESCRIPTION
## Summary by Sourcery

引入延迟初始化浏览器机制，并将调用方适配为异步浏览器标签页 API。

新功能：
- 通过 `ensure_started` 辅助函数添加延迟启动浏览器的能力，在首次使用时初始化浏览器。

改进：
- 将 `BrowserManager.new_tab` 改为异步方法，并确保在打开新标签页前，如有需要会先启动浏览器。
- 通过移除自动启动钩子简化浏览器生命周期管理，同时保留优雅的关闭钩子，并提供更清晰的日志记录。

构建：
- 新增 Sourcery 配置文件，指定 Python 3.10 为目标版本。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce lazy browser initialization and adapt callers to the asynchronous browser tab API.

New Features:
- Add lazy browser startup via an ensure_started helper that initializes the browser on first use.

Enhancements:
- Make BrowserManager.new_tab asynchronous and ensure it starts the browser if needed before opening a tab.
- Simplify browser lifecycle handling by removing the automatic startup hook while keeping a graceful shutdown hook with clearer logging.

Build:
- Add a Sourcery configuration file specifying Python 3.10 as the target version.

</details>