### PR TITLE
feat(render/sticker): 优化贴纸图片占位

### DIFF
--- a/src/nonebot_plugin_parser_lite/render/__init__.py
+++ b/src/nonebot_plugin_parser_lite/render/__init__.py
@@ -105,18 +105,18 @@ async def safe_src(
     try:
         if not hasattr(obj, method):
             logger.warning(f"对象 {type(obj).__name__} 不存在方法 '{method}'")
-            return PLACEHOLDER_IMAGE
+            return None if return_none_on_fail else PLACEHOLDER_IMAGE
 
         method_attr = getattr(obj, method)
 
         if not callable(method_attr):
             logger.warning(f"{type(obj).__name__} 的属性 '{method}' 不是可调用对象")
-            return PLACEHOLDER_IMAGE
+            return None if return_none_on_fail else PLACEHOLDER_IMAGE
 
         call_result: Path | Awaitable[Path] = method_attr()  # type: ignore[assignment]
 
         src = await call_result if isinstance(call_result, Awaitable) else call_result
-        return src.as_uri()
+        return src.as_uri()  # 若不存在此属性，进入exception分支判断
     except Exception as e:
         logger.warning(f"safe_src({method}) 处理 {type(obj).__name__} 时失败: {e}")
         return None if return_none_on_fail else PLACEHOLDER_IMAGE

--- a/src/nonebot_plugin_parser_lite/render/__init__.py
+++ b/src/nonebot_plugin_parser_lite/render/__init__.py
@@ -89,7 +89,9 @@ def split_text_by_length_with_punct(text: str, max_len: int) -> list[str]:
     return [seg for seg in result if seg]
 
 
-async def safe_src(obj: Any, method: str = "get_path") -> str:
+async def safe_src(
+    obj: Any, method: str = "get_path", *, return_none_on_fail: bool = False
+) -> str | None:
     """
     通用安全资源获取过滤器
 
@@ -97,7 +99,8 @@ async def safe_src(obj: Any, method: str = "get_path") -> str:
         {{ cont | safe_src }}                    # 默认调用 get_path()
         {{ cont | safe_src("get_base") }}        # 调用 get_base()
         {{ cont | safe_src("get_cover_path") }}  # 调用 get_cover_path()
-        {{ author | safe_src("get_avatar_path") }} # 调用 get_avatar_path()
+        {{ author | safe_src("get_avatar_path", return_none_on_fail=True) }} #
+        调用 get_avatar_path(), 在获取失败时返回`None`而不是空白图片
     """
     try:
         if not hasattr(obj, method):
@@ -113,10 +116,10 @@ async def safe_src(obj: Any, method: str = "get_path") -> str:
         call_result: Path | Awaitable[Path] = method_attr()  # type: ignore[assignment]
 
         src = await call_result if isinstance(call_result, Awaitable) else call_result
-        return src.as_uri() if src else PLACEHOLDER_IMAGE
+        return src.as_uri()
     except Exception as e:
         logger.warning(f"safe_src({method}) 处理 {type(obj).__name__} 时失败: {e}")
-        return PLACEHOLDER_IMAGE
+        return None if return_none_on_fail else PLACEHOLDER_IMAGE
 
 
 class Renderer:

--- a/src/nonebot_plugin_parser_lite/render/templates/default.html.jinja
+++ b/src/nonebot_plugin_parser_lite/render/templates/default.html.jinja
@@ -5,8 +5,8 @@
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <title>Media Card · New</title>
         <meta name="referrer" content="no-referrer" />
-        <link rel="preconnect" href="https://emoji.awkchan.top" crossorigin />
-        <link rel="dns-prefetch" href="https://emoji.awkchan.top" />
+        <link rel="preconnect" href="https://sticker.sokoko.org" crossorigin />
+        <link rel="dns-prefetch" href="https://sticker.sokoko.org" />
         <link rel="stylesheet" href="icon.css" />
         <link rel="stylesheet" href="tailwind.css" />
         {% from "macros.jinja" import render_content %}

--- a/src/nonebot_plugin_parser_lite/render/templates/macros.jinja
+++ b/src/nonebot_plugin_parser_lite/render/templates/macros.jinja
@@ -241,11 +241,11 @@
             {# 4. 贴纸 #}
         {% elif cls == 'StickerContent' %}
             {% set src = cont | safe_src(return_none_on_fail=True) %}
-            {% set size = cont.size %}
-            {% set size_class = 'h-6' if size == 'small' else 'h-12' %}
             {% if not src %}
                 {% set _ = html_parts.append('<span class="whitespace-pre-wrap text-sm text-slate-800">' ~ cont.desc|e ~ '</span>') %}
             {% else %}
+                {% set size = cont.size %}
+                {% set size_class = 'h-6' if size == 'small' else 'h-12' %}
                 {% set _ = html_parts.append(
                                     '<img class="inline-block align-text-bottom ' ~ size_class ~ '"
                      src="' ~ src ~ '"

--- a/src/nonebot_plugin_parser_lite/render/templates/macros.jinja
+++ b/src/nonebot_plugin_parser_lite/render/templates/macros.jinja
@@ -240,14 +240,18 @@
                         ) %}
             {# 4. 贴纸 #}
         {% elif cls == 'StickerContent' %}
-            {% set src = cont | safe_src %}
+            {% set src = cont | safe_src(return_none_on_fail=True) %}
             {% set size = cont.size %}
             {% set size_class = 'h-6' if size == 'small' else 'h-12' %}
-            {% set _ = html_parts.append(
-                            '<img class="inline-block align-text-bottom ' ~ size_class ~ '"
-                 src="' ~ src ~ '"
-                 alt="' ~ (cont.desc|e) ~ '" />'
-                        ) %}
+            {% if not src %}
+                {% set _ = html_parts.append('<span class="whitespace-pre-wrap text-sm text-slate-800">' ~ cont.desc|e ~ '</span>') %}
+            {% else %}
+                {% set _ = html_parts.append(
+                                    '<img class="inline-block align-text-bottom ' ~ size_class ~ '"
+                     src="' ~ src ~ '"
+                     alt="' ~ (cont.desc|e) ~ '" />'
+                                ) %}
+            {% endif %}
             {# 5. 视频封面 + 播放按钮 #}
         {% elif cls == 'VideoContent' %}
             {% set _ = flush_images() %}

--- a/src/nonebot_plugin_parser_lite/utils/format.py
+++ b/src/nonebot_plugin_parser_lite/utils/format.py
@@ -39,9 +39,9 @@ def replace_placeholder_to_sticker(
             size = size_resolver(name) if size_resolver is not None else "small"
             result.append(
                 create_sticker(
-                    url=f"https://emoji.awkchan.top/assets/{platform}/{name}.webp",
+                    url=f"https://sticker.sokoko.org/assets/{platform}/{name}.webp",
                     size=size,
-                    desc=name,
+                    desc=f"[{name}]",
                 )
             )
         elif placeholder_text := text[start:end]:


### PR DESCRIPTION
- 修改 `default.html.jinja` 和 `macros.jinja` 模板文件中的 `safe_src` 调用，添加 `return_none_on_fail=True` 参数。
- 在 `StickerContent` 模板中，如果 `src` 为 `None`，则添加描述文本，否则添加图片。
- 更新 `replace_placeholder_to_sticker` 函数中的 URL。

## Summary by Sourcery

在渲染器和模板中优化贴纸渲染和占位符处理。

新功能：
- 当图片 URL 无法解析时，将贴纸占位符渲染为描述性文本。

改进：
- 允许 `safe_src` 过滤器在失败时可选地返回 `None`，而不是始终回退到占位符图片。
- 将贴纸资源主机 URL 更新为新的 `sticker.sokoko.org` 域名，并将默认贴纸描述调整为使用方括号括起来的标签。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Optimize sticker rendering and placeholder handling in the renderer and templates.

New Features:
- Render sticker placeholders as descriptive text when image URLs cannot be resolved.

Enhancements:
- Allow the safe_src filter to optionally return None on failures instead of always falling back to a placeholder image.
- Update sticker asset host URLs to use the new sticker.sokoko.org domain and adjust default sticker descriptions to be bracketed labels.

</details>