### PR TITLE
feat(matcher): 懒下载支持不发送命令提示

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,9 @@ plite_need_forward_contents=True
 # [可选] 是否开启懒下载模式，仅在用户请求时才下载视频
 plite_lazy_download=False
 
+# [可选] 懒下载是否发送命令提示
+plite_lazy_downlaod_tip=False
+
 # [可选] 懒下载模式等待命令超时时间
 plite_lazy_download_timeout=30
 

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ plite_need_forward_contents=True
 plite_lazy_download=False
 
 # [可选] 懒下载是否发送命令提示
-plite_lazy_downlaod_tip=False
+plite_lazy_download_tip=False
 
 # [可选] 懒下载模式等待命令超时时间
 plite_lazy_download_timeout=30

--- a/src/nonebot_plugin_parser_lite/config.py
+++ b/src/nonebot_plugin_parser_lite/config.py
@@ -42,6 +42,8 @@ class Config(BaseModel):
     """是否需要合并转发内容(大于四项时始终转发)"""
     plite_lazy_download: bool = False
     """是否开启懒下载模式，仅在用户请求时才下载视频"""
+    plite_lazy_downlaod_tip: bool = False
+    """懒下载是否发送命令提示"""
     plite_lazy_download_timeout: int = 30
     """懒下载模式等待命令超时时间"""
     plite_download_command: list[str] = ["xz", "下载"]
@@ -106,6 +108,7 @@ class Config(BaseModel):
     def bili_ck(self) -> str | None:
         """bilibili cookies"""
         return self.plite_bili_ck
+
     @property
     def need_upload_audio(self) -> bool:
         """是否需要上传音频文件"""
@@ -150,6 +153,11 @@ class Config(BaseModel):
     def lazy_download(self) -> bool:
         """是否开启懒下载模式"""
         return self.plite_lazy_download
+
+    @property
+    def lazy_downlaod_tip(self) -> bool:
+        """懒下载是否发送命令提示"""
+        return self.plite_lazy_downlaod_tip
 
     @property
     def lazy_download_timeout(self) -> int:

--- a/src/nonebot_plugin_parser_lite/config.py
+++ b/src/nonebot_plugin_parser_lite/config.py
@@ -42,7 +42,7 @@ class Config(BaseModel):
     """是否需要合并转发内容(大于四项时始终转发)"""
     plite_lazy_download: bool = False
     """是否开启懒下载模式，仅在用户请求时才下载视频"""
-    plite_lazy_downlaod_tip: bool = False
+    plite_lazy_download_tip: bool = False
     """懒下载是否发送命令提示"""
     plite_lazy_download_timeout: int = 30
     """懒下载模式等待命令超时时间"""
@@ -155,9 +155,9 @@ class Config(BaseModel):
         return self.plite_lazy_download
 
     @property
-    def lazy_downlaod_tip(self) -> bool:
+    def lazy_download_tip(self) -> bool:
         """懒下载是否发送命令提示"""
-        return self.plite_lazy_downlaod_tip
+        return self.plite_lazy_download_tip
 
     @property
     def lazy_download_timeout(self) -> int:

--- a/src/nonebot_plugin_parser_lite/matchers/__init__.py
+++ b/src/nonebot_plugin_parser_lite/matchers/__init__.py
@@ -140,7 +140,6 @@ async def parser_handler(
     """统一的解析处理器"""
     cache_key = sr.searched.cache_key
 
-    # 1. 从缓存获取或重新解析
     result = _RESULT_CACHE.get(cache_key)
     if result is None:
         parser = get_parser(sr.keyword)
@@ -150,10 +149,8 @@ async def parser_handler(
     else:
         logger.debug(f"命中缓存: {cache_key}, 结果: {result!r}")
 
-    # 2. 渲染并发送
     summary_msg = await RENDERER.render_messages(result)
     await summary_msg.send()
-    # 若所有内容都是纯文本，则无需再发送媒体
     contents = list(result.content)
     if result.repost:
         contents.extend(result.repost.content)
@@ -161,11 +158,12 @@ async def parser_handler(
     if not has_media:
         return
     if pconfig.lazy_download:
-        download_cmd = ", ".join(pconfig.download_command)
-        await UniMessage(
-            f"请在{LazyManager.TIMEOUT_SECONDS}秒内发送以下命令之一来获取媒体资源: "
-            f"\n{download_cmd}"
-        ).send()
+        if pconfig.lazy_downlaod_tip:
+            download_cmd = ", ".join(pconfig.download_command)
+            await UniMessage(
+                f"请在{LazyManager.TIMEOUT_SECONDS}秒内发送以下命令之一来获取媒体资源: "
+                f"\n{download_cmd}"
+            ).send()
         LazyManager.add(session.user.id, result)
         return
 

--- a/src/nonebot_plugin_parser_lite/matchers/__init__.py
+++ b/src/nonebot_plugin_parser_lite/matchers/__init__.py
@@ -158,7 +158,7 @@ async def parser_handler(
     if not has_media:
         return
     if pconfig.lazy_download:
-        if pconfig.lazy_downlaod_tip:
+        if pconfig.lazy_download_tip:
             download_cmd = ", ".join(pconfig.download_command)
             await UniMessage(
                 f"请在{LazyManager.TIMEOUT_SECONDS}秒内发送以下命令之一来获取媒体资源: "


### PR DESCRIPTION
## Summary by Sourcery

为懒加载下载模式在媒体可用时是否发送命令提示，添加可配置的控制选项。

新功能：
- 引入一个配置标志，用于切换在懒加载下载模式下是否发送命令提示。
- 在面向用户的配置和 README 文档中公开懒加载下载命令提示选项。

文档：
- 在 README 中记录新的懒加载下载命令提示配置选项。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add configurable control over whether lazy download mode sends command prompts when media is available.

New Features:
- Introduce a configuration flag to toggle sending command prompts in lazy download mode.
- Expose the lazy download command prompt option in the user-facing configuration and README documentation.

Documentation:
- Document the new lazy download command prompt configuration option in README.

</details>