### PR TITLE
feat(parser): 添加 LinkContent 类型并更新相关方法

### DIFF
--- a/src/nonebot_plugin_parser_lite/creator.py
+++ b/src/nonebot_plugin_parser_lite/creator.py
@@ -9,8 +9,10 @@ from .data import (
     AudioContent,
     Author,
     Comment,
+    ContentItem,
     GraphicContent,
     ImageContent,
+    LinkContent,
     LivePhotoContent,
     MediaContent,
     Stats,
@@ -324,7 +326,7 @@ class Creator:
     @staticmethod
     def comment(
         author: Author,
-        content: Sequence[MediaContent | str | None],
+        content: Sequence[ContentItem],
         timestamp: int | None = None,
         stats: Stats | None = None,
         replies: list[Comment] | None = None,
@@ -353,3 +355,15 @@ class Creator:
             replies=replies,
             parent_author=parent_author,
         )
+
+    @staticmethod
+    def link(url: str, text: str | None = None):
+        """
+        创建链接内容
+
+        :param url: 链接地址
+        :param text: 链接文本
+        """
+        if text is None:
+            text = url
+        return LinkContent(url=url, text=text)

--- a/src/nonebot_plugin_parser_lite/data.py
+++ b/src/nonebot_plugin_parser_lite/data.py
@@ -222,7 +222,7 @@ class Comment:
 
     author: Author
     """作者信息"""
-    content: Sequence[MediaContent | str | None]
+    content: Sequence[ContentItem]
     """评论内容，可以是文本或媒体对象"""
     timestamp: int | None
     """发布时间戳，单位秒"""
@@ -246,6 +246,16 @@ class Comment:
         return datetime.fromtimestamp(self.timestamp).strftime("%Y-%m-%d %H:%M:%S")
 
 
+@dataclass(slots=True)
+class LinkContent:
+    """链接信息"""
+
+    url: str
+    """链接地址"""
+    text: str
+    """链接文本"""
+
+
 @dataclass(repr=False, slots=True)
 class ParseResult:
     """完整的解析结果"""
@@ -256,7 +266,7 @@ class ParseResult:
     """作者信息"""
     url: str
     """来源链接"""
-    content: Sequence[MediaContent | str]
+    content: Sequence[ContentItem]
     """资源/文本内容"""
     title: str | None = field(default=None)
     """标题"""
@@ -331,3 +341,15 @@ class ParseResultKwargs(TypedDict, total=False):
     """评论列表"""
     ai_summary: str | None
     """AI摘要"""
+
+
+ContentItem = (
+    LinkContent
+    | LivePhotoContent
+    | StickerContent
+    | GraphicContent
+    | ImageContent
+    | VideoContent
+    | AudioContent
+    | str
+)

--- a/src/nonebot_plugin_parser_lite/parsers/base.py
+++ b/src/nonebot_plugin_parser_lite/parsers/base.py
@@ -32,7 +32,7 @@ from ..creator import Creator, VideoDownloadFunc
 from ..data import (
     Author,
     Comment,
-    MediaContent,
+    ContentItem,
     ParseResult,
     ParseResultKwargs,
     Platform,
@@ -303,7 +303,7 @@ class BaseParser:
         cls,
         author: Author,
         url: str,
-        content: Sequence[MediaContent | str],
+        content: Sequence[ContentItem],
         **kwargs: Unpack[ParseResultKwargs],
     ) -> ParseResult:
         """构建解析结果"""
@@ -555,7 +555,7 @@ class BaseParser:
     def create_comment(
         self,
         author: Author,
-        content: Sequence[MediaContent | str | None],
+        content: Sequence[ContentItem],
         timestamp: int | None = None,
         stats: Stats | None = None,
         replies: list[Comment] | None = None,
@@ -580,3 +580,12 @@ class BaseParser:
             replies=replies,
             parent_author=parent_author,
         )
+
+    def create_link(self, url: str, text: str | None = None):
+        """
+        创建链接内容
+
+        :param url: 链接地址
+        :param text: 链接文本
+        """
+        return Creator.link(url=url, text=text)

--- a/src/nonebot_plugin_parser_lite/parsers/bilibili/__init__.py
+++ b/src/nonebot_plugin_parser_lite/parsers/bilibili/__init__.py
@@ -28,8 +28,8 @@ from ..base import (
     Author,
     BaseParser,
     Comment,
+    ContentItem,
     MatchWithParams,
-    MediaContent,
     ParseException,
     Platform,
     PlatformEnum,
@@ -440,7 +440,7 @@ class BilibiliParser(BaseParser):
         dynamic_title = dynamic_info.title
 
         # 主体内容：文字 + 图片
-        contents: list[MediaContent | str] = []
+        contents: list[ContentItem] = []
         contents.extend(await self._build_dynamic_contents(dynamic_info))
         # 统计数据
         stats = self._extract_dynamic_stats(dynamic_info)
@@ -481,7 +481,7 @@ class BilibiliParser(BaseParser):
 
     async def _build_dynamic_contents(
         self, dynamic_info: DynamicInfo
-    ) -> list[MediaContent | str]:
+    ) -> list[ContentItem]:
         """构建动态主体 contents：文字 + 图片。
 
         - 连续文本节点合并为一个字符串
@@ -492,7 +492,7 @@ class BilibiliParser(BaseParser):
         if not rich_nodes and not medias:
             return []
 
-        contents: list[MediaContent | str] = []
+        contents: list[ContentItem] = []
         text_buffer: list[str] = []
 
         def flush_text_buffer() -> None:
@@ -742,7 +742,7 @@ class BilibiliParser(BaseParser):
         )
 
         # 按顺序处理图文内容（参考 parse_read 的逻辑）
-        contents: list[MediaContent | str] = []
+        contents: list[ContentItem] = []
 
         for node in opus_data.gen_text_img():
             if isinstance(node, ImageNode):
@@ -858,7 +858,7 @@ class BilibiliParser(BaseParser):
 
         await self.raise_if_in_black_list(room_data.mid)
 
-        contents: list[MediaContent | str] = [room_data.detail]
+        contents: list[ContentItem] = [room_data.detail]
         # 下载封面
         if cover := room_data.cover:
             contents.append(self.create_image(cover))
@@ -1115,7 +1115,7 @@ class BilibiliParser(BaseParser):
 
     def _format_content_with_emote(
         self, raw: str, emote: dict[str, Any]
-    ) -> list[str | MediaContent]:
+    ) -> list[ContentItem]:
         """将原始 message + emote 渲染为媒体列表"""
         if not raw:
             return [""]
@@ -1124,10 +1124,10 @@ class BilibiliParser(BaseParser):
 
         length = len(raw)
         cursor = 0
-        parts: list[str | MediaContent] = []
+        parts: list[ContentItem] = []
 
-        # 预处理所有可用表情：表情文本及封装好的 MediaContent
-        emote_entries: list[tuple[str, MediaContent]] = []
+        # 预处理所有可用表情：表情文本及封装好的 ContentItem
+        emote_entries: list[tuple[str, ContentItem]] = []
         for e in emote.values():
             if e.get("type") == 4:
                 continue
@@ -1146,7 +1146,7 @@ class BilibiliParser(BaseParser):
         while cursor < length:
             best_pos = length  # 当前找到的最近表情位置
             best_end = cursor
-            best_media: MediaContent | None = None
+            best_media = None
 
             # 在 [cursor, length) 范围内寻找「起始位置最靠前」的一次表情命中
             for text, media in emote_entries:

--- a/src/nonebot_plugin_parser_lite/parsers/bilibili/dynamic.py
+++ b/src/nonebot_plugin_parser_lite/parsers/bilibili/dynamic.py
@@ -5,7 +5,7 @@ from typing import Any
 from msgspec import Struct, convert
 
 from ...creator import Creator
-from ...data import MediaContent
+from ...data import ContentItem
 
 
 class AuthorInfo(Struct):
@@ -93,7 +93,7 @@ class DynamicMajor(Struct):
 
 
     @property
-    def medias(self) -> list[MediaContent]:
+    def medias(self) -> list[ContentItem]:
         """
         获取媒体资源列表（图片 + Live Photo）
         说明:
@@ -103,7 +103,7 @@ class DynamicMajor(Struct):
             - 对于 draw.pictures:
                 - 当前只有普通图片（没有 live）
         """
-        items: list[MediaContent] = []
+        items: list[ContentItem] = []
 
         # 优先处理 opus 图文里的图片 / livephoto
         if self.type == "MAJOR_TYPE_OPUS" and self.opus:
@@ -229,7 +229,7 @@ class DynamicInfo(Struct):
         return None
 
     @property
-    def medias(self) -> list[MediaContent]:
+    def medias(self) -> list[ContentItem]:
         """
         统一获取当前动态的媒体资源（图片 + Live Photo）
 

--- a/src/nonebot_plugin_parser_lite/parsers/buff/comments.py
+++ b/src/nonebot_plugin_parser_lite/parsers/buff/comments.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from msgspec import Struct, field
 
 from ...creator import Creator
-from ...data import MediaContent
+from ...data import ContentItem
 
 
 class Author(Struct):
@@ -28,9 +28,9 @@ class Comment(Struct):
     replies: list[Comment] = field(default_factory=list)
 
     @property
-    def content(self) -> list[MediaContent | str]:
+    def content(self) -> list[ContentItem]:
         """将原始 message + pictures 转为文本 + 媒体内容列表。"""
-        contents: list[MediaContent | str] = []
+        contents: list[ContentItem] = []
         text = self.message or ""
 
         for pic in self.pictures:

--- a/src/nonebot_plugin_parser_lite/parsers/buff/news.py
+++ b/src/nonebot_plugin_parser_lite/parsers/buff/news.py
@@ -3,7 +3,7 @@ from bs4.element import NavigableString
 from msgspec import Struct
 
 from ...creator import Creator
-from ...data import MediaContent
+from ...data import ContentItem
 from .share import ShareData
 
 
@@ -21,9 +21,9 @@ class News(Struct):
     share_data: ShareData
 
     @property
-    def content(self) -> list[MediaContent | str]:
+    def content(self) -> list[ContentItem]:
         """按 DOM 顺序依次产出文本 / 图片 / 视频内容列表。"""
-        data: list[MediaContent | str] = []
+        data: list[ContentItem] = []
         soup = BeautifulSoup(self.body, "html.parser")
 
         for element in soup.descendants:

--- a/src/nonebot_plugin_parser_lite/parsers/buff/topic.py
+++ b/src/nonebot_plugin_parser_lite/parsers/buff/topic.py
@@ -1,7 +1,7 @@
 from msgspec import Struct, field
 
 from ...creator import Creator
-from ...data import MediaContent
+from ...data import ContentItem
 from .share import ShareData
 
 
@@ -28,7 +28,7 @@ class Item(Struct):
     share_data: ShareData
 
     @property
-    def content(self) -> list[MediaContent | str]:
+    def content(self) -> list[ContentItem]:
         return [self.text, *[Creator.image(pic.image_url) for pic in self.pictures]]
 
 

--- a/src/nonebot_plugin_parser_lite/parsers/buff/video.py
+++ b/src/nonebot_plugin_parser_lite/parsers/buff/video.py
@@ -1,7 +1,7 @@
 from msgspec import Struct
 
 from ...creator import Creator
-from ...data import MediaContent
+from ...data import ContentItem
 from .share import ShareData
 
 
@@ -26,7 +26,7 @@ class Video(Struct):
     share_data: ShareData
 
     @property
-    def content(self) -> list[MediaContent | str]:
+    def content(self) -> list[ContentItem]:
         return [
             self.body,
             *[

--- a/src/nonebot_plugin_parser_lite/parsers/coolapk/util.py
+++ b/src/nonebot_plugin_parser_lite/parsers/coolapk/util.py
@@ -1,12 +1,12 @@
 import re
 
-from ...data import MediaContent
+from ...data import ContentItem
 from ...utils.format import replace_placeholder_to_sticker
 
 COOLAPK_PATTERN = re.compile(r"\[(?P<name>[^]]+)\]")
 
 
-def format_sticker(text: str) -> list[MediaContent | str]:
+def format_sticker(text: str) -> list[ContentItem]:
     return replace_placeholder_to_sticker(
         text,
         COOLAPK_PATTERN,

--- a/src/nonebot_plugin_parser_lite/parsers/douyin/__init__.py
+++ b/src/nonebot_plugin_parser_lite/parsers/douyin/__init__.py
@@ -9,8 +9,8 @@ from ...utils.browser import BrowserManager
 from ...utils.format import format_num
 from ..base import (
     BaseParser,
+    ContentItem,
     MatchWithParams,
-    MediaContent,
     ParseException,
     Platform,
     PlatformEnum,
@@ -89,7 +89,7 @@ class DouyinParser(BaseParser):
             ),
             Note,
         )
-        content: list[MediaContent | str] = [data.aweme.detail.desc]
+        content: list[ContentItem] = [data.aweme.detail.desc]
         content.extend(data.aweme.content)
         comments = [
             self.create_comment(
@@ -139,7 +139,7 @@ class DouyinParser(BaseParser):
 
         data = video_or_article_decoder.decode(matched[1].strip())
         video_data = data.video_data
-        content: list[MediaContent | str] = [video_data.desc]
+        content: list[ContentItem] = [video_data.desc]
 
         content.extend(video_data.medias)
 

--- a/src/nonebot_plugin_parser_lite/parsers/douyin/note.py
+++ b/src/nonebot_plugin_parser_lite/parsers/douyin/note.py
@@ -3,7 +3,7 @@ import re
 from msgspec import Struct, field
 
 from ...creator import Creator
-from ...data import MediaContent
+from ...data import ContentItem
 from ...utils.format import replace_placeholder_to_sticker
 
 DOUYIN_PATTERN = re.compile(r"\[(?P<name>[^]]+)\]")
@@ -69,8 +69,8 @@ class Aweme(Struct):
     music: Music | None = field(default=None)
 
     @property
-    def content(self) -> list[MediaContent | str]:
-        content: list[MediaContent | str] = [self.detail.desc.replace("\\n", "\n")]
+    def content(self) -> list[ContentItem]:
+        content: list[ContentItem] = [self.detail.desc.replace("\\n", "\n")]
         for image in self.detail.images:
             if image.livePhotoType == 1 and image.video:
                 content.append(
@@ -116,8 +116,8 @@ class Comment(Struct):
     ipLabel: str = ""
 
     @property
-    def content(self) -> list[MediaContent | str]:
-        content: list[MediaContent | str] = []
+    def content(self) -> list[ContentItem]:
+        content: list[ContentItem] = []
         content.extend(
             replace_placeholder_to_sticker(self.text, DOUYIN_PATTERN, "douyin")
         )

--- a/src/nonebot_plugin_parser_lite/parsers/douyin/video_or_article.py
+++ b/src/nonebot_plugin_parser_lite/parsers/douyin/video_or_article.py
@@ -5,7 +5,7 @@ from msgspec import Struct, field
 from msgspec.json import Decoder
 
 from ...creator import Creator
-from ...data import MediaContent
+from ...data import ContentItem
 
 
 class Avatar(Struct):
@@ -66,8 +66,8 @@ class VideoData(Struct):
     video: Video | None = None
 
     @property
-    def medias(self) -> list[MediaContent]:
-        medias: list[MediaContent] = []
+    def medias(self) -> list[ContentItem]:
+        medias: list[ContentItem] = []
         if self.images:
             medias.extend(
                 Creator.image(

--- a/src/nonebot_plugin_parser_lite/parsers/duitang/__init__.py
+++ b/src/nonebot_plugin_parser_lite/parsers/duitang/__init__.py
@@ -6,8 +6,8 @@ from ...utils.format import format_num
 from ..base import (
     BaseParser,
     Comment,
+    ContentItem,
     MatchWithParams,
-    MediaContent,
     Platform,
     PlatformEnum,
     handle,
@@ -30,7 +30,7 @@ class DuiTangParser(BaseParser):
             subject_type=0,
         )
 
-        content: list[MediaContent | str] = [
+        content: list[ContentItem] = [
             blog_data.msg,
             self.create_image(blog_data.photo.path),
         ]
@@ -62,7 +62,7 @@ class DuiTangParser(BaseParser):
             subject_type=23,
         )
 
-        content: list[MediaContent | str] = [
+        content: list[ContentItem] = [
             atlas_data.desc,
             *self.create_images(atlas_data.img_list),
         ]
@@ -174,7 +174,7 @@ class DuiTangParser(BaseParser):
         comments: list[Comment] = []
 
         for root_comment in comment_data.object_list:
-            root_content: list[MediaContent | str] = [
+            root_content: list[ContentItem] = [
                 root_comment.content,
                 *self.create_images(root_comment.img_list),
             ]

--- a/src/nonebot_plugin_parser_lite/parsers/heybox/model.py
+++ b/src/nonebot_plugin_parser_lite/parsers/heybox/model.py
@@ -8,7 +8,7 @@ from msgspec import Struct, field
 
 from ...constants import STICKER_CDN
 from ...creator import Creator
-from ...data import MediaContent
+from ...data import ContentItem
 from ...utils.format import replace_placeholder_to_sticker
 
 HEYBOX_PATTERN = re.compile(r"\[(?P<name>[^]]+)\]")
@@ -46,7 +46,7 @@ class CommentItem(Struct):
     imgs: list[Img] = field(default_factory=list)
 
     @property
-    def content(self) -> list[MediaContent | str]:
+    def content(self) -> list[ContentItem]:
         content = replace_placeholder_to_sticker(
             self.text, HEYBOX_PATTERN, "heybox", size_resolver
         )
@@ -94,9 +94,9 @@ class Link(Struct):
     video_thumb: str | None = None
 
     @property
-    def content(self) -> list[MediaContent | str]:
+    def content(self) -> list[ContentItem]:
         """格式化的富文本内容"""
-        content: list[MediaContent | str] = []
+        content: list[ContentItem] = []
         try:
             parts = json.loads(self.text)
             for part in parts:
@@ -126,12 +126,12 @@ class BaseResult(Struct):
     link: Link
 
 
-def extract_from_html(html: str) -> list[MediaContent | str]:
+def extract_from_html(html: str) -> list[ContentItem]:
     """
     从 HTML 内容中按顺序提取纯文本和图片
 
     :param html: 包含知乎内容的 HTML 字符串。
-    :return: 由纯文本字符串和 MediaContent 对象组成的列表
+    :return: 由纯文本字符串和 ContentItem 对象组成的列表
     """
 
     soup = BeautifulSoup(html.replace(r"\"", '"'), "html.parser")
@@ -140,7 +140,7 @@ def extract_from_html(html: str) -> list[MediaContent | str]:
     for noscript in soup.find_all("noscript"):
         noscript.decompose()
 
-    result: list[MediaContent | str] = []
+    result: list[ContentItem] = []
 
     for element in soup.descendants:
         # 处理图片标签

--- a/src/nonebot_plugin_parser_lite/parsers/hupu/util.py
+++ b/src/nonebot_plugin_parser_lite/parsers/hupu/util.py
@@ -2,13 +2,13 @@ from bs4 import BeautifulSoup
 from bs4.element import NavigableString, Tag
 
 from ...creator import Creator
-from ...data import MediaContent
+from ...data import ContentItem
 
 
-def parse_rich_content(html: str) -> list[MediaContent | str]:
+def parse_rich_content(html: str) -> list[ContentItem]:
     soup = BeautifulSoup(html.replace(r"\"", '"'), "html.parser")
 
-    result: list[MediaContent | str] = []
+    result: list[ContentItem] = []
     buffer: list[str] = []
 
     for item in _iter_media_and_text(soup):

--- a/src/nonebot_plugin_parser_lite/parsers/illu/drawingDetail.py
+++ b/src/nonebot_plugin_parser_lite/parsers/illu/drawingDetail.py
@@ -2,7 +2,7 @@ from msgspec import Struct
 from msgspec.json import Decoder
 
 from ...creator import Creator
-from ...data import MediaContent
+from ...data import ContentItem
 from .models import File, Time, User
 
 
@@ -21,7 +21,7 @@ class DrawingDetail(Struct):
     publishDate: Time
 
     @property
-    def medias(self) -> list[MediaContent | str]:
+    def medias(self) -> list[ContentItem]:
         return [
             self.content,
             *[Creator.image(url=image.url) for image in self.images],

--- a/src/nonebot_plugin_parser_lite/parsers/kuaishou/__init__.py
+++ b/src/nonebot_plugin_parser_lite/parsers/kuaishou/__init__.py
@@ -7,8 +7,8 @@ from ...exception import TipException
 from ...utils.cookie import ck2dict
 from ..base import (
     BaseParser,
+    ContentItem,
     MatchWithParams,
-    MediaContent,
     ParseException,
     Platform,
     PlatformEnum,
@@ -69,7 +69,7 @@ class KuaiShouParser(BaseParser):
 
         status = vision_video_detail_data.get("status")
         if status != 1:
-            raise TipException("不支持解析的视频") # 比如图集
+            raise TipException("不支持解析的视频")  # 比如图集
 
         try:
             response = await self.httpx.post(
@@ -110,12 +110,12 @@ class KuaiShouParser(BaseParser):
             comments = []
 
         visionVideoDetail = convert(vision_video_detail_data, VisionVideoDetail)
-        contents: list[MediaContent | str] = [visionVideoDetail.photo.caption]
+        content: list[ContentItem] = [visionVideoDetail.photo.caption]
         photoUrl = visionVideoDetail.photo.media_url
         cover_url = visionVideoDetail.photo.coverUrl
 
         if photoUrl:
-            contents.append(
+            content.append(
                 self.create_video(
                     url_or_task=photoUrl,
                     cover_url=cover_url,
@@ -124,7 +124,7 @@ class KuaiShouParser(BaseParser):
             )
 
         if not photoUrl and cover_url:
-            contents.append(self.create_image(url=cover_url))
+            content.append(self.create_image(url=cover_url))
 
         author = self.create_author(
             name=visionVideoDetail.author.name,
@@ -133,7 +133,7 @@ class KuaiShouParser(BaseParser):
         )
         return self.result(
             author=author,
-            content=contents,
+            content=content,
             stats=self.create_stats(
                 view_count=visionVideoDetail.photo.viewCount,
                 like_count=visionVideoDetail.photo.likeCount,

--- a/src/nonebot_plugin_parser_lite/parsers/kugou.py
+++ b/src/nonebot_plugin_parser_lite/parsers/kugou.py
@@ -7,7 +7,7 @@ from typing import ClassVar
 from msgspec import Struct, field
 from msgspec.json import Decoder
 
-from ..data import MediaContent, Platform
+from ..data import ContentItem, Platform
 from .base import BaseParser, MatchWithParams, ParseException, PlatformEnum, handle
 
 
@@ -171,7 +171,7 @@ class KuGouParser(BaseParser):
             raise ParseException(f"酷狗音乐解析失败: 歌词获取失败: {lyrics.info}")
         lyric = base64.b64decode(lyrics.content).decode(lyrics.charset)
         cover_url = playinfo.album_img.format(size=480)
-        contents: list[MediaContent] = [
+        contents: list[ContentItem] = [
             self.create_image(url=cover_url, need_send=False)
         ]
 

--- a/src/nonebot_plugin_parser_lite/parsers/kuwo.py
+++ b/src/nonebot_plugin_parser_lite/parsers/kuwo.py
@@ -1,6 +1,6 @@
 from typing import ClassVar
 
-from ..data import MediaContent, Platform
+from ..data import ContentItem, Platform
 from .base import (
     BaseParser,
     MatchWithParams,
@@ -56,7 +56,7 @@ class KuWoParser(BaseParser):
         audio_content = self.create_audio(audio_url, duration, audio_name=audio_name)
         dis_dura = display_duration(music_data["duration"])
 
-        contents: list[MediaContent] = []
+        contents: list[ContentItem] = []
         if cover_url := music_data.get("pic"):
             contents.append(self.create_image(cover_url, need_send=False))
 

--- a/src/nonebot_plugin_parser_lite/parsers/lofter/__init__.py
+++ b/src/nonebot_plugin_parser_lite/parsers/lofter/__init__.py
@@ -6,8 +6,8 @@ from nonebot import logger
 from ...utils.format import format_num
 from ..base import (
     BaseParser,
+    ContentItem,
     MatchWithParams,
-    MediaContent,
     ParseException,
     Platform,
     PlatformEnum,
@@ -76,7 +76,7 @@ class LofterParser(BaseParser):
             comment_list = convert(com_data.get("data") or {}, CommentList)
 
         # 构建正文内容：文本 + 媒体
-        contents: list[MediaContent | str] = [post.text]
+        contents: list[ContentItem] = [post.text]
         contents.extend(post.medias)
 
         author = post.blogInfo

--- a/src/nonebot_plugin_parser_lite/parsers/lofter/comments.py
+++ b/src/nonebot_plugin_parser_lite/parsers/lofter/comments.py
@@ -4,7 +4,7 @@ from bs4 import BeautifulSoup
 from msgspec import Struct, field
 
 from ...creator import Creator
-from ...data import MediaContent
+from ...data import ContentItem
 
 
 class BlogInfo(Struct):
@@ -42,7 +42,7 @@ class Comment(Struct):
     """子评论"""
 
     @property
-    def content(self) -> list[MediaContent | str]:
+    def content(self) -> list[ContentItem]:
         """
         将 Lofter 评论内容解析为 [文本/贴纸] 序列。
 
@@ -63,7 +63,7 @@ class Comment(Struct):
         if not emote_map:
             return [text]
 
-        contents: list[MediaContent | str] = []
+        contents: list[ContentItem] = []
         text_len = len(text)
         i = 0
         last_plain_start = 0

--- a/src/nonebot_plugin_parser_lite/parsers/lofter/post.py
+++ b/src/nonebot_plugin_parser_lite/parsers/lofter/post.py
@@ -5,7 +5,7 @@ from bs4 import BeautifulSoup
 from msgspec import Struct
 
 from ...creator import Creator
-from ...data import MediaContent
+from ...data import ContentItem
 
 
 class PostType(IntEnum):
@@ -75,5 +75,5 @@ class Post(Struct):
         return soup.get_text("\n", strip=True)
 
     @property
-    def medias(self) -> list[MediaContent]:
+    def medias(self) -> list[ContentItem]:
         return [Creator.image(photo["orign"]) for photo in json.loads(self.photoLinks)]

--- a/src/nonebot_plugin_parser_lite/parsers/netease.py
+++ b/src/nonebot_plugin_parser_lite/parsers/netease.py
@@ -9,8 +9,8 @@ from cryptography.hazmat.primitives.ciphers.aead import AESGCM
 
 from .base import (
     BaseParser,
+    ContentItem,
     MatchWithParams,
-    MediaContent,
     ParseException,
     Platform,
     PlatformEnum,
@@ -136,7 +136,7 @@ class NCMParser(BaseParser):
         url_no_params = audio_url.split("?", 1)[0]
         ext = url_no_params.rsplit(".", 1)[-1].lower() if "." in url_no_params else ""
         audio_type = ext if ext in {"flac", "wav", "m4a", "aac", "mp3"} else "mp3"
-        contents: list[MediaContent] = []
+        contents: list[ContentItem] = []
 
         audio_name = f"{title}-{artist}.{audio_type}"
         audio = self.create_audio(

--- a/src/nonebot_plugin_parser_lite/parsers/qsmusic/__init__.py
+++ b/src/nonebot_plugin_parser_lite/parsers/qsmusic/__init__.py
@@ -3,8 +3,8 @@ from typing import ClassVar
 
 from ..base import (
     BaseParser,
+    ContentItem,
     MatchWithParams,
-    MediaContent,
     ParseException,
     Platform,
     PlatformEnum,
@@ -38,7 +38,7 @@ class QSMusicParser(BaseParser):
         music_data = shareDecoder.decode(
             raw
         ).loaderData.track_page.audioWithLyricsOption
-        contents: list[MediaContent] = [
+        contents: list[ContentItem] = [
             self.create_audio(
                 music_data.url,
                 duration=music_data.duration,

--- a/src/nonebot_plugin_parser_lite/parsers/rednote/discovery.py
+++ b/src/nonebot_plugin_parser_lite/parsers/rednote/discovery.py
@@ -6,7 +6,7 @@ from msgspec import Struct, field
 from msgspec.json import Decoder
 
 from ...creator import Creator
-from ...data import MediaContent
+from ...data import ContentItem
 from ...utils.format import replace_placeholder_to_sticker
 
 REDNOTE_PATTERN = re.compile(r"\[(?P<name>[^]]+[a-zA-Z])\]")
@@ -141,7 +141,7 @@ class NoteDetail(Struct):
         return self.user.avatar
 
     @property
-    def medias(self) -> list[MediaContent]:
+    def medias(self) -> list[ContentItem]:
         """
         统一构建当前笔记的媒体内容列表
 
@@ -149,7 +149,7 @@ class NoteDetail(Struct):
         - 普通图片   -> ImageContent
         - 主视频     -> VideoContent (如果有视频，则第一张图是封面)
         """
-        items: list[MediaContent] = []
+        items: list[ContentItem] = []
         if self.video:
             items.append(
                 Creator.video(
@@ -200,7 +200,7 @@ class Comment(Struct):
     subComments: list[Comment] = field(default_factory=list)
 
     @property
-    def content(self) -> list[MediaContent | str]:
+    def content(self) -> list[ContentItem]:
         content = replace_placeholder_to_sticker(self.text, REDNOTE_PATTERN, "rednote")
         content.extend(
             Creator.image(

--- a/src/nonebot_plugin_parser_lite/parsers/tieba/utils.py
+++ b/src/nonebot_plugin_parser_lite/parsers/tieba/utils.py
@@ -7,7 +7,7 @@ from httpx import AsyncClient
 
 from ...constants import STICKER_CDN
 from ...creator import Creator
-from ...data import Comment, MediaContent
+from ...data import Comment, ContentItem
 from .models import (
     Contents,
     FragAt,
@@ -106,7 +106,7 @@ async def get_post(tid: int) -> Posts:
     return parse_res(data)
 
 
-def build_content(posts: Posts) -> list[MediaContent | str]:
+def build_content(posts: Posts) -> list[ContentItem]:
     """
     构建帖子内容
 
@@ -114,7 +114,7 @@ def build_content(posts: Posts) -> list[MediaContent | str]:
 
     :return: 富文本内容列表
     """
-    contents: list[MediaContent | str] = [posts.thread.title]
+    contents: list[ContentItem] = [posts.thread.title]
 
     # 提取帖子正文
     for part in posts.objs[0].contents.objs:
@@ -166,13 +166,13 @@ def build_content(posts: Posts) -> list[MediaContent | str]:
     return contents
 
 
-def build_comment(contents: Contents) -> list[MediaContent | str]:
+def build_comment(contents: Contents) -> list[ContentItem]:
     """
     构建帖子评论内容
 
     :param contents: 内容碎片列表
     """
-    content: list[MediaContent | str] = []
+    content: list[ContentItem] = []
     for part in contents.objs:
         if isinstance(part, FragText):
             content.append(part.text)

--- a/src/nonebot_plugin_parser_lite/parsers/weibo/article.py
+++ b/src/nonebot_plugin_parser_lite/parsers/weibo/article.py
@@ -3,7 +3,7 @@ from msgspec import Struct, field
 from msgspec.json import Decoder
 
 from ...creator import Creator
-from ...data import MediaContent
+from ...data import ContentItem
 
 
 class UserInfo(Struct):
@@ -28,7 +28,7 @@ class Data(Struct):
     @property
     def content(self):
         soup = BeautifulSoup(self.html, "html.parser")
-        content: list[MediaContent | str] = []
+        content: list[ContentItem] = []
 
         for element in soup.find_all(["p", "img"]):
             if not isinstance(element, Tag):

--- a/src/nonebot_plugin_parser_lite/parsers/x/__init__.py
+++ b/src/nonebot_plugin_parser_lite/parsers/x/__init__.py
@@ -6,8 +6,8 @@ from msgspec import convert
 from ...utils.format import format_num
 from ..base import (
     BaseParser,
+    ContentItem,
     MatchWithParams,
-    MediaContent,
     ParseException,
     ParseResult,
     Platform,
@@ -31,7 +31,7 @@ class XParser(BaseParser):
         tweet = raw.result.as_tweet
         legacy = tweet.legacy
 
-        content: list[MediaContent | str] = [legacy.text]
+        content: list[ContentItem] = [legacy.text]
         content.extend(legacy.medias)
 
         user = tweet.core.user_results.result

--- a/src/nonebot_plugin_parser_lite/parsers/x/model.py
+++ b/src/nonebot_plugin_parser_lite/parsers/x/model.py
@@ -5,7 +5,7 @@ from datetime import datetime
 from msgspec import Struct, field
 
 from ...creator import Creator
-from ...data import MediaContent
+from ...data import ContentItem
 
 
 class Views(Struct):
@@ -87,12 +87,12 @@ class TweetLegacy(Struct):
     extended_entities: ExtendedEntities | None = None
 
     @property
-    def medias(self) -> list[MediaContent]:
+    def medias(self) -> list[ContentItem]:
         """返回所有媒体的资源"""
         if not self.extended_entities or not self.extended_entities.media:
             return []
 
-        medias: list[MediaContent] = []
+        medias: list[ContentItem] = []
 
         for media in self.extended_entities.media:
             # 图片：直接用 media_url_https

--- a/src/nonebot_plugin_parser_lite/parsers/zhihu/util.py
+++ b/src/nonebot_plugin_parser_lite/parsers/zhihu/util.py
@@ -2,7 +2,7 @@ from bs4 import BeautifulSoup
 from bs4.element import NavigableString, Tag
 
 from ...creator import Creator
-from ...data import MediaContent
+from ...data import ContentItem
 from ...download import DOWNLOADER
 
 VIDEO_HEADER = {**DOWNLOADER.headers, "x-app-za": "OS=webplayer", "x-referer": ""}
@@ -49,14 +49,14 @@ async def fetch_video(video_id: str, content_type: str):
     )
 
 
-async def parse_rich_content(html: str, content_type: str) -> list[MediaContent | str]:
+async def parse_rich_content(html: str, content_type: str) -> list[ContentItem]:
     """
     将知乎内容 HTML 解析为有顺序的文本 + 媒体列表
     """
     soup = BeautifulSoup(html.replace(r"\"", '"'), "html.parser")
     _clean_soup(soup)
 
-    result: list[MediaContent | str] = []
+    result: list[ContentItem] = []
     buffer: list[str] = []
 
     async for item in _iter_media_and_text(soup, content_type):

--- a/src/nonebot_plugin_parser_lite/render/templates/macros.jinja
+++ b/src/nonebot_plugin_parser_lite/render/templates/macros.jinja
@@ -268,10 +268,29 @@
                             '<div class="absolute bottom-2 right-2 flex items-center bg-black/60 text-white h-[19px] px-1.5 rounded-[2px] text-[10px] font-mono">' ~ cont.display_duration ~ '</div>'
                             '</div>'
                         ) %}
-        {% endif %}
-    {% endfor %}
-    {% set _ = flush_images() %}
-    {{ html_parts|join("") | safe }}
+            {# 6. 链接卡片 #}
+        {% elif cls == 'LinkContent' %}
+            {% set _ = flush_images() %}
+            {% set _ = html_parts.append(
+                            '<a href="'~(url|e)~'"
+               target="_blank"
+               rel="noreferrer noopener"
+               class="block mt-3 rounded-xl border border-slate-200 bg-slate-50 hover:bg-slate-100 transition-colors duration-150 shadow-sm">
+                            <div class="px-3 py-2.5">
+                                <div class="flex items-center justify-between space-x-2">
+                                    <div class="flex-1 min-w-0">
+                                        <div class="text-sm font-semibold text-slate-800 truncate">'~(cont.text|e)~'</div>
+                                        <div class="mt-0.5 text-xs text-slate-500 line-clamp-2">'~(cont.url|e)~'</div>
+                                    </div>
+                                </div>
+                            </div>
+                        </a>'
+                    ) %}
+    {% endif %}
+{% endif %}
+{% endfor %}
+{% set _ = flush_images() %}
+{{ html_parts|join("") | safe }}
 {% endmacro %}
 {# 3. 内容+转发宏（Tailwind 样式 + is_repost） #}
 {% macro render_content(result, is_repost=False) %}

--- a/src/nonebot_plugin_parser_lite/render/templates/macros.jinja
+++ b/src/nonebot_plugin_parser_lite/render/templates/macros.jinja
@@ -272,7 +272,7 @@
         {% elif cls == 'LinkContent' %}
             {% set _ = flush_images() %}
             {% set _ = html_parts.append(
-                            '<a href="'~(url|e)~'"
+                            '<a href="'~(cont.url|e)~'"
                target="_blank"
                rel="noreferrer noopener"
                class="block mt-3 rounded-xl border border-slate-200 bg-slate-50 hover:bg-slate-100 transition-colors duration-150 shadow-sm">

--- a/src/nonebot_plugin_parser_lite/render/templates/tailwind.css
+++ b/src/nonebot_plugin_parser_lite/render/templates/tailwind.css
@@ -62,6 +62,8 @@
     --aspect-video: 16 / 9;
     --default-font-family: var(--font-sans);
     --default-mono-font-family: var(--font-mono);
+    --default-transition-duration: 150ms;
+    --default-transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
   }
 }
 @layer base {
@@ -774,6 +776,9 @@
   .inline-block {
     display: inline-block;
   }
+  .block {
+    display: block;
+  }
   .mt-1 {
     margin-top: calc(var(--spacing) * 1);
   }
@@ -860,6 +865,34 @@
   }
   .whitespace-pre-wrap {
     white-space: pre-wrap;
+  }
+  .duration-150 {
+    --tw-duration: 150ms;
+    transition-duration: 150ms;
+  }
+  .line-clamp-2 {
+    overflow: hidden;
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+  }
+  .transition-colors {
+    transition-property:
+      color, background-color, border-color, outline-color,
+      text-decoration-color, fill, stroke, --tw-gradient-from,
+      --tw-gradient-via, --tw-gradient-to;
+    transition-timing-function: var(
+      --tw-ease,
+      var(--default-transition-timing-function)
+    );
+    transition-duration: var(--tw-duration, var(--default-transition-duration));
+  }
+  .hover\:bg-slate-100 {
+    &:hover {
+      @media (hover: hover) {
+        background-color: var(--color-slate-100);
+      }
+    }
   }
 }
 @property --tw-space-y-reverse {
@@ -992,6 +1025,10 @@
   inherits: false;
 }
 @property --tw-backdrop-sepia {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-duration {
   syntax: "*";
   inherits: false;
 }

--- a/src/nonebot_plugin_parser_lite/utils/format.py
+++ b/src/nonebot_plugin_parser_lite/utils/format.py
@@ -4,7 +4,7 @@ from typing import Final, Literal
 
 from ..constants import STICKER_CDN
 from ..creator import Creator
-from ..data import MediaContent
+from ..data import ContentItem
 
 DEFAULT_PLACEHOLDER_PATTERN: Final = re.compile(r"\[(?P<name>[^]]+)\]")
 
@@ -14,7 +14,7 @@ def replace_placeholder_to_sticker(
     placeholder_pattern: re.Pattern[str],
     platform: str,
     size_resolver: Callable[[str], Literal["small", "medium"]] | None = None,
-) -> list[MediaContent | str]:
+) -> list[ContentItem]:
     """
     将包含表情占位符的文本拆分为文本与表情。
 
@@ -24,12 +24,12 @@ def replace_placeholder_to_sticker(
     :param size_resolver: 一个接收表情名称并返回 size 字符串的函数，例如
                           lambda name: "small" / "medium"
                           若为 None，则默认使用 "small"。
-    :return: 由普通文本和 MediaContent 组成的列表，顺序与原字符串一致。
+    :return: 由普通文本和 ContentItem 组成的列表，顺序与原字符串一致。
     """
     if not placeholder_pattern.search(text):
         return [text]
 
-    result: list[MediaContent | str] = []
+    result: list[ContentItem] = []
     last_pos = 0
 
     for match in placeholder_pattern.finditer(text):


### PR DESCRIPTION
新增了一个 `LinkContent` 类型用于表示链接信息，并在相关类和方法中使用 `ContentItem` 代替 `MediaContent | str | None` 以统一内容类型。

- 在 `creator.py` 中添加了 `LinkContent` 类型的定义以及 `link` 静态方法，用于创建链接内容。
- 在 `data.py` 中定义了 `LinkContent` 类型的 `dataclass`，并新增了 `ContentItem` 类型的联合类型定义。
- 在多个解析器文件（如 `bilibili/__init__.py`, `buff/comments.py`, `buff/news.py`, `buff/topic.py`, `buff/video.py`, `coolapk/util.py`, `douyin/__init__.py`, `douyin/note.py`, `douyin/video_or_article.py`, `duitang/__init__.py`, `heybox/model.py`, `hupu/util.py`, `illu/drawingDetail.py`, `kuaishou/__init__.py`, `kugou.py`, `kuwo.py`, `lofter/__init__.py`, `lofter/comments.py`, `lofter/post.py`, `netease.py`, `qsmusic/__init__.py`, `rednote/discovery.py`, `tieba/utils.py`, `weibo/article.py`, `x/__init__.py`, `x/model.py`, `zhihu/util.py`）中，将 `MediaContent | str | None` 或 `MediaContent | str` 替换为 `ContentItem`，以支持统一的内容类型。
- 在 `render/templates/macros.jinja` 中添加了对 `LinkContent` 的渲染逻辑。
- 在 `render/templates/tailwind.css` 中添加了支持 `LinkContent` 渲染所需的 CSS 样式。

## Summary by Sourcery

引入统一的 `ContentItem` 类型，其中新增 `LinkContent` 变体，并在解析器、内容创建器以及渲染模板中采用该类型，以实现一致的富内容处理。

新功能：
- 添加 `LinkContent` 数据类以及创建器/辅助方法，用于在解析结果中表示链接卡片内容。
- 在 `macros.jinja` 中使用基于 Tailwind 的样式类将 `LinkContent` 渲染为样式化的链接卡片，展示文本和 URL。

改进：
- 通过在核心数据模型和解析工具中使用 `ContentItem` 类型，替换原有的 `MediaContent | str | None` 联合类型，实现文本和媒体处理的统一。
- 扩展 Tailwind CSS 工具类，增加过渡效果、布局(Display)和多行截断(line-clamp)等辅助类，用于新的链接卡片渲染。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a unified ContentItem type that now includes a new LinkContent variant and adopt it across parsers, creators, and render templates for consistent rich content handling.

New Features:
- Add LinkContent dataclass and creator/helper methods to represent link card content in parse results.
- Render LinkContent as styled link cards in macros.jinja with Tailwind-based classes for text and URL display.

Enhancements:
- Unify text and media handling by replacing MediaContent | str | None unions with the ContentItem type in core data models and parser utilities.
- Extend Tailwind CSS utilities with transition, display, and line-clamp helpers used by the new link card rendering.

</details>