### PR TITLE
feat(doubao): 新增豆包(DouBao)平台解析器支持

### DIFF
--- a/api_txt/doubao/video.json
+++ b/api_txt/doubao/video.json
@@ -1,0 +1,20 @@
+{
+    "code": 0,
+    "msg": "",
+    "data": {
+        "play_info": {
+            "main": "https://v6-default.365yg.com/091b68aba83d8fcf475be9da0ddcebe1/6a5c9c6b/video/tos/cn/tos-cn-v-9ecd54/oYVXDieiGqOWQgZHxfx6ppGxBLUMUIxgPbDRYA/?a=0&ch=0&cr=7&dr=3&lr=video_gen_watermark_dyn&cd=0%7C0%7C0%7C1&cv=1&br=617&bt=617&cs=4&ds=4&ft=Oi.pi77JWH6BMTZSjJr0PD1IN&mime_type=video_mp4&qs=0&rc=ZDNnOjw3NDdmNjtmNjo0NUBpM2t5Nzlrb285PDczNGY5M0BeXy8xNi1eXzIxLWJiMGMzYSMwZXFxcWduNDVhLS1kNjBzcw%3D%3D&btag=c0000e00008000&cquery=10iH&dy_q=1784450641&feature_id=069767e0b4f5d9d87fcf68b96cd224a7&l=20260719164401C34415E45793BBCEDE03",
+            "backup": "https://v26-default.365yg.com/ccee94cf63e6e52387c4ca35649dcebb/6a5c9c6b/video/tos/cn/tos-cn-v-9ecd54/oYVXDieiGqOWQgZHxfx6ppGxBLUMUIxgPbDRYA/?a=0&ch=0&cr=7&dr=3&lr=video_gen_watermark_dyn&cd=0%7C0%7C0%7C1&cv=1&br=617&bt=617&cs=4&ds=4&ft=Oi.pi77JWH6BMTZSjJr0PD1IN&mime_type=video_mp4&qs=0&rc=ZDNnOjw3NDdmNjtmNjo0NUBpM2t5Nzlrb285PDczNGY5M0BeXy8xNi1eXzIxLWJiMGMzYSMwZXFxcWduNDVhLS1kNjBzcw%3D%3D&btag=c0000e00008000&cquery=10iH&dy_q=1784450641&feature_id=069767e0b4f5d9d87fcf68b96cd224a7&l=20260719164401C34415E45793BBCEDE03",
+            "height": 1280,
+            "width": 720,
+            "definition": "1080p",
+            "poster_url": "https://p5-ex-gddgtc-sign.douyinpic.com/tos-cn-p-9ecd54/oYE1Q140YADXvQ4TmvIIBesgHY4PxKAj6qGr9h~tplv-noop.image?cquery=10iH&dy_q=1784450641&l=20260719164401C34415E45793BBCEDE03&x-expires=1784454251&x-signature=Op4UlBESpbeNfVCO95nftoC08%2F0%3D"
+        },
+        "user_info": {
+            "user_id": 511706721172652,
+            "user_name": "",
+            "nickname": "jojo"
+        },
+        "prompt": "配方：一个小白兔在一个白色的房间内，镜头渐渐靠近小白兔，然后小白兔微笑地说：Hello my friend。然后小白兔疯狂还很狂野并且大声的说：我是个扫福瑞福瑞福瑞福瑞福瑞福瑞扫福瑞我是个扫福瑞扫福瑞我是个扫福瑞我是个扫福瑞我是个扫福瑞我是个扫福瑞我是个扫福瑞我是个扫福瑞。全程都是现实风格。底下要有中文字幕和英文字幕。9:16。"
+    }
+}

--- a/src/nonebot_plugin_parser_lite/constants.py
+++ b/src/nonebot_plugin_parser_lite/constants.py
@@ -63,6 +63,7 @@ class PlatformEnum(str, Enum):
     MIYOUSHE = "miyoushe"
     DOUBAN = "douban"
     FIVEEPLAY = "5eplay"
+    DOUBAO = "doubao"
 
     def __str__(self) -> str:
         return self.value

--- a/src/nonebot_plugin_parser_lite/parsers/__init__.py
+++ b/src/nonebot_plugin_parser_lite/parsers/__init__.py
@@ -3,6 +3,7 @@ from .bilibili import BilibiliParser
 from .buff import BuffParser
 from .coolapk import CoolapkParser
 from .douban import DoubanParser
+from .doubao import DouBaoParser
 from .douyin import DouyinParser
 from .duitang import DuiTangParser
 from .fiveeplay import FiveEPlayParser
@@ -27,6 +28,7 @@ __all__ = [
     "BilibiliParser",
     "BuffParser",
     "CoolapkParser",
+    "DouBaoParser",
     "DoubanParser",
     "DouyinParser",
     "DuiTangParser",

--- a/src/nonebot_plugin_parser_lite/parsers/doubao/__init__.py
+++ b/src/nonebot_plugin_parser_lite/parsers/doubao/__init__.py
@@ -1,0 +1,52 @@
+from typing import ClassVar
+
+from msgspec import convert
+
+from ..base import (
+    BaseParser,
+    MatchWithParams,
+    ParseException,
+    Platform,
+    PlatformEnum,
+    handle,
+)
+from .model import Data
+
+
+class DouBaoParser(BaseParser):
+    platform: ClassVar[Platform] = Platform(
+        name=PlatformEnum.DOUBAO, display_name="豆包"
+    )
+
+    # https://www.doubao.com/video-sharing?source_type=mobile&share_id=49939181380407810&video_id=v0369cg10004d9867lqljht6t4tvhh30
+    @handle("www.doubao.com/video-sharing", params={"share_id": {}, "video_id": {}})
+    async def _parse(self, searched: MatchWithParams):
+        share_id = searched["share_id"]
+        video_id = searched["video_id"]
+
+        resp = await self.httpx.post(
+            "https://www.doubao.com/creativity/share/get_video_share_info",
+            json={
+                "share_id": share_id,
+                "vid": video_id,
+            },
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        if data["code"] != 0:
+            raise ParseException(f"豆包接口返回错误: {data}")
+        result = convert(data["data"], type=Data)
+        return self.result(
+            author=self.create_author(
+                name=result.user_info.nickname,
+                id=str(result.user_info.user_id),
+            ),
+            url=f"https://www.doubao.com/video-sharing?share_id={share_id}&video_id={video_id}",
+            content=[
+                result.prompt,
+                self.create_video(
+                    url_or_task=result.play_info.main,
+                    cover_url=result.play_info.poster_url,
+                ),
+            ],
+        )

--- a/src/nonebot_plugin_parser_lite/parsers/doubao/model.py
+++ b/src/nonebot_plugin_parser_lite/parsers/doubao/model.py
@@ -1,0 +1,19 @@
+from msgspec import Struct
+
+
+class PlayInfo(Struct):
+    main: str
+    backup: str
+    poster_url: str
+
+
+class UserInfo(Struct):
+    user_id: int
+    user_name: str
+    nickname: str
+
+
+class Data(Struct):
+    play_info: PlayInfo
+    user_info: UserInfo
+    prompt: str


### PR DESCRIPTION
新增豆包视频分享链接解析功能，包括：
- 添加 DOUBAO 平台枚举类型
- 实现 DouBaoParser 解析器类
- 定义豆包 API 数据模型结构
- 支持解析视频分享信息、用户信息和提示内容
- 添加相应的 API 响应数据示例文件

## Summary by Sourcery

为解析抖报（DouBao）视频分享链接并通过新的平台解析器暴露其元数据添加支持。

新增功能：
- 引入 `DOUBAO` 平台枚举和 `DouBaoParser`，用于处理抖报视频分享 URL。
- 定义抖报 API 数据模型，包括视频播放信息、用户信息和提示内容。
- 提供一个抖报视频 API 响应示例负载供参考。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for parsing DouBao video sharing links and exposing their metadata via a new platform parser.

New Features:
- Introduce the DOUBAO platform enum and DouBaoParser to handle DouBao video-sharing URLs.
- Define DouBao API data models for video play info, user info, and prompt content.
- Provide an example DouBao video API response payload for reference.

</details>