### PR TITLE
feat(helper): 添加私聊消息不支持反应的警告处理

### DIFF
--- a/src/nonebot_plugin_parser_lite/helper.py
+++ b/src/nonebot_plugin_parser_lite/helper.py
@@ -151,6 +151,9 @@ class UniHelper:
         """
         message_id = uniseg.get_message_id(event)
         target = uniseg.get_target(event)
+        if target.private:
+            logger.warning("private message not support reaction")
+            return
 
         if target.adapter in (
             SupportAdapter.onebot11,


### PR DESCRIPTION
当目标为私聊消息时，添加日志警告并提前返回， 避免在不支持反应的私聊场景中继续执行后续逻辑

## Summary by Sourcery

错误修复：
- 当目标为私信时，通过记录警告并提前返回，阻止尝试向私信添加表情反应。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent attempts to add reactions to private messages by logging a warning and returning early when the target is private.

</details>