### PR TITLE
feat(cache): 引入缓存管理器并优化缓存清理功能

### DIFF
--- a/src/nonebot_plugin_parser_lite/__init__.py
+++ b/src/nonebot_plugin_parser_lite/__init__.py
@@ -1,4 +1,3 @@
-import asyncio
 import traceback
 
 from nonebot import logger, require
@@ -10,15 +9,12 @@ require("nonebot_plugin_htmlrender")
 require("nonebot_plugin_apscheduler")
 require("nonebot_plugin_localstore")
 
-import time
-
-from anyio import Path
 from nonebot_plugin_apscheduler import scheduler
 
-from .config import Config, pconfig
+from .cache import CacheManager
+from .config import Config
 from .matchers import clear_result_cache
 from .utils.browser import BrowserManager
-from .utils.common import safe_unlink
 
 __plugin_meta__ = PluginMetadata(
     name="链接分享解析 Lite 版",
@@ -44,41 +40,7 @@ async def clean_plugin_cache() -> None:
     """周期性清理过期缓存文件，并重置解析状态。"""
 
     try:
-        # 保留最近 N 小时内的缓存，默认 1 小时
-        reserve_hours: int = 1
-        now = time.time()
-
-        if all_files := [
-            f async for f in pconfig.cache_dir.iterdir() if await f.is_file()
-        ]:
-            to_delete: list[Path] = []
-            expire_seconds = reserve_hours * 60 * 60
-            for f in all_files:
-                try:
-                    mtime = (await f.stat()).st_mtime
-                except OSError:
-                    # 拿不到 stat 就直接尝试删除
-                    to_delete.append(f)
-                    continue
-
-                if now - mtime >= expire_seconds:
-                    to_delete.append(f)
-
-            if not to_delete:
-                logger.info(
-                    f"缓存文件共 {len(all_files)} 个，"
-                    f"无早于 {reserve_hours} 小时的文件，本次跳过清理"
-                )
-            else:
-                tasks = [safe_unlink(file) for file in to_delete]
-                await asyncio.gather(*tasks)
-                logger.success(
-                    f"已清理 {len(to_delete)} 个过期缓存文件，"
-                    f"保留 {len(all_files) - len(to_delete)} 个"
-                )
-
-        else:
-            logger.info("未找到需要清理的缓存文件")
+        await CacheManager.clean_expired()
     except Exception:
         logger.exception(f"清理缓存文件时发生异常: {traceback.format_exc()}")
 

--- a/src/nonebot_plugin_parser_lite/cache.py
+++ b/src/nonebot_plugin_parser_lite/cache.py
@@ -1,0 +1,141 @@
+import asyncio
+from collections.abc import AsyncIterator
+from dataclasses import dataclass
+import time
+from typing import ClassVar
+
+from anyio import Path
+from nonebot import logger
+
+from .config import pconfig
+from .utils.common import safe_unlink
+
+
+@dataclass(frozen=True, slots=True)
+class CachePolicy:
+    """缓存目录策略。ttl_seconds 为 None 时默认不清理。"""
+
+    subdir: str
+    ttl_seconds: int | None
+
+
+class CacheManager:
+    """集中管理插件缓存目录与清理策略。"""
+
+    MEDIA = "media"
+    RENDER = "render"
+    LOGO = "logo"
+    STICKER = "sticker"
+    LEGACY = "legacy"
+
+    _POLICIES: ClassVar[dict[str, CachePolicy]] = {
+        MEDIA: CachePolicy("media", 60 * 60),
+        RENDER: CachePolicy("render", 60 * 60),
+        LOGO: CachePolicy("logo", None),
+        STICKER: CachePolicy("sticker", 60 * 60 * 24 * 14),
+        LEGACY: CachePolicy("", 60 * 60),
+    }
+    _MANAGED_DIRS: ClassVar[set[str]] = {
+        policy.subdir for policy in _POLICIES.values() if policy.subdir
+    }
+
+    @classmethod
+    def cache_dir(cls, cache_type: str = MEDIA) -> Path:
+        policy = cls._POLICIES.get(cache_type, cls._POLICIES[cls.MEDIA])
+        return pconfig.cache_dir / policy.subdir if policy.subdir else pconfig.cache_dir
+
+    @classmethod
+    async def ensure_dir(cls, cache_type: str = MEDIA) -> Path:
+        cache_dir = cls.cache_dir(cache_type)
+        await cache_dir.mkdir(parents=True, exist_ok=True)
+        return cache_dir
+
+    @classmethod
+    async def iter_files(cls, path: Path) -> AsyncIterator[Path]:
+        if not await path.exists():
+            return
+        async for item in path.iterdir():
+            if await item.is_file():
+                yield item
+            elif await item.is_dir():
+                async for child in cls.iter_files(item):
+                    yield child
+
+    @classmethod
+    async def _collect_expired_files(
+        cls, cache_type: str, now: float
+    ) -> tuple[int, list[Path]]:
+        policy = cls._POLICIES[cache_type]
+        if policy.ttl_seconds is None:
+            return 0, []
+
+        cache_dir = cls.cache_dir(cache_type)
+        total = 0
+        expired: list[Path] = []
+        async for file in cls.iter_files(cache_dir):
+            total += 1
+            try:
+                mtime = (await file.stat()).st_mtime
+            except OSError:
+                expired.append(file)
+                continue
+
+            if now - mtime >= policy.ttl_seconds:
+                expired.append(file)
+        return total, expired
+
+    @classmethod
+    async def _collect_legacy_expired_files(cls, now: float) -> tuple[int, list[Path]]:
+        policy = cls._POLICIES[cls.LEGACY]
+        assert policy.ttl_seconds is not None
+
+        total = 0
+        expired: list[Path] = []
+        if not await pconfig.cache_dir.exists():
+            return total, expired
+
+        async for item in pconfig.cache_dir.iterdir():
+            if await item.is_dir():
+                continue
+            if not await item.is_file():
+                continue
+
+            total += 1
+            try:
+                mtime = (await item.stat()).st_mtime
+            except OSError:
+                expired.append(item)
+                continue
+
+            if now - mtime >= policy.ttl_seconds:
+                expired.append(item)
+        return total, expired
+
+    @classmethod
+    async def clean_expired(cls) -> None:
+        now = time.time()
+        cleanup_types = (cls.MEDIA, cls.RENDER, cls.LOGO, cls.STICKER)
+
+        totals: dict[str, int] = {}
+        expired_files: list[Path] = []
+        for cache_type in cleanup_types:
+            total, expired = await cls._collect_expired_files(cache_type, now)
+            totals[cache_type] = total
+            expired_files.extend(expired)
+
+        legacy_total, legacy_expired = await cls._collect_legacy_expired_files(now)
+        totals[cls.LEGACY] = legacy_total
+        expired_files.extend(legacy_expired)
+
+        if not expired_files:
+            logger.info(
+                "缓存清理完成，无过期文件；"
+                + ", ".join(f"{name}={count}" for name, count in totals.items())
+            )
+            return
+
+        await asyncio.gather(*(safe_unlink(file) for file in expired_files))
+        logger.success(
+            f"已清理 {len(expired_files)} 个过期缓存文件；"
+            + ", ".join(f"{name}={count}" for name, count in totals.items())
+        )

--- a/src/nonebot_plugin_parser_lite/creator.py
+++ b/src/nonebot_plugin_parser_lite/creator.py
@@ -3,6 +3,7 @@ from typing import Any, Literal, Protocol, TypeVar, runtime_checkable
 
 from anyio import Path
 
+from .cache import CacheManager
 from .config import pconfig as pconfig
 from .data import (
     AudioContent,
@@ -253,7 +254,11 @@ class Creator:
         :param ext_headers: 额外请求头
         """
 
-        image_task = DOWNLOADER.download_img(url=url, ext_headers=ext_headers)
+        image_task = DOWNLOADER.download_img(
+            url=url,
+            ext_headers=ext_headers,
+            cache_type=CacheManager.STICKER,
+        )
         return StickerContent(path_task=image_task, size=size, desc=desc)
 
     @staticmethod

--- a/src/nonebot_plugin_parser_lite/data.py
+++ b/src/nonebot_plugin_parser_lite/data.py
@@ -289,7 +289,7 @@ class ParseResult:
         for cont in self.content:
             if isinstance(cont, VideoContent):
                 return await cont.get_cover_path()
-            elif isinstance(cont, ImageContent | GraphicContent):
+            elif isinstance(cont, (ImageContent, GraphicContent)):
                 return await cont.get_path()
         return None
 

--- a/src/nonebot_plugin_parser_lite/data.py
+++ b/src/nonebot_plugin_parser_lite/data.py
@@ -7,6 +7,7 @@ from typing import Any, Literal, TypedDict
 
 from anyio import Path
 
+from .cache import CacheManager
 from .constants import STICKER_CDN
 from .download import DOWNLOADER
 from .download.task import DownloadTaskWrapper
@@ -174,6 +175,7 @@ class Platform:
         return await DOWNLOADER.download_img(
             url=STICKER_CDN.format(platform="logo", name=self.name),
             img_name=f"{self.name}.webp",
+            cache_type=CacheManager.LOGO,
         )
 
 
@@ -287,7 +289,7 @@ class ParseResult:
         for cont in self.content:
             if isinstance(cont, VideoContent):
                 return await cont.get_cover_path()
-            elif isinstance(cont, (ImageContent, GraphicContent)):
+            elif isinstance(cont, ImageContent | GraphicContent):
                 return await cont.get_path()
         return None
 

--- a/src/nonebot_plugin_parser_lite/download/__init__.py
+++ b/src/nonebot_plugin_parser_lite/download/__init__.py
@@ -19,6 +19,7 @@ from rich.progress import (
     TransferSpeedColumn,
 )
 
+from ..cache import CacheManager
 from ..config import pconfig
 from ..constants import COMMON_HEADER, DOWNLOAD_TIMEOUT
 from ..exception import DownloadException, SizeLimitException, ZeroSizeException
@@ -34,6 +35,7 @@ class StreamDownloader:
         self.headers: dict[str, str] = COMMON_HEADER.copy()
         self.cache_dir: Path = pconfig.cache_dir
         self.client: AsyncClient = AsyncClient(timeout=DOWNLOAD_TIMEOUT, verify=False)
+        self._active_downloads: dict[str, asyncio.Task[None]] = {}
         self._ffmpeg_available: bool | None = None
 
     async def aclose(self) -> None:
@@ -94,11 +96,13 @@ class StreamDownloader:
         url: str,
         file_name: str | None = None,
         ext_headers: dict[str, str] | None = None,
+        cache_type: str = CacheManager.MEDIA,
     ) -> Path:
         """
         :param url: 下载文件的链接地址
         :param file_name: 保存到本地的文件名，为空时根据 url 自动生成
         :param ext_headers: 额外的请求头，会与默认请求头合并
+        :param cache_type: 缓存类型
 
         :return: 下载完成后的本地文件路径
         :raise ZeroSizeException: 资源大小为 0 时抛出
@@ -106,20 +110,37 @@ class StreamDownloader:
         :raise DownloadException: 重试多次仍失败时抛出
         """
         file_name = make_filename(file_name) if file_name else generate_file_name(url)
-        file_path = self.cache_dir / file_name
+        cache_dir = await CacheManager.ensure_dir(cache_type)
+        file_path = cache_dir / file_name
 
         # 已有缓存文件，直接返回
         if await file_path.exists():
             return file_path
 
         headers = {**self.headers, **(ext_headers or {})}
+        download_key = str(file_path)
+        active_download = self._active_downloads.get(download_key)
+        if active_download is not None:
+            await active_download
+            return file_path
 
-        await self._download_with_stream(
-            url=url,
-            file_path=file_path,
-            headers=headers,
-            desc=file_name,
+        download_task = asyncio.create_task(
+            self._download_with_stream(
+                url=url,
+                file_path=file_path,
+                headers=headers,
+                desc=file_name,
+            )
         )
+        self._active_downloads[download_key] = download_task
+        try:
+            await download_task
+        except Exception:
+            await safe_unlink(file_path)
+            raise
+        finally:
+            if self._active_downloads.get(download_key) is download_task:
+                self._active_downloads.pop(download_key, None)
         return file_path
 
     async def _download_with_stream(
@@ -208,6 +229,7 @@ class StreamDownloader:
         url: str,
         video_name: str | None = None,
         ext_headers: dict[str, str] | None = None,
+        cache_type: str = CacheManager.MEDIA,
     ) -> Path:
         """
         下载普通视频
@@ -215,6 +237,7 @@ class StreamDownloader:
         :param url: 视频下载地址
         :param video_name: 保存到本地的视频文件名，为空时根据 url 自动生成 mp4 文件名
         :param ext_headers: 额外的请求头，会与默认请求头合并
+        :param cache_type: 缓存类型
 
         :return: 下载完成后的视频文件路径
         :raise ZeroSizeException: 资源大小为 0 时抛出
@@ -225,7 +248,10 @@ class StreamDownloader:
             video_name = generate_file_name(url, ".mp4")
 
         return await self.streamd(
-            url=url, file_name=video_name, ext_headers=ext_headers
+            url=url,
+            file_name=video_name,
+            ext_headers=ext_headers,
+            cache_type=cache_type,
         )
 
     @auto_task
@@ -235,6 +261,7 @@ class StreamDownloader:
         url: str,
         video_name: str | None = None,
         ext_headers: dict[str, str] | None = None,
+        cache_type: str = CacheManager.MEDIA,
     ) -> Path:
         """
         下载 m3u8 视频并合并到 mp4
@@ -242,6 +269,7 @@ class StreamDownloader:
         :param m3u8_url: m3u8 播放列表链接地址
         :param video_name: 输出的 mp4 文件名，为空时根据 m3u8 链接生成
         :param ext_headers: 额外的请求头，会与默认请求头合并
+        :param cache_type: 缓存类型
 
         :return: 最终合并并转封装后的 mp4 文件路径
         :raise SizeLimitException: 资源大小超过配置的最大限制时抛出
@@ -252,8 +280,9 @@ class StreamDownloader:
         if video_name is None:
             video_name = f"{file_id}.mp4"
 
-        final_video_path = self.cache_dir / video_name
-        temp_ts_path = self.cache_dir / f"{file_id}_temp.ts"
+        cache_dir = await CacheManager.ensure_dir(cache_type)
+        final_video_path = cache_dir / video_name
+        temp_ts_path = cache_dir / f"{file_id}_temp.ts"
 
         if await final_video_path.exists():
             return final_video_path
@@ -520,12 +549,14 @@ class StreamDownloader:
         url: str,
         audio_name: str | None = None,
         ext_headers: dict[str, str] | None = None,
+        cache_type: str = CacheManager.MEDIA,
     ) -> Path:
         """
         下载音频
         :param url: 音频下载地址
         :param audio_name: 保存到本地的音频文件名，为空时根据 url 自动生成 mp3 文件名
         :param ext_headers: 额外的请求头，会与默认请求头合并
+        :param cache_type: 缓存类型
 
         :return: 下载完成后的音频文件路径
         :raise DownloadException: 下载过程中发生错误时抛出
@@ -533,7 +564,10 @@ class StreamDownloader:
         if audio_name is None:
             audio_name = generate_file_name(url, ".mp3")
         return await self.streamd(
-            url=url, file_name=audio_name, ext_headers=ext_headers
+            url=url,
+            file_name=audio_name,
+            ext_headers=ext_headers,
+            cache_type=cache_type,
         )
 
     @auto_task
@@ -543,6 +577,7 @@ class StreamDownloader:
         url: str,
         img_name: str | None = None,
         ext_headers: dict[str, str] | None = None,
+        cache_type: str = CacheManager.MEDIA,
     ) -> Path:
         """
         下载图片
@@ -550,13 +585,19 @@ class StreamDownloader:
         :param url: 图片下载地址
         :param img_name: 保存到本地的图片文件名，为空时根据 url 自动生成 jpg 文件名
         :param ext_headers: 额外的请求头，会与默认请求头合并
+        :param cache_type: 缓存类型
 
         :return: 下载完成后的图片文件路径
         :raise DownloadException: 下载过程中发生错误时抛出
         """
         if img_name is None:
             img_name = generate_file_name(url, ".jpg")
-        return await self.streamd(url=url, file_name=img_name, ext_headers=ext_headers)
+        return await self.streamd(
+            url=url,
+            file_name=img_name,
+            ext_headers=ext_headers,
+            cache_type=cache_type,
+        )
 
     async def download_av_and_merge(
         self,

--- a/src/nonebot_plugin_parser_lite/download/__init__.py
+++ b/src/nonebot_plugin_parser_lite/download/__init__.py
@@ -113,7 +113,6 @@ class StreamDownloader:
         cache_dir = await CacheManager.ensure_dir(cache_type)
         file_path = cache_dir / file_name
 
-        # 已有缓存文件，直接返回
         if await file_path.exists():
             return file_path
 
@@ -124,15 +123,19 @@ class StreamDownloader:
             await active_download
             return file_path
 
-        download_task = asyncio.create_task(
-            self._download_with_stream(
+        async def _download_task() -> None:
+            if await file_path.exists():
+                return
+            await self._download_with_stream(
                 url=url,
                 file_path=file_path,
                 headers=headers,
                 desc=file_name,
             )
-        )
+
+        download_task = asyncio.create_task(_download_task())
         self._active_downloads[download_key] = download_task
+
         try:
             await download_task
         except Exception:
@@ -141,6 +144,7 @@ class StreamDownloader:
         finally:
             if self._active_downloads.get(download_key) is download_task:
                 self._active_downloads.pop(download_key, None)
+
         return file_path
 
     async def _download_with_stream(

--- a/src/nonebot_plugin_parser_lite/render/__init__.py
+++ b/src/nonebot_plugin_parser_lite/render/__init__.py
@@ -280,7 +280,7 @@ class Renderer:
         :raise DurationLimitException: 媒体时长超过配置的最大限制时抛出
         :raise DownloadException: 重试多次仍失败时抛出
         """
-        if not isinstance(cont, VideoContent | AudioContent):
+        if not isinstance(cont, (VideoContent, AudioContent)):
             return
         if cont.duration > pconfig.duration_maximum:
             raise DurationLimitException(cont.duration)

--- a/src/nonebot_plugin_parser_lite/render/__init__.py
+++ b/src/nonebot_plugin_parser_lite/render/__init__.py
@@ -12,6 +12,7 @@ from nonebot import logger
 from nonebot_plugin_htmlrender import template_to_pic
 import qrcode
 
+from ..cache import CacheManager
 from ..config import _nickname, pconfig
 from ..data import (
     AudioContent,
@@ -279,7 +280,7 @@ class Renderer:
         :raise DurationLimitException: 媒体时长超过配置的最大限制时抛出
         :raise DownloadException: 重试多次仍失败时抛出
         """
-        if not isinstance(cont, (VideoContent, AudioContent)):
+        if not isinstance(cont, VideoContent | AudioContent):
             return
         if cont.duration > pconfig.duration_maximum:
             raise DurationLimitException(cont.duration)
@@ -520,7 +521,8 @@ class Renderer:
         """
         cache_key = result.url
         file_name = f"{uuid.uuid5(uuid.NAMESPACE_URL, cache_key)}.jpeg"
-        image_path = pconfig.cache_dir / file_name
+        cache_dir = await CacheManager.ensure_dir(CacheManager.RENDER)
+        image_path = cache_dir / file_name
         if await image_path.exists():
             result.render_image = image_path
         else:

--- a/src/nonebot_plugin_parser_lite/utils/ffmpeg.py
+++ b/src/nonebot_plugin_parser_lite/utils/ffmpeg.py
@@ -4,7 +4,7 @@ import hashlib
 from anyio import Path
 from nonebot import logger
 
-from ..config import pconfig
+from ..cache import CacheManager
 from .common import fmt_size
 
 
@@ -50,7 +50,8 @@ class FFmpeg:
         :param file_name: 输出文件名
         """
         file_name = file_name or cls.generate_file_name(v_path, a_path)
-        output_path = pconfig.cache_dir / f"{file_name}.mp4"
+        cache_dir = await CacheManager.ensure_dir(CacheManager.MEDIA)
+        output_path = cache_dir / f"{file_name}.mp4"
         if await output_path.exists():
             return output_path
         logger.info(f"Merging {v_path.name} and {a_path.name} to {output_path.name}")
@@ -99,7 +100,8 @@ class FFmpeg:
         :param file_name: 输出文件名
         """
         file_name = file_name or cls.generate_file_name(image_path, video_path)
-        output_path = pconfig.cache_dir / f"{file_name}.mp4"
+        cache_dir = await CacheManager.ensure_dir(CacheManager.MEDIA)
+        output_path = cache_dir / f"{file_name}.mp4"
         if await output_path.exists():
             return output_path
         # 2. 构建指令：单进程一次性完成
@@ -179,7 +181,8 @@ class FFmpeg:
         :return: 转码后的 mp3 文件路径
         """
         file_name = file_name or cls.generate_file_name(audio_path)
-        output_path = pconfig.cache_dir / f"{file_name}.mp3"
+        cache_dir = await CacheManager.ensure_dir(CacheManager.MEDIA)
+        output_path = cache_dir / f"{file_name}.mp3"
 
         if await output_path.exists():
             return output_path


### PR DESCRIPTION
- 移除了 `__init__.py` 中不再使用的 `asyncio` 和 `time` 导入。
- 向 `__init__.py` 中添加了 `CacheManager` 导入，并修改了 `clean_plugin_cache` 函数以使用 `CacheManager.clean_expired` 方法来清理过期缓存文件。
- 在 `cache.py` 中创建了 `CachePolicy` 和 `CacheManager` 类，用于集中管理插件缓存目录与清理策略。
- 在 `creator.py` 的 `Creator` 类中，`download_img` 方法添加了 `cache_type` 参数，并使用 `CacheManager.STICKER`。
- 在 `data.py` 中，`download_img` 方法添加了 `cache_type` 参数，并使用 `CacheManager.LOGO`。同时，修改了 `ParseResult` 类中 `get_cover_path` 方法的类型检查表达式。
- 在 `download/__init__.py` 的 `StreamDownloader` 类中，多个方法添加了 `cache_type` 参数，并使用 `CacheManager.MEDIA` 或 `CacheManager.STICKER`。
- 在 `render/__init__.py` 中，`Renderer` 类的 `check_media_duration` 和 `get_image_path` 方法中添加了 `CacheManager.RENDER` 来管理缓存路径。
- 在 `utils/ffmpeg.py` 的 `FFmpeg` 类中，多个方法添加了 `cache_type` 参数，并使用 `CacheManager.MEDIA`。

## Sourcery 总结

引入一个集中式缓存管理器，用于管理插件的缓存目录和过期策略，并将现有的缓存使用和清理逻辑迁移为使用该管理器。

新功能：
- 添加 `CacheManager`，为媒体、渲染、Logo、贴纸以及旧版缓存提供带类型的缓存目录，并支持按类型配置 `CachePolicy`。

改进：
- 重构定期缓存清理逻辑，以基于 `CacheManager` 的策略执行，并在多个缓存类型之间聚合日志。
- 更新下载、渲染、创作者工具、数据及 FFmpeg 工具，使其使用由 `CacheManager` 管理的缓存目录和带类型的缓存用法，包括新的按类型 `ensure_dir` 助手函数以及改进的类型检查。
- 在 `StreamDownloader` 中通过跟踪当前正在进行的下载任务，并对相同目标重用结果，避免对同一文件进行重复并发下载。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a centralized cache manager to manage plugin cache directories and expiration policies, and migrate existing cache usage and cleanup to use it.

New Features:
- Add a CacheManager with typed cache directories and per-type CachePolicy configurations for media, render, logo, sticker, and legacy caches.

Enhancements:
- Refactor periodic cache cleanup to use CacheManager-based policies and aggregated logging across cache types.
- Update download, rendering, creator, data, and FFmpeg utilities to use CacheManager-managed cache directories and typed cache usage, including a new per-type ensure_dir helper and improved type checks.
- Prevent duplicate concurrent downloads of the same file in StreamDownloader by tracking active download tasks and reusing results for identical targets.

</details>