### PR TITLE
feat(download): 添加HTTP客户端POST方法和JSON解析功能

### DIFF
--- a/src/nonebot_plugin_parser_lite/download/__init__.py
+++ b/src/nonebot_plugin_parser_lite/download/__init__.py
@@ -543,7 +543,6 @@ class StreamDownloader:
                         "GET",
                         ts_url,
                         headers=headers,
-                        timeout=15,
                         use_curl_cffi=use_curl_cffi,
                     ) as resp:
                         if resp.status_code != 200:

--- a/src/nonebot_plugin_parser_lite/download/client.py
+++ b/src/nonebot_plugin_parser_lite/download/client.py
@@ -91,18 +91,17 @@ class UniResponse:
 
 class UniHttpClient:
     def __init__(self, timeout: Timeout):
-        self._timeout = timeout
-        self._httpx = AsyncClient(timeout=timeout, verify=False)
-        self._curl = AsyncSession(impersonate="chrome146")
+        self._httpx = AsyncClient(timeout=timeout, verify=False, follow_redirects=True)
+        self._curl = AsyncSession(
+            impersonate="chrome146",
+            timeout=float(max(timeout.connect or 15, timeout.read or 240)),
+            verify=False,
+            allow_redirects=True,
+        )
 
     async def aclose(self) -> None:
         await self._httpx.aclose()
         await self._curl.close()
-
-    def _curl_timeout(self, timeout: float | None = None) -> float:
-        if timeout is not None:
-            return float(timeout)
-        return float(max(self._timeout.connect or 15, self._timeout.read or 240))
 
     async def head(
         self,
@@ -115,15 +114,11 @@ class UniHttpClient:
             resp = await self._curl.head(
                 url=url,
                 headers=headers,
-                allow_redirects=True,
-                timeout=self._curl_timeout(),
-                verify=False,
             )
         else:
             resp = await self._httpx.head(
                 url=url,
                 headers=headers,
-                follow_redirects=True,
             )
         return UniResponse(resp)
 
@@ -140,16 +135,12 @@ class UniHttpClient:
                 url,
                 params=params,
                 headers=headers,
-                allow_redirects=True,
-                timeout=self._curl_timeout(),
-                verify=False,
             )
         else:
             resp = await self._httpx.get(
                 url,
                 params=params,
                 headers=headers,
-                follow_redirects=True,
             )
         return UniResponse(resp)
 
@@ -171,9 +162,6 @@ class UniHttpClient:
                 headers=headers,
                 data=content or data,
                 json=json,
-                allow_redirects=True,
-                timeout=self._curl_timeout(),
-                verify=False,
             )
         else:
             resp = await self._httpx.post(
@@ -183,7 +171,6 @@ class UniHttpClient:
                 content=content,
                 data=data,
                 json=json,
-                follow_redirects=True,
             )
         return UniResponse(resp)
 
@@ -196,7 +183,6 @@ class UniHttpClient:
         url: str,
         *,
         headers: dict[str, str],
-        timeout: float | None = None,
         use_curl_cffi: bool = False,
     ) -> AsyncGenerator[UniResponse]:
         if use_curl_cffi:
@@ -204,17 +190,8 @@ class UniHttpClient:
                 method,
                 url,
                 headers=headers,
-                timeout=self._curl_timeout(timeout),
-                allow_redirects=True,
-                verify=False,
             ) as resp:
                 yield UniResponse(resp)
         else:
-            kwargs: dict[str, Any] = {
-                "headers": headers,
-                "follow_redirects": True,
-            }
-            if timeout is not None:
-                kwargs["timeout"] = timeout
-            async with self._httpx.stream(method, url, **kwargs) as resp:
+            async with self._httpx.stream(method, url, headers=headers) as resp:
                 yield UniResponse(resp)

--- a/src/nonebot_plugin_parser_lite/download/client.py
+++ b/src/nonebot_plugin_parser_lite/download/client.py
@@ -57,6 +57,9 @@ class UniResponse:
     def content(self) -> bytes:
         return self._raw.content
 
+    def json(self) -> Any:
+        return self._raw.json()
+
     def raise_for_status(self):
         if self.status_code >= 400 or self.status_code < 200:
             status_class = self.status_code // 100
@@ -128,12 +131,14 @@ class UniHttpClient:
         self,
         url: str,
         *,
+        params: dict[str, str] | None = None,
         headers: dict[str, str],
         use_curl_cffi: bool = False,
     ) -> UniResponse:
         if use_curl_cffi:
             resp = await self._curl.get(
                 url,
+                params=params,
                 headers=headers,
                 allow_redirects=True,
                 timeout=self._curl_timeout(),
@@ -142,7 +147,42 @@ class UniHttpClient:
         else:
             resp = await self._httpx.get(
                 url,
+                params=params,
                 headers=headers,
+                follow_redirects=True,
+            )
+        return UniResponse(resp)
+
+    async def post(
+        self,
+        url: str,
+        *,
+        params: dict[str, str] | None = None,
+        headers: dict[str, str],
+        content: str | bytes | None = None,
+        data: dict[str, Any] | None = None,
+        json: dict[str, Any] | None = None,
+        use_curl_cffi: bool = False,
+    ) -> UniResponse:
+        if use_curl_cffi:
+            resp = await self._curl.post(
+                url,
+                params=params,
+                headers=headers,
+                data=content or data,
+                json=json,
+                allow_redirects=True,
+                timeout=self._curl_timeout(),
+                verify=False,
+            )
+        else:
+            resp = await self._httpx.post(
+                url,
+                params=params,
+                headers=headers,
+                content=content,
+                data=data,
+                json=json,
                 follow_redirects=True,
             )
         return UniResponse(resp)

--- a/src/nonebot_plugin_parser_lite/download/client.py
+++ b/src/nonebot_plugin_parser_lite/download/client.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from collections.abc import AsyncGenerator, AsyncIterator
 from contextlib import asynccontextmanager
 from typing import Any, Literal
@@ -100,8 +101,7 @@ class UniHttpClient:
         )
 
     async def aclose(self) -> None:
-        await self._httpx.aclose()
-        await self._curl.close()
+        await asyncio.gather(self._httpx.aclose(), self._curl.close())
 
     async def head(
         self,

--- a/src/nonebot_plugin_parser_lite/download/client.py
+++ b/src/nonebot_plugin_parser_lite/download/client.py
@@ -152,7 +152,7 @@ class UniHttpClient:
         headers: dict[str, str],
         content: str | bytes | None = None,
         data: dict[str, Any] | None = None,
-        json: dict[str, Any] | None = None,
+        json: Any | None = None,
         use_curl_cffi: bool = False,
     ) -> UniResponse:
         if use_curl_cffi:

--- a/src/nonebot_plugin_parser_lite/download/client.py
+++ b/src/nonebot_plugin_parser_lite/download/client.py
@@ -57,8 +57,8 @@ class UniResponse:
     def content(self) -> bytes:
         return self._raw.content
 
-    def json(self) -> Any:
-        return self._raw.json()
+    def json(self, **kw: Any) -> Any:
+        return self._raw.json(**kw)
 
     def raise_for_status(self):
         if self.status_code >= 400 or self.status_code < 200:
@@ -131,7 +131,7 @@ class UniHttpClient:
         self,
         url: str,
         *,
-        params: dict[str, str] | None = None,
+        params: dict[str, Any] | None = None,
         headers: dict[str, str],
         use_curl_cffi: bool = False,
     ) -> UniResponse:
@@ -157,7 +157,7 @@ class UniHttpClient:
         self,
         url: str,
         *,
-        params: dict[str, str] | None = None,
+        params: dict[str, Any] | None = None,
         headers: dict[str, str],
         content: str | bytes | None = None,
         data: dict[str, Any] | None = None,


### PR DESCRIPTION
- 在UniResponse类中添加json()方法用于解析响应内容
- 为UniHttpClient类的get方法添加params参数支持
- 实现UniHttpClient类的post方法，支持params、content、data、json等参数
- 统一处理curl_cffi和httpx两种请求方式的参数传递

## Summary by Sourcery

为各个后端添加 JSON 响应解析能力并扩展 HTTP 客户端的请求选项，同时简化超时与重定向的处理。

New Features:
- 在 `UniResponse` 上暴露 `json()` 辅助方法，用于将响应体解析为 JSON。
- 在 `UniHttpClient.get` 请求中支持查询参数（query parameters），适用于 `httpx` 和 `curl_cffi` 两种后端。
- 引入 `UniHttpClient.post`，在 `httpx` 和 `curl_cffi` 后端上支持查询参数、原始内容（raw content）、表单数据（form data）以及 JSON 负载。

Enhancements:
- 在 `UniHttpClient` 初始化时配置共享的超时和重定向行为，而不是在 `head`、`get` 和 `stream` 方法中逐个请求进行配置。
- 通过依赖客户端级别的超时配置来简化流式请求，并移除逐次调用的超时覆盖逻辑（包括 `download_single_ts` 在内）。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add JSON response parsing and extend the HTTP client with richer request options while simplifying timeout and redirect handling across backends.

New Features:
- Expose a json() helper on UniResponse to parse response bodies as JSON.
- Support query parameters on UniHttpClient.get requests for both httpx and curl_cffi backends.
- Introduce UniHttpClient.post with support for query parameters, raw content, form data, and JSON payloads across httpx and curl_cffi backends.

Enhancements:
- Configure shared timeout and redirect behavior at UniHttpClient initialization instead of per-request configuration for head, get, and stream methods.
- Simplify streaming requests by relying on the client-level timeout configuration and removing per-call timeout overrides, including in download_single_ts.

</details>

新特性：
- 在 `UniResponse` 上暴露 `json()` 辅助方法，用于将响应主体解析为 JSON。
- 在 `UniHttpClient.get` 请求中支持查询参数（query parameters）。
- 引入 `UniHttpClient.post`，在 `curl_cffi` 和 `httpx` 两种后端中均支持查询参数、原始内容（raw content）、表单数据（form data）以及 JSON 负载。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

为各个后端添加 JSON 响应解析能力并扩展 HTTP 客户端的请求选项，同时简化超时与重定向的处理。

New Features:
- 在 `UniResponse` 上暴露 `json()` 辅助方法，用于将响应体解析为 JSON。
- 在 `UniHttpClient.get` 请求中支持查询参数（query parameters），适用于 `httpx` 和 `curl_cffi` 两种后端。
- 引入 `UniHttpClient.post`，在 `httpx` 和 `curl_cffi` 后端上支持查询参数、原始内容（raw content）、表单数据（form data）以及 JSON 负载。

Enhancements:
- 在 `UniHttpClient` 初始化时配置共享的超时和重定向行为，而不是在 `head`、`get` 和 `stream` 方法中逐个请求进行配置。
- 通过依赖客户端级别的超时配置来简化流式请求，并移除逐次调用的超时覆盖逻辑（包括 `download_single_ts` 在内）。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add JSON response parsing and extend the HTTP client with richer request options while simplifying timeout and redirect handling across backends.

New Features:
- Expose a json() helper on UniResponse to parse response bodies as JSON.
- Support query parameters on UniHttpClient.get requests for both httpx and curl_cffi backends.
- Introduce UniHttpClient.post with support for query parameters, raw content, form data, and JSON payloads across httpx and curl_cffi backends.

Enhancements:
- Configure shared timeout and redirect behavior at UniHttpClient initialization instead of per-request configuration for head, get, and stream methods.
- Simplify streaming requests by relying on the client-level timeout configuration and removing per-call timeout overrides, including in download_single_ts.

</details>

</details>