### PR TITLE
feat(download): 添加 curl_cffi 支持以增强下载功能

### DIFF
--- a/src/nonebot_plugin_parser_lite/creator.py
+++ b/src/nonebot_plugin_parser_lite/creator.py
@@ -52,6 +52,7 @@ class Creator:
         id: str | None = None,
         location: str | None = None,
         ext_headers: dict[str, str] | None = None,
+        use_curl_cffi: bool = False,
     ):
         """
         创建作者对象
@@ -62,10 +63,15 @@ class Creator:
         :param id: 作者 ID
         :param location: 位置信息
         :param ext_headers: 额外请求头
+        :param use_curl_cffi: 是否使用 curl_cffi 下载头像
         """
 
         avatar_task = (
-            DOWNLOADER.download_img(url=avatar_url, ext_headers=ext_headers)
+            DOWNLOADER.download_img(
+                url=avatar_url,
+                ext_headers=ext_headers,
+                use_curl_cffi=use_curl_cffi,
+            )
             if avatar_url
             else None
         )
@@ -85,6 +91,7 @@ class Creator:
         video_name: str | None = None,
         need_send: bool = True,
         ext_headers: dict[str, str] | None = None,
+        use_curl_cffi: bool = False,
     ):
         """
         创建视频内容,
@@ -98,14 +105,22 @@ class Creator:
         :param video_name: 视频名称
         :param need_send: 是否发送
         :param ext_headers: 额外请求头
+        :param use_curl_cffi: 是否使用 curl_cffi 下载视频/封面
         """
         cover_task = None
         if cover_url:
-            cover_task = DOWNLOADER.download_img(url=cover_url, ext_headers=ext_headers)
+            cover_task = DOWNLOADER.download_img(
+                url=cover_url,
+                ext_headers=ext_headers,
+                use_curl_cffi=use_curl_cffi,
+            )
         if isinstance(url_or_task, str):
             # 1) 传入 URL: 使用默认下载逻辑
             video_task = DOWNLOADER.download_video(
-                url=url_or_task, video_name=video_name, ext_headers=ext_headers
+                url=url_or_task,
+                video_name=video_name,
+                ext_headers=ext_headers,
+                use_curl_cffi=use_curl_cffi,
             )
         elif isinstance(url_or_task, DownloadTaskWrapper):
             # 2) 传入 DownloadTaskWrapper: 保持原样
@@ -124,6 +139,7 @@ class Creator:
                 kwargs={},
                 url=download_func.video_url,
                 ext_headers=download_func.ext_headers,
+                use_curl_cffi=use_curl_cffi,
             )
         else:
             # 4) 传入了不受支持的类型：立即报错，避免 AttributeError
@@ -140,16 +156,22 @@ class Creator:
     def videos(
         video_urls: list[str],
         ext_headers: dict[str, str] | None = None,
+        use_curl_cffi: bool = False,
     ):
         """
         创建视频内容列表
 
         :param video_urls: 视频 URL 列表
         :param ext_headers: 额外请求头
+        :param use_curl_cffi: 是否使用 curl_cffi 下载
         """
 
         return [
-            Creator.video(url_or_task=url, ext_headers=ext_headers)
+            Creator.video(
+                url_or_task=url,
+                ext_headers=ext_headers,
+                use_curl_cffi=use_curl_cffi,
+            )
             for url in video_urls
         ]
 
@@ -159,6 +181,7 @@ class Creator:
         img_name: str | None = None,
         need_send: bool = True,
         ext_headers: dict[str, str] | None = None,
+        use_curl_cffi: bool = False,
     ):
         """
         创建图片内容
@@ -167,10 +190,14 @@ class Creator:
         :param img_name: 图片名称
         :param need_send: 是否发送
         :param ext_headers: 额外请求头
+        :param use_curl_cffi: 是否使用 curl_cffi 下载
         """
 
         task = DOWNLOADER.download_img(
-            url=url, img_name=img_name, ext_headers=ext_headers
+            url=url,
+            img_name=img_name,
+            ext_headers=ext_headers,
+            use_curl_cffi=use_curl_cffi,
         )
 
         return _with_need_send(ImageContent(path_task=task), need_send)
@@ -179,15 +206,24 @@ class Creator:
     def images(
         image_urls: list[str],
         ext_headers: dict[str, str] | None = None,
+        use_curl_cffi: bool = False,
     ):
         """
         创建图片内容列表
 
         :param image_urls: 图片 URL 列表
         :param ext_headers: 额外请求头
+        :param use_curl_cffi: 是否使用 curl_cffi 下载
         """
 
-        return [Creator.image(url=url, ext_headers=ext_headers) for url in image_urls]
+        return [
+            Creator.image(
+                url=url,
+                ext_headers=ext_headers,
+                use_curl_cffi=use_curl_cffi,
+            )
+            for url in image_urls
+        ]
 
     @staticmethod
     def audio(
@@ -196,6 +232,7 @@ class Creator:
         audio_name: str | None = None,
         need_send: bool = True,
         ext_headers: dict[str, str] | None = None,
+        use_curl_cffi: bool = False,
     ):
         """
         创建音频内容
@@ -205,10 +242,14 @@ class Creator:
         :param audio_name: 音频名称
         :param need_send: 是否发送
         :param ext_headers: 额外请求头
+        :param use_curl_cffi: 是否使用 curl_cffi 下载
         """
 
         task = DOWNLOADER.download_audio(
-            url=url, audio_name=audio_name, ext_headers=ext_headers
+            url=url,
+            audio_name=audio_name,
+            ext_headers=ext_headers,
+            use_curl_cffi=use_curl_cffi,
         )
 
         return _with_need_send(
@@ -222,6 +263,7 @@ class Creator:
         alt: str | None = None,
         need_send: bool = True,
         ext_headers: dict[str, str] | None = None,
+        use_curl_cffi: bool = False,
     ):
         """
         图片,此图片不参与九宫格
@@ -231,10 +273,14 @@ class Creator:
         :param alt: 图片描述
         :param need_send: 是否发送
         :param ext_headers: 额外请求头
+        :param use_curl_cffi: 是否使用 curl_cffi 下载
         """
 
         image_task = DOWNLOADER.download_img(
-            url=url, img_name=img_name, ext_headers=ext_headers
+            url=url,
+            img_name=img_name,
+            ext_headers=ext_headers,
+            use_curl_cffi=use_curl_cffi,
         )
         return _with_need_send(GraphicContent(path_task=image_task, alt=alt), need_send)
 
@@ -244,6 +290,7 @@ class Creator:
         size: Literal["small", "medium"] = "medium",
         desc: str | None = None,
         ext_headers: dict[str, str] | None = None,
+        use_curl_cffi: bool = False,
     ):
         """
         创建贴纸内容
@@ -254,12 +301,14 @@ class Creator:
             - medium: 文字大小的两倍大一点
         :param desc: 贴纸描述
         :param ext_headers: 额外请求头
+        :param use_curl_cffi: 是否使用 curl_cffi 下载
         """
 
         image_task = DOWNLOADER.download_img(
             url=url,
             ext_headers=ext_headers,
             cache_type=CacheManager.STICKER,
+            use_curl_cffi=use_curl_cffi,
         )
         return StickerContent(path_task=image_task, size=size, desc=desc)
 
@@ -270,6 +319,7 @@ class Creator:
         bgm_url: str | None = None,
         need_send: bool = True,
         ext_headers: dict[str, str] | None = None,
+        use_curl_cffi: bool = False,
     ):
         """
         创建  iPhone Live Photo 内容
@@ -279,12 +329,25 @@ class Creator:
         :param bgm_url: iPhone Live Photo 背景音乐
         :param need_send: 是否发送
         :param ext_headers: 额外请求头
+        :param use_curl_cffi: 是否使用 curl_cffi 下载
         """
 
-        video_task = DOWNLOADER.download_video(url=video_url, ext_headers=ext_headers)
-        image_task = DOWNLOADER.download_img(url=image_url, ext_headers=ext_headers)
+        video_task = DOWNLOADER.download_video(
+            url=video_url,
+            ext_headers=ext_headers,
+            use_curl_cffi=use_curl_cffi,
+        )
+        image_task = DOWNLOADER.download_img(
+            url=image_url,
+            ext_headers=ext_headers,
+            use_curl_cffi=use_curl_cffi,
+        )
         if bgm_url:
-            bgm_task = DOWNLOADER.download_audio(url=bgm_url, ext_headers=ext_headers)
+            bgm_task = DOWNLOADER.download_audio(
+                url=bgm_url,
+                ext_headers=ext_headers,
+                use_curl_cffi=use_curl_cffi,
+            )
         else:
             bgm_task = None
         return _with_need_send(

--- a/src/nonebot_plugin_parser_lite/data.py
+++ b/src/nonebot_plugin_parser_lite/data.py
@@ -301,7 +301,7 @@ class ParseResult:
         for cont in self.content:
             if isinstance(cont, VideoContent):
                 return await cont.get_cover_path()
-            elif isinstance(cont, ImageContent | GraphicContent):
+            elif isinstance(cont, (ImageContent, GraphicContent)):
                 return await cont.get_path()
         return None
 

--- a/src/nonebot_plugin_parser_lite/data.py
+++ b/src/nonebot_plugin_parser_lite/data.py
@@ -56,7 +56,9 @@ class MediaContent:
         if self._size_bytes is None:
             try:
                 self._size_bytes = await DOWNLOADER.head_size(
-                    url=self.path_task.url, ext_headers=self.path_task.ext_headers
+                    url=self.path_task.url,
+                    ext_headers=self.path_task.ext_headers,
+                    use_curl_cffi=self.path_task.use_curl_cffi,
                 )
             except Exception:
                 # HEAD 失败时不抛出，避免影响主流程
@@ -299,7 +301,7 @@ class ParseResult:
         for cont in self.content:
             if isinstance(cont, VideoContent):
                 return await cont.get_cover_path()
-            elif isinstance(cont, (ImageContent, GraphicContent)):
+            elif isinstance(cont, ImageContent | GraphicContent):
                 return await cont.get_path()
         return None
 

--- a/src/nonebot_plugin_parser_lite/download/__init__.py
+++ b/src/nonebot_plugin_parser_lite/download/__init__.py
@@ -8,7 +8,7 @@ from urllib.parse import urljoin
 
 import aiofiles
 from anyio import Path
-from httpx import AsyncClient, Response
+from httpx import Response
 from nonebot import logger
 from rich.progress import (
     BarColumn,
@@ -25,6 +25,7 @@ from ..constants import COMMON_HEADER, DOWNLOAD_TIMEOUT
 from ..exception import DownloadException, SizeLimitException, ZeroSizeException
 from ..utils.common import generate_file_name, make_filename, safe_unlink
 from ..utils.ffmpeg import FFmpeg
+from .client import DownloadHttpClient, DownloadResponse
 from .task import auto_task
 
 
@@ -34,7 +35,7 @@ class StreamDownloader:
     def __init__(self):
         self.headers: dict[str, str] = COMMON_HEADER.copy()
         self.cache_dir: Path = pconfig.cache_dir
-        self.client: AsyncClient = AsyncClient(timeout=DOWNLOAD_TIMEOUT, verify=False)
+        self.client = DownloadHttpClient(timeout=DOWNLOAD_TIMEOUT)
         self._active_downloads: dict[str, asyncio.Task[None]] = {}
         self._ffmpeg_available: bool | None = None
 
@@ -42,13 +43,17 @@ class StreamDownloader:
         await self.client.aclose()
 
     async def head(
-        self, url: str, ext_headers: dict[str, str] | None = None
+        self,
+        url: str,
+        ext_headers: dict[str, str] | None = None,
+        use_curl_cffi: bool = False,
     ) -> Response:
         """
         发送 HEAD 请求并返回响应对象。
 
         :param url: 目标资源地址
         :param ext_headers: 额外请求头
+        :param use_curl_cffi: 是否使用 curl_cffi 发起请求
         :return: httpx.Response 对象
         :raise httpx.HTTPStatusError: HEAD 与 GET 均非 2xx 时抛出
         """
@@ -56,31 +61,33 @@ class StreamDownloader:
         resp = await self.client.head(
             url=url,
             headers=headers,
-            follow_redirects=True,
+            use_curl_cffi=use_curl_cffi,
         )
         if 200 <= resp.status_code < 300:
-            return resp
+            return resp.to_httpx_response()
         logger.debug(
             f"[StreamDownloader] HEAD {url} returned {resp.status_code}, fallback to streamed GET"  # noqa: E501
         )
         async with self.client.stream(
-            "GET", url, headers=headers, follow_redirects=True
+            "GET",
+            url,
+            headers=headers,
+            use_curl_cffi=use_curl_cffi,
         ) as stream_resp:
-            slim_resp = Response(
-                status_code=stream_resp.status_code,
-                headers=stream_resp.headers,
-                request=stream_resp.request,
-            )
-            slim_resp.cookies.update(stream_resp.cookies)
-            return slim_resp
+            return stream_resp.to_httpx_response()
 
     async def head_size(
-        self, url: str, ext_headers: dict[str, str] | None = None
+        self,
+        url: str,
+        ext_headers: dict[str, str] | None = None,
+        use_curl_cffi: bool = False,
     ) -> int | None:
         """
         对给定 url 发送 HEAD 请求，返回 Content-Length
         """
-        response = await self.head(url, ext_headers=ext_headers)
+        response = await self.head(
+            url, ext_headers=ext_headers, use_curl_cffi=use_curl_cffi
+        )
         raw_len = response.headers.get("Content-Length")
         if not raw_len:
             return None
@@ -97,12 +104,14 @@ class StreamDownloader:
         file_name: str | None = None,
         ext_headers: dict[str, str] | None = None,
         cache_type: str = CacheManager.MEDIA,
+        use_curl_cffi: bool = False,
     ) -> Path:
         """
         :param url: 下载文件的链接地址
         :param file_name: 保存到本地的文件名，为空时根据 url 自动生成
         :param ext_headers: 额外的请求头，会与默认请求头合并
         :param cache_type: 缓存类型
+        :param use_curl_cffi: 是否使用 curl_cffi 下载
 
         :return: 下载完成后的本地文件路径
         :raise ZeroSizeException: 资源大小为 0 时抛出
@@ -131,6 +140,7 @@ class StreamDownloader:
                 file_path=file_path,
                 headers=headers,
                 desc=file_name,
+                use_curl_cffi=use_curl_cffi,
             )
 
         download_task = asyncio.create_task(_download_task())
@@ -153,6 +163,7 @@ class StreamDownloader:
         file_path: Path,
         headers: dict[str, str],
         desc: str,
+        use_curl_cffi: bool = False,
     ) -> None:
         def parse_content_length(header_val: str | None) -> int | None:
             if not header_val:
@@ -174,7 +185,10 @@ class StreamDownloader:
                 raise SizeLimitException(file_size_mb)
 
         async with self.client.stream(
-            "GET", url, headers=headers, follow_redirects=True
+            "GET",
+            url,
+            headers=headers,
+            use_curl_cffi=use_curl_cffi,
         ) as response:
             try:
                 response.raise_for_status()
@@ -195,7 +209,7 @@ class StreamDownloader:
 
     async def _write_stream_to_file(
         self,
-        response: Response,
+        response: DownloadResponse,
         file_path: Path,
         desc: str,
         declared_length: int | None,
@@ -234,6 +248,7 @@ class StreamDownloader:
         video_name: str | None = None,
         ext_headers: dict[str, str] | None = None,
         cache_type: str = CacheManager.MEDIA,
+        use_curl_cffi: bool = False,
     ) -> Path:
         """
         下载普通视频
@@ -242,6 +257,7 @@ class StreamDownloader:
         :param video_name: 保存到本地的视频文件名，为空时根据 url 自动生成 mp4 文件名
         :param ext_headers: 额外的请求头，会与默认请求头合并
         :param cache_type: 缓存类型
+        :param use_curl_cffi: 是否使用 curl_cffi 下载
 
         :return: 下载完成后的视频文件路径
         :raise ZeroSizeException: 资源大小为 0 时抛出
@@ -256,6 +272,7 @@ class StreamDownloader:
             file_name=video_name,
             ext_headers=ext_headers,
             cache_type=cache_type,
+            use_curl_cffi=use_curl_cffi,
         )
 
     @auto_task
@@ -266,6 +283,7 @@ class StreamDownloader:
         video_name: str | None = None,
         ext_headers: dict[str, str] | None = None,
         cache_type: str = CacheManager.MEDIA,
+        use_curl_cffi: bool = False,
     ) -> Path:
         """
         下载 m3u8 视频并合并到 mp4
@@ -274,6 +292,7 @@ class StreamDownloader:
         :param video_name: 输出的 mp4 文件名，为空时根据 m3u8 链接生成
         :param ext_headers: 额外的请求头，会与默认请求头合并
         :param cache_type: 缓存类型
+        :param use_curl_cffi: 是否使用 curl_cffi 下载
 
         :return: 最终合并并转封装后的 mp4 文件路径
         :raise SizeLimitException: 资源大小超过配置的最大限制时抛出
@@ -295,7 +314,9 @@ class StreamDownloader:
 
         try:
             # 1. 智能解析 m3u8 (自动处理嵌套列表)
-            ts_urls = await self._smart_parse_m3u8(url)
+            ts_urls = await self._smart_parse_m3u8(
+                url, ext_headers=ext_headers, use_curl_cffi=use_curl_cffi
+            )
             if not ts_urls:
                 raise DownloadException("m3u8 解析结果为空")
 
@@ -306,6 +327,7 @@ class StreamDownloader:
                 temp_ts_path=temp_ts_path,
                 video_name=video_name,
                 headers=headers,
+                use_curl_cffi=use_curl_cffi,
             )
 
             # 3/4. 校验大小并转封装
@@ -332,6 +354,7 @@ class StreamDownloader:
         temp_ts_path: Path,
         video_name: str,
         headers: dict[str, str],
+        use_curl_cffi: bool = False,
     ) -> int:
         """
         下载所有 ts 片段并写入临时 ts 文件，返回最终文件实际字节数
@@ -350,7 +373,7 @@ class StreamDownloader:
                         ts_url,
                         headers=headers,
                         timeout=15,
-                        follow_redirects=True,
+                        use_curl_cffi=use_curl_cffi,
                     ) as resp:
                         if resp.status_code != 200:
                             raise DownloadException(
@@ -421,7 +444,12 @@ class StreamDownloader:
         ):
             raise DownloadException("视频下载失败，最终文件不存在或大小过小")
 
-    async def _smart_parse_m3u8(self, m3u8_url: str) -> list[str]:
+    async def _smart_parse_m3u8(
+        self,
+        m3u8_url: str,
+        ext_headers: dict[str, str] | None = None,
+        use_curl_cffi: bool = False,
+    ) -> list[str]:
         """
         智能解析 m3u8，支持 Master Playlist (嵌套) 和 Media Playlist
 
@@ -432,7 +460,9 @@ class StreamDownloader:
         """
 
         logger.info(f"[StreamDownloader] 开始解析 m3u8: {m3u8_url}")
-        content = await self.text(m3u8_url)
+        content = await self.text(
+            m3u8_url, ext_headers=ext_headers, use_curl_cffi=use_curl_cffi
+        )
         base_url = m3u8_url.rsplit("/", 1)[0] + "/"
 
         # 检查是否是 Master Playlist (包含子 m3u8 链接)
@@ -454,7 +484,11 @@ class StreamDownloader:
             if sub_playlists:
                 # 通常最后一个是最高画质，或者是第一个
                 logger.debug(f"[StreamDownloader] 转向子播放列表: {sub_playlists[-1]}")
-                return await self._smart_parse_m3u8(sub_playlists[-1])
+                return await self._smart_parse_m3u8(
+                    sub_playlists[-1],
+                    ext_headers=ext_headers,
+                    use_curl_cffi=use_curl_cffi,
+                )
             else:
                 raise DownloadException("Master Playlist 解析失败，未找到子链接")
 
@@ -476,36 +510,54 @@ class StreamDownloader:
         )
         return ts_urls
 
-    async def text(self, url: str, ext_headers: dict[str, str] | None = None) -> str:
+    async def text(
+        self,
+        url: str,
+        ext_headers: dict[str, str] | None = None,
+        use_curl_cffi: bool = False,
+    ) -> str:
         """
         获取文本内容
 
         :param url: 目标文本资源的链接地址
         :param ext_headers: 额外的请求头，会与默认请求头合并
+        :param use_curl_cffi: 是否使用 curl_cffi 请求
 
         :return: 响应体的文本内容
         :raise DownloadException: 请求状态码非 200 时抛出
         """
         headers = {**self.headers, **(ext_headers or {})}
-        resp = await self.client.get(url, headers=headers, follow_redirects=True)
+        resp = await self.client.get(
+            url,
+            headers=headers,
+            use_curl_cffi=use_curl_cffi,
+        )
         if resp.status_code != 200:
             raise DownloadException(f"请求失败: {resp.status_code}")
         return resp.text
 
     async def content(
-        self, url: str, ext_headers: dict[str, str] | None = None
+        self,
+        url: str,
+        ext_headers: dict[str, str] | None = None,
+        use_curl_cffi: bool = False,
     ) -> bytes:
         """
         获取内容
 
         :param url: 目标资源的链接地址
         :param ext_headers: 额外的请求头，会与默认请求头合并
+        :param use_curl_cffi: 是否使用 curl_cffi 请求
 
         :return: 响应体的内容
         :raise DownloadException: 请求状态码非 200 时抛出
         """
         headers = {**self.headers, **(ext_headers or {})}
-        resp = await self.client.get(url, headers=headers, follow_redirects=True)
+        resp = await self.client.get(
+            url,
+            headers=headers,
+            use_curl_cffi=use_curl_cffi,
+        )
         if resp.status_code != 200:
             raise DownloadException(f"请求失败: {resp.status_code}")
         return resp.content
@@ -554,6 +606,7 @@ class StreamDownloader:
         audio_name: str | None = None,
         ext_headers: dict[str, str] | None = None,
         cache_type: str = CacheManager.MEDIA,
+        use_curl_cffi: bool = False,
     ) -> Path:
         """
         下载音频
@@ -561,6 +614,7 @@ class StreamDownloader:
         :param audio_name: 保存到本地的音频文件名，为空时根据 url 自动生成 mp3 文件名
         :param ext_headers: 额外的请求头，会与默认请求头合并
         :param cache_type: 缓存类型
+        :param use_curl_cffi: 是否使用 curl_cffi 下载
 
         :return: 下载完成后的音频文件路径
         :raise DownloadException: 下载过程中发生错误时抛出
@@ -572,6 +626,7 @@ class StreamDownloader:
             file_name=audio_name,
             ext_headers=ext_headers,
             cache_type=cache_type,
+            use_curl_cffi=use_curl_cffi,
         )
 
     @auto_task
@@ -582,6 +637,7 @@ class StreamDownloader:
         img_name: str | None = None,
         ext_headers: dict[str, str] | None = None,
         cache_type: str = CacheManager.MEDIA,
+        use_curl_cffi: bool = False,
     ) -> Path:
         """
         下载图片
@@ -590,6 +646,7 @@ class StreamDownloader:
         :param img_name: 保存到本地的图片文件名，为空时根据 url 自动生成 jpg 文件名
         :param ext_headers: 额外的请求头，会与默认请求头合并
         :param cache_type: 缓存类型
+        :param use_curl_cffi: 是否使用 curl_cffi 下载
 
         :return: 下载完成后的图片文件路径
         :raise DownloadException: 下载过程中发生错误时抛出
@@ -601,6 +658,7 @@ class StreamDownloader:
             file_name=img_name,
             ext_headers=ext_headers,
             cache_type=cache_type,
+            use_curl_cffi=use_curl_cffi,
         )
 
     async def download_av_and_merge(
@@ -609,6 +667,7 @@ class StreamDownloader:
         a_url: str,
         file_name: str,
         ext_headers: dict[str, str] | None = None,
+        use_curl_cffi: bool = False,
     ) -> Path:
         """
         下载音频和视频文件并合并
@@ -617,12 +676,21 @@ class StreamDownloader:
         :param a_url: 音频流下载地址
         :param file_name: 合并后输出文件名(不含扩展名)
         :param ext_headers: 额外的请求头，会与默认请求头合并
+        :param use_curl_cffi: 是否使用 curl_cffi 下载
         :return: 合并后的视频文件本地路径
         :raise DownloadException: 下载或合并过程中发生错误时抛出
         """
         v_path, a_path = await asyncio.gather(
-            self.download_video(url=v_url, ext_headers=ext_headers),
-            self.download_audio(url=a_url, ext_headers=ext_headers),
+            self.download_video(
+                url=v_url,
+                ext_headers=ext_headers,
+                use_curl_cffi=use_curl_cffi,
+            ),
+            self.download_audio(
+                url=a_url,
+                ext_headers=ext_headers,
+                use_curl_cffi=use_curl_cffi,
+            ),
         )
         return await FFmpeg.merge_av(v_path=v_path, a_path=a_path, file_name=file_name)
 

--- a/src/nonebot_plugin_parser_lite/download/client.py
+++ b/src/nonebot_plugin_parser_lite/download/client.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator, AsyncIterator
+from contextlib import asynccontextmanager
+from typing import Any, Literal
+
+from curl_cffi import AsyncSession
+from httpx import AsyncClient, Headers, Request, Response, Timeout
+
+
+class DownloadResponse:
+    """Normalize the small response surface used by StreamDownloader."""
+
+    __slots__ = ("_raw",)
+
+    def __init__(self, raw: Any):
+        self._raw = raw
+
+    @property
+    def status_code(self) -> int:
+        return self._raw.status_code
+
+    @property
+    def headers(self) -> Headers:
+        return Headers(self._raw.headers)
+
+    @property
+    def url(self) -> str:
+        return str(self._raw.url)
+
+    @property
+    def text(self) -> str:
+        return self._raw.text
+
+    @property
+    def content(self) -> bytes:
+        return self._raw.content
+
+    def raise_for_status(self) -> None:
+        self._raw.raise_for_status()
+
+    async def aiter_bytes(self, chunk_size: int | None = None) -> AsyncIterator[bytes]:
+        if hasattr(self._raw, "aiter_bytes"):
+            async for chunk in self._raw.aiter_bytes(chunk_size):
+                yield chunk
+            return
+
+        async for chunk in self._raw.aiter_content():
+            yield chunk
+
+    def to_httpx_response(self) -> Response:
+        request = getattr(self._raw, "request", None)
+        if not isinstance(request, Request):
+            request = Request("GET", self.url)
+        return Response(
+            status_code=self.status_code,
+            headers=self.headers,
+            request=request,
+        )
+
+
+class DownloadHttpClient:
+    """Adapter over httpx and curl_cffi with one request interface."""
+
+    def __init__(self, timeout: Timeout):
+        self._timeout = timeout
+        self._httpx = AsyncClient(timeout=timeout, verify=False)
+        self._curl = AsyncSession(impersonate="chrome146")
+
+    async def aclose(self) -> None:
+        await self._httpx.aclose()
+        await self._curl.close()
+
+    def _curl_timeout(self, timeout: float | None = None) -> float:
+        if timeout is not None:
+            return float(timeout)
+        return float(max(self._timeout.connect or 15, self._timeout.read or 240))
+
+    async def head(
+        self,
+        url: str,
+        *,
+        headers: dict[str, str],
+        use_curl_cffi: bool = False,
+    ) -> DownloadResponse:
+        if use_curl_cffi:
+            resp = await self._curl.head(
+                url=url,
+                headers=headers,
+                allow_redirects=True,
+                timeout=self._curl_timeout(),
+                verify=False,
+            )
+        else:
+            resp = await self._httpx.head(
+                url=url,
+                headers=headers,
+                follow_redirects=True,
+            )
+        return DownloadResponse(resp)
+
+    async def get(
+        self,
+        url: str,
+        *,
+        headers: dict[str, str],
+        use_curl_cffi: bool = False,
+    ) -> DownloadResponse:
+        if use_curl_cffi:
+            resp = await self._curl.get(
+                url,
+                headers=headers,
+                allow_redirects=True,
+                timeout=self._curl_timeout(),
+                verify=False,
+            )
+        else:
+            resp = await self._httpx.get(
+                url,
+                headers=headers,
+                follow_redirects=True,
+            )
+        return DownloadResponse(resp)
+
+    @asynccontextmanager
+    async def stream(
+        self,
+        method: Literal[
+            "GET", "POST", "PUT", "DELETE", "OPTIONS", "HEAD", "TRACE", "PATCH", "QUERY"
+        ],
+        url: str,
+        *,
+        headers: dict[str, str],
+        timeout: float | None = None,
+        use_curl_cffi: bool = False,
+    ) -> AsyncGenerator[DownloadResponse]:
+        if use_curl_cffi:
+            async with self._curl.stream(
+                method,
+                url,
+                headers=headers,
+                timeout=self._curl_timeout(timeout),
+                allow_redirects=True,
+                verify=False,
+            ) as resp:
+                yield DownloadResponse(resp)
+        else:
+            kwargs: dict[str, Any] = {
+                "headers": headers,
+                "follow_redirects": True,
+            }
+            if timeout is not None:
+                kwargs["timeout"] = timeout
+            async with self._httpx.stream(method, url, **kwargs) as resp:
+                yield DownloadResponse(resp)

--- a/src/nonebot_plugin_parser_lite/download/task.py
+++ b/src/nonebot_plugin_parser_lite/download/task.py
@@ -22,6 +22,7 @@ class DownloadTaskWrapper(Awaitable[T], Generic[T]):
         "_result",
         "ext_headers",
         "url",
+        "use_curl_cffi",
     )
 
     def __init__(
@@ -31,12 +32,14 @@ class DownloadTaskWrapper(Awaitable[T], Generic[T]):
         kwargs: dict[str, Any],
         url: str,
         ext_headers: dict[str, str] | None = None,
+        use_curl_cffi: bool = False,
     ):
         self._func = func
         self._args = args
         self._kwargs = kwargs
         self.url: str = url
         self.ext_headers: dict[str, str] | None = ext_headers
+        self.use_curl_cffi: bool = use_curl_cffi
         self._has_result = False
         self._lock: asyncio.Lock | None = None
         self._result: T | None = None
@@ -72,8 +75,10 @@ def auto_task(
     - 被修饰函数签名必须包含：
         url: str
         ext_headers: dict[str, str] | None = None
+        use_curl_cffi: bool = False
     - 调用方必须使用关键字传参 url=...
     - ext_headers 可以省略，不传时等价于 None（使用默认 headers）
+    - use_curl_cffi 可以省略，不传时等价于 False（使用 httpx）
     """
 
     @wraps(func)
@@ -88,6 +93,7 @@ def auto_task(
         raw_url = kwargs["url"]
         # 2) ext_headers 允许缺省，默认为 None
         ext_headers = kwargs.get("ext_headers", None)
+        use_curl_cffi = kwargs.get("use_curl_cffi", False)
 
         # 3) 运行时类型校验（防御性）
         if not isinstance(raw_url, str):
@@ -100,6 +106,11 @@ def auto_task(
                 f"@auto_task 要求 {func.__qualname__} 的 ext_headers 类型为 dict[str, str] | None, "  # noqa: E501
                 f"但实际是 {type(ext_headers)!r}"
             )
+        if not isinstance(use_curl_cffi, bool):
+            raise TypeError(
+                f"@auto_task 要求 {func.__qualname__} 的 use_curl_cffi 类型为 bool, "
+                f"但实际是 {type(use_curl_cffi)!r}"
+            )
 
         url: str = raw_url
 
@@ -110,6 +121,7 @@ def auto_task(
             kwargs=dict(kwargs),
             url=url,
             ext_headers=ext_headers,
+            use_curl_cffi=use_curl_cffi,
         )
 
     return wrapper

--- a/src/nonebot_plugin_parser_lite/parsers/base.py
+++ b/src/nonebot_plugin_parser_lite/parsers/base.py
@@ -235,9 +235,14 @@ class BaseParser:
         self,
         url: str,
         headers: dict[str, str] | None = None,
+        use_curl_cffi: bool = False,
     ) -> ParseResult:
         """先重定向再解析"""
-        redirect_url = await self.get_final_url(url, headers=headers or self.headers)
+        redirect_url = await self.get_final_url(
+            url,
+            headers=headers,
+            use_curl_cffi=use_curl_cffi,
+        )
 
         if redirect_url == url:
             raise ParseException(f"无法重定向 URL: {url}")
@@ -316,9 +321,12 @@ class BaseParser:
     async def get_final_url(
         url: str,
         headers: dict[str, str] | None = None,
+        use_curl_cffi: bool = False,
     ) -> str:
         """获取最终重定向后的 URL"""
-        response = await DOWNLOADER.head(url, ext_headers=headers)
+        response = await DOWNLOADER.head(
+            url, ext_headers=headers, use_curl_cffi=use_curl_cffi
+        )
         return str(response.url)
 
     def create_author(
@@ -329,6 +337,7 @@ class BaseParser:
         id: str | None = None,
         location: str | None = None,
         ext_headers: dict[str, str] | None = None,
+        use_curl_cffi: bool = False,
     ):
         """
         创建作者对象
@@ -339,6 +348,7 @@ class BaseParser:
         :param id: 作者 ID
         :param location: 位置信息
         :param ext_headers: 额外请求头
+        :param use_curl_cffi: 是否使用 curl_cffi 下载头像
         """
 
         return Creator.author(
@@ -348,6 +358,7 @@ class BaseParser:
             id=id,
             location=location,
             ext_headers=ext_headers,
+            use_curl_cffi=use_curl_cffi,
         )
 
     def create_video(
@@ -358,6 +369,7 @@ class BaseParser:
         video_name: str | None = None,
         need_send: bool = True,
         ext_headers: dict[str, str] | None = None,
+        use_curl_cffi: bool = False,
     ):
         """
         创建视频内容
@@ -368,6 +380,7 @@ class BaseParser:
         :param video_name: 视频名称
         :param need_send: 是否发送
         :param ext_headers: 额外请求头
+        :param use_curl_cffi: 是否使用 curl_cffi 下载视频/封面
         """
 
         return Creator.video(
@@ -377,35 +390,48 @@ class BaseParser:
             video_name=video_name,
             need_send=need_send,
             ext_headers=ext_headers,
+            use_curl_cffi=use_curl_cffi,
         )
 
     def create_videos(
         self,
         video_urls: list[str],
         ext_headers: dict[str, str] | None = None,
+        use_curl_cffi: bool = False,
     ):
         """
         创建视频内容列表
 
         :param video_urls: 视频 URL 列表
         :param ext_headers: 额外请求头
+        :param use_curl_cffi: 是否使用 curl_cffi 下载
         """
 
-        return Creator.videos(video_urls=video_urls, ext_headers=ext_headers)
+        return Creator.videos(
+            video_urls=video_urls,
+            ext_headers=ext_headers,
+            use_curl_cffi=use_curl_cffi,
+        )
 
     def create_images(
         self,
         image_urls: list[str],
         ext_headers: dict[str, str] | None = None,
+        use_curl_cffi: bool = False,
     ):
         """
         创建图片内容列表
 
         :param image_urls: 图片 URL 列表
         :param ext_headers: 额外请求头
+        :param use_curl_cffi: 是否使用 curl_cffi 下载
         """
 
-        return Creator.images(image_urls=image_urls, ext_headers=ext_headers)
+        return Creator.images(
+            image_urls=image_urls,
+            ext_headers=ext_headers,
+            use_curl_cffi=use_curl_cffi,
+        )
 
     def create_image(
         self,
@@ -413,6 +439,7 @@ class BaseParser:
         img_name: str | None = None,
         need_send: bool = True,
         ext_headers: dict[str, str] | None = None,
+        use_curl_cffi: bool = False,
     ):
         """
         创建图片内容
@@ -421,10 +448,15 @@ class BaseParser:
         :param img_name: 图片名称
         :param need_send: 是否发送
         :param ext_headers: 额外请求头
+        :param use_curl_cffi: 是否使用 curl_cffi 下载
         """
 
         return Creator.image(
-            url=url, img_name=img_name, need_send=need_send, ext_headers=ext_headers
+            url=url,
+            img_name=img_name,
+            need_send=need_send,
+            ext_headers=ext_headers,
+            use_curl_cffi=use_curl_cffi,
         )
 
     def create_audio(
@@ -434,6 +466,7 @@ class BaseParser:
         audio_name: str | None = None,
         need_send: bool = True,
         ext_headers: dict[str, str] | None = None,
+        use_curl_cffi: bool = False,
     ):
         """
         创建音频内容
@@ -443,6 +476,7 @@ class BaseParser:
         :param audio_name: 音频名称
         :param need_send: 是否发送
         :param ext_headers: 额外请求头
+        :param use_curl_cffi: 是否使用 curl_cffi 下载
         """
 
         return Creator.audio(
@@ -451,6 +485,7 @@ class BaseParser:
             audio_name=audio_name,
             need_send=need_send,
             ext_headers=ext_headers,
+            use_curl_cffi=use_curl_cffi,
         )
 
     def create_graphic(
@@ -460,6 +495,7 @@ class BaseParser:
         alt: str | None = None,
         need_send: bool = True,
         ext_headers: dict[str, str] | None = None,
+        use_curl_cffi: bool = False,
     ):
         """
         图片,此图片不参与九宫格
@@ -469,6 +505,7 @@ class BaseParser:
         :param alt: 图片描述
         :param need_send: 是否发送
         :param ext_headers: 额外请求头
+        :param use_curl_cffi: 是否使用 curl_cffi 下载
         """
 
         return Creator.graphic(
@@ -477,6 +514,7 @@ class BaseParser:
             alt=alt,
             need_send=need_send,
             ext_headers=ext_headers,
+            use_curl_cffi=use_curl_cffi,
         )
 
     def create_sticker(
@@ -485,6 +523,7 @@ class BaseParser:
         size: Literal["small", "medium"] = "medium",
         desc: str | None = None,
         ext_headers: dict[str, str] | None = None,
+        use_curl_cffi: bool = False,
     ):
         """
         创建贴纸内容
@@ -495,9 +534,16 @@ class BaseParser:
             - medium: 文字大小的两倍大一点
         :param desc: 贴纸描述
         :param ext_headers: 额外请求头
+        :param use_curl_cffi: 是否使用 curl_cffi 下载
         """
 
-        return Creator.sticker(url=url, size=size, desc=desc, ext_headers=ext_headers)
+        return Creator.sticker(
+            url=url,
+            size=size,
+            desc=desc,
+            ext_headers=ext_headers,
+            use_curl_cffi=use_curl_cffi,
+        )
 
     def create_live_photo(
         self,
@@ -506,6 +552,7 @@ class BaseParser:
         bgm_url: str | None = None,
         need_send: bool = True,
         ext_headers: dict[str, str] | None = None,
+        use_curl_cffi: bool = False,
     ):
         """
         创建  iPhone Live Photo 内容
@@ -515,6 +562,7 @@ class BaseParser:
         :param bgm_url: iPhone Live Photo 背景音乐
         :param need_send: 是否发送
         :param ext_headers: 额外请求头
+        :param use_curl_cffi: 是否使用 curl_cffi 下载
         """
         return Creator.live_photo(
             video_url=video_url,
@@ -522,6 +570,7 @@ class BaseParser:
             bgm_url=bgm_url,
             need_send=need_send,
             ext_headers=ext_headers,
+            use_curl_cffi=use_curl_cffi,
         )
 
     def create_stats(

--- a/src/nonebot_plugin_parser_lite/parsers/base.py
+++ b/src/nonebot_plugin_parser_lite/parsers/base.py
@@ -240,7 +240,7 @@ class BaseParser:
         """先重定向再解析"""
         redirect_url = await self.get_final_url(
             url,
-            headers=headers,
+            headers=headers or self.headers,
             use_curl_cffi=use_curl_cffi,
         )
 


### PR DESCRIPTION
添加 use_curl_cffi 参数到下载相关的所有方法中，使用户可以选择 使用 curl_cffi 作为替代的 HTTP 客户端。引入了 DownloadHttpClient 适配器类来统一管理 httpx 和 curl_cffi 两种客户端的接口。

同时更新了 Creator、BaseParser 和 StreamDownloader 中的相关方法， 确保在创建内容和下载资源时能够传递 use_curl_cffi 参数。

## Summary by Sourcery

在下载流水线中新增可选的基于 curl_cffi 的 HTTP 客户端路径，并将这一可配置项贯穿到解析器和内容创建器中。

新功能：
- 引入统一的 `DownloadHttpClient` 适配器，使其可以使用 `httpx` 或 `curl_cffi` 来发起 HTTP 请求。
- 在下载器、创建器和基础解析器的 API 中暴露 `use_curl_cffi` 标志，让调用方可以在每次请求时选择 HTTP 后端。

增强内容：
- 通过 `DownloadResponse` 包装器规范化响应处理，将 `StreamDownloader` 与具体的 HTTP 客户端实现解耦。
- 扩展 `DownloadTaskWrapper` 及相关辅助工具，以便在延迟下载任务中传递 HTTP 客户端选择的元数据。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add an optional curl_cffi-based HTTP client path to the download pipeline and thread this configurability through parsers and content creators.

New Features:
- Introduce a unified DownloadHttpClient adapter that can use either httpx or curl_cffi for HTTP requests.
- Expose a use_curl_cffi flag across downloader, creator, and base parser APIs to let callers choose the HTTP backend per request.

Enhancements:
- Normalize response handling via a DownloadResponse wrapper to decouple StreamDownloader from specific HTTP client implementations.
- Extend DownloadTaskWrapper and related helpers to carry HTTP client selection metadata through deferred download tasks.

</details>