### PR TITLE
feat(parser/5eplay): 添加对5EPlay平台的支持

### DIFF
--- a/src/nonebot_plugin_parser_lite/constants.py
+++ b/src/nonebot_plugin_parser_lite/constants.py
@@ -62,7 +62,7 @@ class PlatformEnum(str, Enum):
     HUPU = "hupu"
     MIYOUSHE = "miyoushe"
     DOUBAN = "douban"
-    FiveEPlay = "5eplay"
+    FIVEEPLAY = "5eplay"
 
     def __str__(self) -> str:
         return self.value

--- a/src/nonebot_plugin_parser_lite/constants.py
+++ b/src/nonebot_plugin_parser_lite/constants.py
@@ -62,6 +62,7 @@ class PlatformEnum(str, Enum):
     HUPU = "hupu"
     MIYOUSHE = "miyoushe"
     DOUBAN = "douban"
+    FiveEPlay = "5eplay"
 
     def __str__(self) -> str:
         return self.value

--- a/src/nonebot_plugin_parser_lite/parsers/__init__.py
+++ b/src/nonebot_plugin_parser_lite/parsers/__init__.py
@@ -5,6 +5,7 @@ from .coolapk import CoolapkParser
 from .douban import DoubanParser
 from .douyin import DouyinParser
 from .duitang import DuiTangParser
+from .fiveeplay import FiveEPlayParser
 from .heybox import HeyBoxParser
 from .hupu import HupuParser
 from .illu import IlluParser
@@ -29,6 +30,7 @@ __all__ = [
     "DoubanParser",
     "DouyinParser",
     "DuiTangParser",
+    "FiveEPlayParser",
     "HeyBoxParser",
     "HupuParser",
     "IlluParser",

--- a/src/nonebot_plugin_parser_lite/parsers/fiveeplay/__init__.py
+++ b/src/nonebot_plugin_parser_lite/parsers/fiveeplay/__init__.py
@@ -6,7 +6,7 @@ from .topic import decoder as postDecoder
 
 class FiveEPlayParser(BaseParser):
     platform: ClassVar[Platform] = Platform(
-        name=PlatformEnum.FiveEPlay, display_name="5EPlay"
+        name=PlatformEnum.FIVEEPLAY, display_name="5EPlay"
     )
 
     # https://csgo.5eplay.com/forum/share/1050838

--- a/src/nonebot_plugin_parser_lite/parsers/fiveeplay/__init__.py
+++ b/src/nonebot_plugin_parser_lite/parsers/fiveeplay/__init__.py
@@ -1,0 +1,32 @@
+from typing import ClassVar
+
+from ..base import BaseParser, MatchWithParams, Platform, PlatformEnum, handle
+from .topic import decoder as postDecoder
+
+
+class FiveEPlayParser(BaseParser):
+    platform: ClassVar[Platform] = Platform(
+        name=PlatformEnum.FiveEPlay, display_name="5EPlay"
+    )
+
+    # https://csgo.5eplay.com/forum/share/1050838
+    # https://csgo.5eplay.com/forum/1050838
+    # https://csgo.5eplay.com/forum/share/1050797
+    @handle("csgo.5eplay.com/forum", r"forum/(?P<topic_id>\d+)")
+    @handle("csgo.5eplay.com/forum", r"share/(?P<topic_id>\d+)")
+    async def parse_topic(self, searched: MatchWithParams):
+        topic_id = searched["topic_id"]
+        res = await self.httpx.get(
+            f"https://app.5eplay.com/api/csgo/forum/topic/{topic_id}"
+        )
+        res.raise_for_status()
+        post = postDecoder.decode(res.content)
+        return self.result(
+            author=post.author,
+            url=post.url,
+            content=post.content,
+            timestamp=post.timestamp,
+            title=post.title,
+            stats=post.stats,
+            comments=post.comments,
+        )

--- a/src/nonebot_plugin_parser_lite/parsers/fiveeplay/topic.py
+++ b/src/nonebot_plugin_parser_lite/parsers/fiveeplay/topic.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+
+from msgspec import Struct, field
+from msgspec.json import Decoder
+
+from ...creator import Creator
+from ...data import Comment, ContentItem
+from ...utils.format import format_num
+
+
+class UserData(Struct):
+    username: str
+    domain: str
+    avatar_url: str
+
+
+class FComment(Struct):
+    pid: str
+    likes: int
+    html: str = field(name="content")
+    dateline: str
+    user_data: UserData
+    images: list[str] | None
+    children: list[FComment] | None = None
+
+    @property
+    def content(self) -> list[ContentItem]:
+        content: list[ContentItem] = [
+            self.html.split("<***>", 1)[0].split("<end>", 1)[0]
+        ]
+        if images := self.images:
+            content.extend(Creator.images(images))
+        return content
+
+
+class ShareData(Struct):
+    share_url: str
+
+
+class VideoData(Struct):
+    video_cover: str | None = None
+    video_url: str | None = None
+
+
+class Post(Struct):
+    tid: str
+    type: str
+    """0-文字,2-视频"""
+    domain: str
+    username: str
+    avatar_url: str
+    title: str
+    dateline: str
+    topic_likes_count: str
+    images: list[str] | None
+    hits: str
+    intro_text: str
+    forward: str
+    topic_favorites: str
+    share_data: ShareData
+    video_data: VideoData
+
+    @property
+    def author(self):
+        return Creator.author(
+            name=self.username,
+            avatar_url=self.avatar_url,
+            id=self.domain,
+        )
+
+    @property
+    def timestamp(self):
+        return int(self.dateline)
+
+    @property
+    def url(self):
+        return self.share_data.share_url
+
+    @property
+    def content(self):
+        content: list[ContentItem] = [self.intro_text.split("<img", 1)[0]]
+        if images := self.images:
+            content.extend(Creator.images(images))
+        if video_url := self.video_data.video_url:
+            content.append(
+                Creator.video(
+                    url_or_task=video_url,
+                    cover_url=self.video_data.video_cover,
+                )
+            )
+        return content
+
+
+class CommentList(Struct):
+    total: int
+    _list: list[FComment] | None = field(name="list")
+
+    @property
+    def comments(self):
+        if not self._list:
+            return []
+
+        def to_author(fd: FComment):
+            return Creator.author(
+                name=fd.user_data.username,
+                id=fd.user_data.domain,
+                avatar_url=fd.user_data.avatar_url,
+            )
+
+        def to_comment(fd: FComment):
+            return Creator.comment(
+                author=to_author(fd),
+                content=fd.content,
+                timestamp=int(fd.dateline),
+                stats=Creator.stats(like_count=format_num(fd.likes)),
+            )
+
+        result: list[Comment] = []
+        for c in self._list:
+            root = to_comment(c)
+            if children := c.children:
+                for sc in children:
+                    root.add_reply(to_comment(sc))
+            result.append(root)
+        return result
+
+
+class Data(Struct):
+    content: Post
+    comments: CommentList
+
+
+class Response(Struct):
+    success: bool
+    errcode: int
+    data: Data
+
+    @property
+    def post(self):
+        return self.data.content
+
+    @property
+    def stats(self):
+        return Creator.stats(
+            like_count=self.post.topic_likes_count,
+            share_count=self.post.forward,
+            comment_count=format_num(self.data.comments.total),
+            collect_count=self.post.topic_favorites,
+            view_count=self.post.hits,
+        )
+
+    @property
+    def author(self):
+        return self.post.author
+
+    @property
+    def timestamp(self) -> int:
+        return self.post.timestamp
+
+    @property
+    def url(self) -> str:
+        return self.post.url
+
+    @property
+    def content(self) -> list[ContentItem]:
+        return self.post.content
+
+    @property
+    def title(self) -> str:
+        return self.post.title
+
+    @property
+    def comments(self) -> list[Comment]:
+        return self.data.comments.comments
+
+
+decoder = Decoder(Response)


### PR DESCRIPTION
在 `PlatformEnum` 类中添加了5EPlay平台的枚举值。 在 `__init__.py` 文件中引入了新的 `FiveEPlayParser` 类，并将其添加到 `__all__` 列表中。 新增了 `FiveEPlayParser` 类，用于解析5EPlay平台的帖子，并定义了处理帖子的URL模式。 在 `topic.py` 文件中定义了用于解析5EPlay平台帖子数据的结构类，包括 `UserData`, `FComment`, `ShareData`, `VideoData`, `Post`, `CommentList` 和 `Data`。 定义了 `Response` 结构类用于解析API响应数据，并实现了相关属性以提供帖子的详细信息，如作者、时间戳、URL、内容、标题和评论列表。

## Summary by Sourcery

为 5EPlay 平台添加解析支持，并将其集成到现有的解析器注册表中。

新功能：
- 引入 `FiveEPlayParser`，用于处理 5EPlay 论坛主题 URL，并生成规范化的帖子结果。
- 将 5EPlay 添加到 `PlatformEnum` 中，使其能够被识别为受支持的平台。

改进：
- 为 5EPlay 的主题、帖子和评论数据定义结构化模型和解码逻辑，使其与通用解析器数据格式保持一致。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add parsing support for the 5EPlay platform and integrate it into the existing parser registry.

New Features:
- Introduce FiveEPlayParser to handle 5EPlay forum topic URLs and produce normalized post results.
- Add 5EPlay to the PlatformEnum so it can be recognized as a supported platform.

Enhancements:
- Define structured models and decoding logic for 5EPlay topic, post, and comment data to align with the common parser data format.

</details>