### PR TITLE
fix(bilibili): 修复视频流可能缺失的问题

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,9 +98,9 @@ API_TIMEOUT=30.0
 plite_bili_ck="SESSDATA=xxxxxxxxxx;ac_time_value=131231241231241"
 
 # [可选] 允许的 B 站视频编码，越靠前的编码优先级越高
-# 可选 "avc"(H.264，体积较大), "hev"(HEVC), "av01"(AV1)
+# 可选 "avc"(H.264，体积较大), "hev"(HEVC), "av01"(AV1), "unknown"(未知)
 # 后两项在不同设备可能有兼容性问题，如需完全避免，可只填一项，如 '["avc"]'
-plite_bili_video_codes=["avc", "av01", "hev"]
+plite_bili_video_codes=["avc", "av01", "hev", "unknown"]
 
 # [可选] B 站视频清晰度
 # 360p(16), 480p(32), 720p(64), 1080p(80), 1080p+(112), 1080p_60(116), 4k(120)

--- a/src/nonebot_plugin_parser_lite/config.py
+++ b/src/nonebot_plugin_parser_lite/config.py
@@ -37,6 +37,7 @@ class Config(BaseModel):
         BiliVideoCodecs.AVC,
         BiliVideoCodecs.AV1,
         BiliVideoCodecs.HEV,
+        BiliVideoCodecs.UNKNOWN,
     ]
     """B站视频编码"""
     plite_bili_video_quality: BiliVideoQuality = BiliVideoQuality._1080P

--- a/src/nonebot_plugin_parser_lite/constants.py
+++ b/src/nonebot_plugin_parser_lite/constants.py
@@ -112,14 +112,15 @@ class BiliVideoCodecs(tuple, Enum):
     HEV = ("hev", "hvc1", "hev1")
     AVC = ("avc",)
     AV1 = ("av1", "av01")
+    UNKNOWN = ()
 
     @classmethod
-    def from_codec(cls, codec: str) -> "BiliVideoCodecs | None":
+    def from_codec(cls, codec: str) -> "BiliVideoCodecs":
         """根据 codec 字符串推断枚举值"""
         codec = codec.lower()
         return next(
             (item for item in cls if any(alias in codec for alias in item.value)),
-            None,
+            cls.UNKNOWN,
         )
 
 

--- a/src/nonebot_plugin_parser_lite/constants.py
+++ b/src/nonebot_plugin_parser_lite/constants.py
@@ -1,4 +1,4 @@
-from enum import Enum
+from enum import Enum, IntEnum
 from re import Match
 from typing import Final, TypedDict
 from urllib.parse import parse_qs, urlparse
@@ -70,7 +70,7 @@ EMOJI_MAP: Final[dict[str, tuple[str, str]]] = {
 }
 
 
-class BiliVideoQuality(Enum):
+class BiliVideoQuality(IntEnum):
     """
     视频的视频流分辨率枚举
 
@@ -100,7 +100,7 @@ class BiliVideoQuality(Enum):
     _8K = 127
 
 
-class BiliVideoCodecs(Enum):
+class BiliVideoCodecs(tuple, Enum):
     """
     视频的视频流编码枚举
 
@@ -109,12 +109,21 @@ class BiliVideoCodecs(Enum):
     :cvar AV1: AV1
     """
 
-    HEV = "hev"
-    AVC = "avc"
-    AV1 = "av01"
+    HEV = ("hev", "hvc1", "hev1")
+    AVC = ("avc",)
+    AV1 = ("av1", "av01")
+
+    @classmethod
+    def from_codec(cls, codec: str) -> "BiliVideoCodecs | None":
+        """根据 codec 字符串推断枚举值"""
+        codec = codec.lower()
+        return next(
+            (item for item in cls if any(alias in codec for alias in item.value)),
+            None,
+        )
 
 
-class BiliAudioQuality(Enum):
+class BiliAudioQuality(IntEnum):
     """
     视频的音频流清晰度枚举
 

--- a/src/nonebot_plugin_parser_lite/constants.py
+++ b/src/nonebot_plugin_parser_lite/constants.py
@@ -100,28 +100,30 @@ class BiliVideoQuality(IntEnum):
     _8K = 127
 
 
-class BiliVideoCodecs(tuple, Enum):
+class BiliVideoCodecs(str, Enum):
     """
     视频的视频流编码枚举
 
     :cvar HEV: HEVC(H.265)
     :cvar AVC: AVC(H.264)
     :cvar AV1: AV1
+    :cvar UNKNOWN: 未知
     """
 
-    HEV = ("hev", "hvc1", "hev1")
-    AVC = ("avc",)
-    AV1 = ("av1", "av01")
-    UNKNOWN = ()
+    HEV = "hev"
+    AVC = "avc"
+    AV1 = "av01"
+    UNKNOWN = "unknown"
 
     @classmethod
     def from_codec(cls, codec: str) -> "BiliVideoCodecs":
-        """根据 codec 字符串推断枚举值"""
+        """根据返回的 codec 字符串推断枚举值"""
         codec = codec.lower()
-        return next(
-            (item for item in cls if any(alias in codec for alias in item.value)),
-            cls.UNKNOWN,
-        )
+        if any(k in codec for k in ("hev", "hvc1", "hev1")):
+            return cls.HEV
+        if any(k in codec for k in ("avc",)):
+            return cls.AVC
+        return cls.AV1 if any(k in codec for k in ("av1", "av01")) else cls.UNKNOWN
 
 
 class BiliAudioQuality(IntEnum):

--- a/src/nonebot_plugin_parser_lite/parsers/bilibili/utils.py
+++ b/src/nonebot_plugin_parser_lite/parsers/bilibili/utils.py
@@ -272,9 +272,6 @@ class VideoDownloadURLDataDetecter:
             # 编码过滤
             codecs_str: str = video_data["codecs"]
             video_stream_codecs = BiliVideoCodecs.from_codec(codecs_str)
-            if video_stream_codecs is None:
-                continue
-
             video_streams.append(
                 VideoStreamDownloadURL(
                     url=video_data["base_url"],

--- a/src/nonebot_plugin_parser_lite/parsers/bilibili/utils.py
+++ b/src/nonebot_plugin_parser_lite/parsers/bilibili/utils.py
@@ -272,6 +272,8 @@ class VideoDownloadURLDataDetecter:
             # 编码过滤
             codecs_str: str = video_data["codecs"]
             video_stream_codecs = BiliVideoCodecs.from_codec(codecs_str)
+            if video_stream_codecs not in codecs:
+                continue
             video_streams.append(
                 VideoStreamDownloadURL(
                     url=video_data["base_url"],

--- a/src/nonebot_plugin_parser_lite/parsers/bilibili/utils.py
+++ b/src/nonebot_plugin_parser_lite/parsers/bilibili/utils.py
@@ -271,12 +271,8 @@ class VideoDownloadURLDataDetecter:
 
             # 编码过滤
             codecs_str: str = video_data["codecs"]
-            video_stream_codecs: BiliVideoCodecs | None = None
-            for val in BiliVideoCodecs:
-                if val.value in codecs_str:
-                    video_stream_codecs = val
-                    break
-            if video_stream_codecs is None or video_stream_codecs not in codecs:
+            video_stream_codecs = BiliVideoCodecs.from_codec(codecs_str)
+            if video_stream_codecs is None:
                 continue
 
             video_streams.append(


### PR DESCRIPTION
在 `constants.py` 中，将 `BiliVideoQuality` 类从 `Enum` 改为 `IntEnum`，以便更好地表示分辨率的整数值。 将 `BiliVideoCodecs` 类从 `Enum` 改为 `tuple, Enum`，并添加 `from_codec` 类方法，用于根据 codec 字符串推断枚举值。 将 `BiliAudioQuality` 类从 `Enum` 改为 `IntEnum`，以便更好地表示音频质量的整数值。

在 `utils.py` 中，修改 `VideoDownloadURLDataDetecter` 类中的编码过滤逻辑，使用 `BiliVideoCodecs.from_codec` 方法来确定 `video_stream_codecs`，从而简化代码并提高可读性。

resolve #135

## Summary by Sourcery

改进 Bilibili 直播画质和编码格式处理，避免出现缺失视频流的情况。

新功能：
- 在 `BiliVideoCodecs` 枚举上新增编码字符串推断辅助方法，用于将编码标识符映射到已知的编码类型。

错误修复：
- 修复由于编码字符串匹配逻辑不完整而导致跳过部分 Bilibili 视频流的问题。

改进优化：
- 将 Bilibili 视频和音频画质枚举改为使用 `IntEnum`，以更好地反映其底层数值含义。
- 扩展 `BiliVideoCodecs` 的取值以支持多个编码别名，并简化 Bilibili 解析器中的编码检测逻辑。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve Bilibili stream quality and codec handling to avoid missing video streams.

New Features:
- Add a codec string inference helper on the BiliVideoCodecs enum to map codec identifiers to known codec types.

Bug Fixes:
- Fix cases where Bilibili video streams were skipped due to incomplete codec string matching logic.

Enhancements:
- Represent Bilibili video and audio quality enums as IntEnum to better reflect their underlying numeric values.
- Extend BiliVideoCodecs values to support multiple codec aliases and simplify codec detection logic in the Bilibili parser.

</details>

Bug 修复：
- 解决由于无法识别的编解码器字符串导致 Bilibili 视频流被跳过的情况。

增强点：
- 将 Bilibili 视频和音频画质枚举表示为 IntEnum，以更好地建模数值化的画质等级。
- 扩展 Bilibili 视频编解码器枚举，以支持多个编解码器别名，并通过 `from_codec` 辅助函数集中进行编解码器查找。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

改进 Bilibili 直播画质和编码格式处理，避免出现缺失视频流的情况。

新功能：
- 在 `BiliVideoCodecs` 枚举上新增编码字符串推断辅助方法，用于将编码标识符映射到已知的编码类型。

错误修复：
- 修复由于编码字符串匹配逻辑不完整而导致跳过部分 Bilibili 视频流的问题。

改进优化：
- 将 Bilibili 视频和音频画质枚举改为使用 `IntEnum`，以更好地反映其底层数值含义。
- 扩展 `BiliVideoCodecs` 的取值以支持多个编码别名，并简化 Bilibili 解析器中的编码检测逻辑。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve Bilibili stream quality and codec handling to avoid missing video streams.

New Features:
- Add a codec string inference helper on the BiliVideoCodecs enum to map codec identifiers to known codec types.

Bug Fixes:
- Fix cases where Bilibili video streams were skipped due to incomplete codec string matching logic.

Enhancements:
- Represent Bilibili video and audio quality enums as IntEnum to better reflect their underlying numeric values.
- Extend BiliVideoCodecs values to support multiple codec aliases and simplify codec detection logic in the Bilibili parser.

</details>

</details>