### PR TITLE
feat(heybox): 支持设备token持久化保存

### DIFF
--- a/src/nonebot_plugin_parser_lite/parsers/heybox/__init__.py
+++ b/src/nonebot_plugin_parser_lite/parsers/heybox/__init__.py
@@ -13,6 +13,7 @@ from ..base import (
     Platform,
     PlatformEnum,
     handle,
+    pconfig,
 )
 from .encrypt import build_url
 from .model import BaseResult
@@ -22,7 +23,6 @@ class HeyBoxParser(BaseParser):
     platform: ClassVar[Platform] = Platform(
         name=PlatformEnum.HEYBOX, display_name="小黑盒"
     )
-    x_xhh_tokenid: str = ""
 
     def __init__(self):
         super().__init__()
@@ -34,23 +34,30 @@ class HeyBoxParser(BaseParser):
                 "Accept": "application/json, text/plain, */*",
             }
         )
+        self.device_path = pconfig.config_dir / "heybox_device.txt"
+        self.device_id: str = ""
+
+    async def ensure_token(self):
+        if not self.device_id:
+            if await self.device_path.exists():
+                self.device_id = await self.device_path.read_text(encoding="utf-8")
+            else:
+                tab = await BrowserManager.new_tab(url="https://www.xiaoheihe.cn/")
+                self.device_id = tab.run_js("window.SMSdk.getDeviceId()", as_expr=True)
+                tab.close()
+                logger.info(f"成功获取到小黑盒tokenid: {self.device_id[:5]}...")
+                await self.device_path.write_text(self.device_id)
 
     @handle("api.xiaoheihe.cn/v3/bbs/app/api/web/share", params={"link_id": {}})
     @handle("xiaoheihe.cn/bbs/post_share", params={"link_id": {}})
     @handle("xiaoheihe.cn/app/bbs", r"link\/(?P<link_id>[A-Za-z0-9]+)")
     async def _parse(self, searched: MatchWithParams):
         link_id = searched["link_id"]
-
-        if not self.x_xhh_tokenid:
-            tab = await BrowserManager.new_tab(url="https://www.xiaoheihe.cn/")
-            self.x_xhh_tokenid = tab.run_js("window.SMSdk.getDeviceId()", as_expr=True)
-            logger.info(f"成功获取到小黑盒tokenid: {self.x_xhh_tokenid[:5]}...")
-            tab.close()
-
+        await self.ensure_token()
         response = await self.httpx.get(
             build_url(link_id),
             headers=self.headers,
-            cookies={"x_xhh_tokenid": self.x_xhh_tokenid},
+            cookies={"x_xhh_tokenid": self.device_id},
         )
         response.raise_for_status()
         res = response.json()

--- a/src/nonebot_plugin_parser_lite/parsers/heybox/__init__.py
+++ b/src/nonebot_plugin_parser_lite/parsers/heybox/__init__.py
@@ -40,13 +40,15 @@ class HeyBoxParser(BaseParser):
     async def ensure_token(self):
         if not self.device_id:
             if await self.device_path.exists():
-                self.device_id = await self.device_path.read_text(encoding="utf-8")
+                self.device_id = (
+                    await self.device_path.read_text(encoding="utf-8")
+                ).strip()
             else:
                 tab = await BrowserManager.new_tab(url="https://www.xiaoheihe.cn/")
                 self.device_id = tab.run_js("window.SMSdk.getDeviceId()", as_expr=True)
                 tab.close()
                 logger.info(f"成功获取到小黑盒tokenid: {self.device_id[:5]}...")
-                await self.device_path.write_text(self.device_id)
+                await self.device_path.write_text(self.device_id.strip())
 
     @handle("api.xiaoheihe.cn/v3/bbs/app/api/web/share", params={"link_id": {}})
     @handle("xiaoheihe.cn/bbs/post_share", params={"link_id": {}})


### PR DESCRIPTION
- 在HeyBoxParser类中引入`pconfig`以获取配置目录路径。
- 添加`device_path`属性，用于存储设备ID文件的路径。
- 添加`device_id`属性，用于存储设备ID。
- 新增`ensure_token`方法，用于确保获取并保存设备ID（tokenid），首先尝试从文件中读取设备ID，如果文件不存在，则通过浏览器获取设备ID并保存到文件中。
- 在`_parse`方法中调用`ensure_token`方法以确保在进行API请求前已获取到设备ID。
- 替换`x_xhh_tokenid`为`device_id`，用于在请求头中传递设备ID。

## Summary by Sourcery

在多次运行之间持久化 HeyBox 设备 token，并在 API 请求中复用该 token，而不是每次都获取新的 token。

新功能：
- 在配置目录文件中新增对 HeyBox 设备 ID（token）的持久化存储，并在后续请求中复用它。

增强改进：
- 将 HeyBox 设备 ID 的获取重构为一个 `ensure_token` 辅助函数，在 API 调用前执行，并在请求 cookies 中统一使用该 token。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Persist HeyBox device tokens across runs and reuse them for API requests instead of fetching a new token each time.

New Features:
- Add persistent storage of the HeyBox device ID (token) in a config-directory file and reuse it for subsequent requests.

Enhancements:
- Refactor HeyBox device ID acquisition into an ensure_token helper that is invoked before API calls and standardize its usage in request cookies.

</details>