### PR TITLE
fix(miyoushe): 修复米游社URL生成错误

### DIFF
--- a/src/nonebot_plugin_parser_lite/parsers/miyoushe/__init__.py
+++ b/src/nonebot_plugin_parser_lite/parsers/miyoushe/__init__.py
@@ -21,15 +21,7 @@ class MiyousheParser(BaseParser):
     # https://www.miyoushe.com/ys/article/75247726
     @handle(
         "miyoushe.com",
-        r"/[a-zA-Z]+/#/article/(?P<post_id>\d+)",
-    )
-    @handle(
-        "miyoushe.com",
-        r"/[a-zA-Z]+\?channel=beta/#/article/(?P<post_id>\d+)",
-    )
-    @handle(
-        "miyoushe.com",
-        r"/[a-zA-Z]+/article/(?P<post_id>\d+)",
+        r"/[a-zA-Z]+(?:\?channel=beta)?/(?:#/)?article/(?P<post_id>\d+)",
     )
     async def _(self, searched: MatchWithParams):
         post_id = searched["post_id"]

--- a/src/nonebot_plugin_parser_lite/parsers/miyoushe/__init__.py
+++ b/src/nonebot_plugin_parser_lite/parsers/miyoushe/__init__.py
@@ -21,15 +21,18 @@ class MiyousheParser(BaseParser):
     # https://www.miyoushe.com/ys/article/75247726
     @handle(
         "miyoushe.com",
-        r"/(?P<forum>[a-zA-Z]+)(.*)/#/article/(?P<post_id>\d+)",
+        r"/[a-zA-Z]+/#/article/(?P<post_id>\d+)",
     )
     @handle(
         "miyoushe.com",
-        r"/(?P<forum>[a-zA-Z]+)/article/(?P<post_id>\d+)",
+        r"/[a-zA-Z]+\?channel=beta/#/article/(?P<post_id>\d+)",
+    )
+    @handle(
+        "miyoushe.com",
+        r"/[a-zA-Z]+/article/(?P<post_id>\d+)",
     )
     async def _(self, searched: MatchWithParams):
         post_id = searched["post_id"]
-        forum = searched["forum"]
         res = await self.httpx.get(
             "https://bbs-api.miyoushe.com/post/wapi/getPostFull",
             params={"post_id": post_id},
@@ -56,7 +59,7 @@ class MiyousheParser(BaseParser):
                 avatar_url=post.user.avatar_url,
                 id=post.user.uid,
             ),
-            url=f"https://m.miyoushe.com/{forum}/#/article/{post_id}",
+            url=post.url,
             content=post.post.content,
             title=post.post.subject,
             stats=post.stats,

--- a/src/nonebot_plugin_parser_lite/parsers/miyoushe/post.py
+++ b/src/nonebot_plugin_parser_lite/parsers/miyoushe/post.py
@@ -14,8 +14,21 @@ class ViewType(IntEnum):
     TEXT = 1
 
 
+class GameId(IntEnum):
+    bh3 = 1
+    ys = 2
+    bh2 = 3
+    wd = 4
+    dby = 5
+    sr = 6
+    zzz = 8
+    hna = 9
+    planet = 10
+
+
 class Post(Struct):
     post_id: str
+    game_id: GameId
     subject: str
     structured_content: str
     images: list[str]
@@ -29,6 +42,10 @@ class Post(Struct):
         if self.view_type == ViewType.IMAGE:
             content.extend(Creator.images(self.images))
         return content
+
+    @property
+    def url(self):
+        return f"https://m.miyoushe.com/{self.game_id.name}/#/article/{self.post_id}"
 
 
 class Forum(Struct):
@@ -85,6 +102,10 @@ class Response(Struct):
     @property
     def stat(self):
         return self.data.post.stat
+
+    @property
+    def url(self):
+        return self.post.url
 
     @property
     def stats(self):


### PR DESCRIPTION
- 添加对带有channel参数的链接格式支持
- 移除不必要的forum参数捕获，简化正则表达式
- 使用Post对象的url属性替代手动构建URL
- 新增GameId枚举类以支持不同游戏的URL生成
- 在Post类中添加url属性用于生成正确的文章链接

## Summary by Sourcery

在不同游戏和链接格式下，支持正确解析和生成米游社帖子 URL。

新特性：
- 添加 `GameId` 枚举和帖子上的 `game_id` 字段，以支持按游戏区分的米游社文章 URL。
- 在 `Post` 和 `Forum` 模型上暴露 `url` 属性，用于一致地生成文章链接。

缺陷修复：
- 修复米游社 URL 匹配逻辑，以处理不同的 `channel` 参数变体，并避免依赖版块路径捕获。
- 使用 `Post.url` 属性替代手动拼接的 URL，避免生成错误的链接。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Support correct Miyoushe post URL parsing and generation across different games and link formats.

New Features:
- Add GameId enum and game_id field on posts to support per-game Miyoushe article URLs.
- Expose a url property on Post and Forum models for consistent article link generation.

Bug Fixes:
- Fix Miyoushe URL matching to handle channel parameter variants and avoid relying on forum path capture.
- Use the Post.url property instead of manually constructed URLs to avoid incorrect link generation.

</details>