### PR TITLE
enhance(download): 增加av合并下载的缓存

### DIFF
--- a/src/nonebot_plugin_parser_lite/download/__init__.py
+++ b/src/nonebot_plugin_parser_lite/download/__init__.py
@@ -781,6 +781,7 @@ class StreamDownloader:
     ) -> Path:
         """
         下载音频
+
         :param url: 音频下载地址
         :param audio_name: 保存到本地的音频文件名，为空时根据 url 自动生成 mp3 文件名
         :param ext_headers: 额外的请求头，会与默认请求头合并

--- a/src/nonebot_plugin_parser_lite/download/__init__.py
+++ b/src/nonebot_plugin_parser_lite/download/__init__.py
@@ -836,7 +836,9 @@ class StreamDownloader:
         self,
         v_url: str,
         a_url: str,
-        file_name: str,
+        merga_name: str,
+        video_name: str | None = None,
+        audio_name: str | None = None,
         ext_headers: dict[str, str] | None = None,
         use_curl_cffi: bool = False,
     ) -> Path:
@@ -845,29 +847,33 @@ class StreamDownloader:
 
         :param v_url: 视频流下载地址
         :param a_url: 音频流下载地址
-        :param file_name: 合并后输出文件名(不含扩展名)
+        :param merga_name: 合并后输出文件名(不含扩展名)
+        :param video_name: 保存到本地的视频文件名，为空时根据 url 自动生成 mp4 文件名
+        :param audio_name: 保存到本地的音频文件名，为空时根据 url 自动生成 mp3 文件名
         :param ext_headers: 额外的请求头，会与默认请求头合并
         :param use_curl_cffi: 是否使用 curl_cffi 下载
         :return: 合并后的视频文件本地路径
         :raise DownloadException: 下载或合并过程中发生错误时抛出
         """
         cache_dir = await CacheManager.ensure_dir(CacheManager.MEDIA)
-        output_path = cache_dir / f"{file_name}.mp4"
+        output_path = cache_dir / f"{merga_name}.mp4"
         if await output_path.exists():
             return output_path
         v_path, a_path = await asyncio.gather(
             self.download_video(
                 url=v_url,
+                video_name=video_name,
                 ext_headers=ext_headers,
                 use_curl_cffi=use_curl_cffi,
             ),
             self.download_audio(
                 url=a_url,
+                audio_name=audio_name,
                 ext_headers=ext_headers,
                 use_curl_cffi=use_curl_cffi,
             ),
         )
-        return await FFmpeg.merge_av(v_path=v_path, a_path=a_path, file_name=file_name)
+        return await FFmpeg.merge_av(v_path=v_path, a_path=a_path, file_name=merga_name)
 
     @staticmethod
     @contextlib.contextmanager

--- a/src/nonebot_plugin_parser_lite/download/__init__.py
+++ b/src/nonebot_plugin_parser_lite/download/__init__.py
@@ -834,9 +834,9 @@ class StreamDownloader:
 
     async def download_av_and_merge(
         self,
-        v_url: str,
-        a_url: str,
-        merga_name: str,
+        video_url: str,
+        audio_url: str,
+        merge_name: str,
         video_name: str | None = None,
         audio_name: str | None = None,
         ext_headers: dict[str, str] | None = None,
@@ -845,35 +845,35 @@ class StreamDownloader:
         """
         下载音频和视频文件并合并
 
-        :param v_url: 视频流下载地址
-        :param a_url: 音频流下载地址
-        :param merga_name: 合并后输出文件名(不含扩展名)
+        :param video_url: 视频流下载地址
+        :param audio_url: 音频流下载地址
+        :param merge_name: 合并后输出文件名(不含扩展名)
         :param video_name: 保存到本地的视频文件名，为空时根据 url 自动生成 mp4 文件名
         :param audio_name: 保存到本地的音频文件名，为空时根据 url 自动生成 mp3 文件名
         :param ext_headers: 额外的请求头，会与默认请求头合并
         :param use_curl_cffi: 是否使用 curl_cffi 下载
-        :return: 合并后的视频文件本地路径
+        :return: 合并后的视频文件本地路径(mp4)
         :raise DownloadException: 下载或合并过程中发生错误时抛出
         """
         cache_dir = await CacheManager.ensure_dir(CacheManager.MEDIA)
-        output_path = cache_dir / f"{merga_name}.mp4"
+        output_path = cache_dir / f"{merge_name}.mp4"
         if await output_path.exists():
             return output_path
         v_path, a_path = await asyncio.gather(
             self.download_video(
-                url=v_url,
+                url=video_url,
                 video_name=video_name,
                 ext_headers=ext_headers,
                 use_curl_cffi=use_curl_cffi,
             ),
             self.download_audio(
-                url=a_url,
+                url=audio_url,
                 audio_name=audio_name,
                 ext_headers=ext_headers,
                 use_curl_cffi=use_curl_cffi,
             ),
         )
-        return await FFmpeg.merge_av(v_path=v_path, a_path=a_path, file_name=merga_name)
+        return await FFmpeg.merge_av(v_path=v_path, a_path=a_path, file_name=merge_name)
 
     @staticmethod
     @contextlib.contextmanager

--- a/src/nonebot_plugin_parser_lite/matchers/__init__.py
+++ b/src/nonebot_plugin_parser_lite/matchers/__init__.py
@@ -185,7 +185,7 @@ async def register_bili_matcher():
         @on_alconna(
             Alconna(
                 "bm",
-                Args["bv", r"re:BV[A-Za-z0-9]{10}"]["page?", int, 0],
+                Args["bv", r"re:BV[A-Za-z0-9]{10}"]["page?", int, 1],
             ),
             priority=3,
             block=True,
@@ -204,9 +204,12 @@ async def register_bili_matcher():
 
             audio_path = await DOWNLOADER.download_audio(
                 url=audio_url,
+                audio_name=f"{bvid}-{page_idx + 1}.m4a",
                 ext_headers=bilip.headers,
             )
-            converted_path = await FFmpeg.convert_audio_to_mp3(audio_path)
+            converted_path = await FFmpeg.convert_audio_to_mp3(
+                audio_path=audio_path, file_name=f"{bvid}-{page_idx + 1}.mp3"
+            )
             if pconfig.need_upload_audio:
                 await UniMessage(await UniHelper.file_seg(converted_path)).send()
             else:

--- a/src/nonebot_plugin_parser_lite/parsers/bilibili/__init__.py
+++ b/src/nonebot_plugin_parser_lite/parsers/bilibili/__init__.py
@@ -332,9 +332,9 @@ class BilibiliParser(BaseParser):
                 # 有单独音频流时，走 av 合并
                 if self._audio_url:
                     return await DOWNLOADER.download_av_and_merge(
-                        self.video_url,
-                        self._audio_url,
-                        merga_name=file_base,
+                        video_url=self.video_url,
+                        audio_url=self._audio_url,
+                        merge_name=file_base,
                         video_name=f"{file_base}.mp4",
                         audio_name=f"{file_base}.m4a",
                         ext_headers=self.ext_headers,

--- a/src/nonebot_plugin_parser_lite/parsers/bilibili/__init__.py
+++ b/src/nonebot_plugin_parser_lite/parsers/bilibili/__init__.py
@@ -334,7 +334,9 @@ class BilibiliParser(BaseParser):
                     return await DOWNLOADER.download_av_and_merge(
                         self.video_url,
                         self._audio_url,
-                        file_name=file_base,
+                        merga_name=file_base,
+                        video_name=f"{file_base}.mp4",
+                        audio_name=f"{file_base}.m4a",
                         ext_headers=self.ext_headers,
                     )
                 # 否则直接用流式下载


### PR DESCRIPTION
- 将 file_name 参数重命名为 merga_name，用于指定合并后输出文件名
- 新增 video_name 和 audio_name 参数，用于自定义视频和音频文件名
- 当 video_name 或 audio_name 为空时，自动根据 URL 生成对应文件名
- 更新 Bilibili 解析器中对下载器的调用方式

## Summary by Sourcery

增强 AV 下载与合并流程，以支持可配置的文件命名和缓存，并使与 Bilibili 相关的下载和转码调用与新的命名约定保持一致。

新特性：
- 支持为合并后的 AV 文件及其中间视频/音频文件分别指定输出文件名。

改进：
- 基于合并后的输出文件名为 AV 下载添加缓存，以避免重复工作。
- 更新 Bilibili 解析器和匹配器，将明确的文件名传递给下载器和 FFmpeg，用于音频/视频输出。
- 在 bm 匹配器中将默认的 Bilibili 页码参数从 0 调整为 1。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhance AV download and merge flows to support configurable file naming and caching, and align Bilibili-related download and conversion calls with the new naming conventions.

New Features:
- Support specifying separate output names for merged AV files and their intermediate video/audio files.

Enhancements:
- Add caching for merged AV downloads based on the merged output filename to avoid redundant work.
- Update Bilibili parser and matcher to pass explicit file names to the downloader and FFmpeg for audio/video outputs.
- Adjust default Bilibili page argument from 0 to 1 in the bm matcher.

</details>