### PR TITLE
fix(douyin): 修复视频文案重复添加的问题

### DIFF
--- a/src/nonebot_plugin_parser_lite/parsers/douyin/__init__.py
+++ b/src/nonebot_plugin_parser_lite/parsers/douyin/__init__.py
@@ -88,8 +88,7 @@ class DouyinParser(BaseParser):
             ),
             Note,
         )
-        content: list[ContentItem] = [data.aweme.detail.desc]
-        content.extend(data.aweme.content)
+        content: list[ContentItem] = data.aweme.content
         comments = [
             self.create_comment(
                 author=self.create_author(


### PR DESCRIPTION
移除重复的内容项合并，直接使用 data.aweme.content 作为内容列表， 避免将 desc 重复添加到内容中

## Summary by Sourcery

错误修复：
- 通过直接使用 aweme 内容列表，防止抖音笔记内容包含重复的视频描述。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent Douyin note content from including the video description twice by using the aweme content list directly.

</details>