### PR TITLE
fix(zhihu): 修复文本换行处理逻辑

### DIFF
--- a/src/nonebot_plugin_parser_lite/parsers/zhihu/util.py
+++ b/src/nonebot_plugin_parser_lite/parsers/zhihu/util.py
@@ -57,8 +57,26 @@ async def parse_rich_content(html: str, content_type: str) -> list[MediaContent 
     _clean_soup(soup)
 
     result: list[MediaContent | str] = []
+    buffer: list[str] = []
+
     async for item in _iter_media_and_text(soup, content_type):
-        result.append(item)
+        if isinstance(item, str):
+            buffer.append(item)
+        else:
+            if buffer:
+                text_block = "".join(buffer)
+                lines = [line.rstrip() for line in text_block.splitlines()]
+                if normalized := "\n".join(lines).strip():
+                    result.append(normalized)
+                buffer.clear()
+            result.append(item)
+
+    if buffer:
+        text_block = "".join(buffer)
+        lines = [line.rstrip() for line in text_block.splitlines()]
+        if normalized := "\n".join(lines).strip():
+            result.append(normalized)
+
     return result
 
 
@@ -74,14 +92,15 @@ async def _iter_media_and_text(soup: BeautifulSoup, content_type: str):
     这是一个 async 生成器，方便内部按需 await。
     """
     for element in soup.descendants:
-        # 标签节点
         if isinstance(element, Tag):
-            # 段落 / 换行：作为显式的换行控制
-            if element.name in {"p", "br"}:
+            if element.name == "p":
                 yield "\n"
                 continue
 
-            # 视频卡片：整体视为一个单元，处理完后从 DOM 移除以避免重复产出
+            if element.name == "br":
+                yield "\n"
+                continue
+
             if element.name == "a" and "video-box" in (element.get("class") or []):
                 video = await _parse_video_box(element, content_type)
                 if video:
@@ -94,7 +113,6 @@ async def _iter_media_and_text(soup: BeautifulSoup, content_type: str):
                 element.decompose()
                 continue
 
-            # 图片
             if element.name == "img":
                 attrs: dict[str, str] = {
                     str(k): str(v[0] if isinstance(v, list) and v else v)

--- a/src/nonebot_plugin_parser_lite/parsers/zhihu/util.py
+++ b/src/nonebot_plugin_parser_lite/parsers/zhihu/util.py
@@ -18,7 +18,7 @@ def _quality_rank(q: str) -> int:
     return 1 if q == "SD" else 0
 
 
-async def fetch_video(video_id: str, content_type: str) -> MediaContent | None:
+async def fetch_video(video_id: str, content_type: str):
     res = await DOWNLOADER.client.post(
         "https://www.zhihu.com/api/v4/video/play_info",
         headers=VIDEO_HEADER,
@@ -76,6 +76,11 @@ async def _iter_media_and_text(soup: BeautifulSoup, content_type: str):
     for element in soup.descendants:
         # 标签节点
         if isinstance(element, Tag):
+            # 段落 / 换行：作为显式的换行控制
+            if element.name in {"p", "br"}:
+                yield "\n"
+                continue
+
             # 视频卡片：整体视为一个单元，处理完后从 DOM 移除以避免重复产出
             if element.name == "a" and "video-box" in (element.get("class") or []):
                 video = await _parse_video_box(element, content_type)
@@ -86,7 +91,6 @@ async def _iter_media_and_text(soup: BeautifulSoup, content_type: str):
                     if text := str(data_name).strip():
                         yield text
 
-                # 从 DOM 树移除该节点及其所有子节点，后续遍历不会再碰到
                 element.decompose()
                 continue
 
@@ -106,11 +110,12 @@ async def _iter_media_and_text(soup: BeautifulSoup, content_type: str):
                     yield Creator.image(url=src)
 
         elif isinstance(element, NavigableString):
-            if text := str(element).strip():
-                yield f"{text}\n"
+            text = str(element)
+            if text.strip():
+                yield text
 
 
-async def _parse_video_box(tag: Tag, content_type: str) -> MediaContent | None:
+async def _parse_video_box(tag: Tag, content_type: str):
     """
     解析知乎 <a class="video-box">，根据 data-lens-id 拉取视频信息
     """


### PR DESCRIPTION
- 将 `fetch_video` 函数的返回类型从 `MediaContent | None` 移除，以便更好地处理返回值。
- 将 `_iter_media_and_text` 函数中对 `<p>` 和 `<br>` 标签的处理改为显式地生成换行符，并且在处理后继续下一个循环迭代。
- 调整 `_iter_media_and_text` 函数中处理 `NavigableString` 的逻辑，避免在每个文本后添加多余的换行符。
- 将 `_parse_video_box` 函数的返回类型从 `MediaContent | None` 移除，以便更好地处理返回值。
- resolve #142 

## Summary by Sourcery

调整知乎解析器的视频处理和文本遍历逻辑，以改进换行行为和媒体解析。

Bug 修复：
- 修复对段落和换行标签的处理方式，使其在不重复为文本节点添加换行的前提下，显式输出换行符。
- 防止在遍历知乎内容时，为每个文本片段额外添加多余的结尾换行符。

增强：
- 简化视频解析辅助函数，从视频获取和视频框解析函数中移除可选返回类型注解，使其更好地反映实际用法。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust Zhihu parser video handling and text traversal to improve line break behavior and media parsing.

Bug Fixes:
- Fix handling of paragraph and line-break tags so they emit explicit newline characters without duplicating breaks after text nodes.
- Prevent extra trailing newlines from being added after each text fragment when traversing Zhihu content.

Enhancements:
- Simplify video parsing helpers by removing optional return type annotations from video fetch and video box parsing functions to better reflect their usage.

</details>