### PR TITLE
fix(miyoushe): 修复米游社帖子时间错误

### DIFF
--- a/src/nonebot_plugin_parser_lite/parsers/miyoushe/__init__.py
+++ b/src/nonebot_plugin_parser_lite/parsers/miyoushe/__init__.py
@@ -56,6 +56,6 @@ class MiyousheParser(BaseParser):
             content=post.post.content,
             title=post.post.subject,
             stats=post.stats,
-            timestamp=post.post.updated_at,
+            timestamp=post.post.created_at,
             comments=comments,
         )

--- a/src/nonebot_plugin_parser_lite/parsers/miyoushe/post.py
+++ b/src/nonebot_plugin_parser_lite/parsers/miyoushe/post.py
@@ -34,6 +34,7 @@ class Post(Struct):
     images: list[str]
     created_at: int
     updated_at: int
+    """最近评论时间"""
     view_type: ViewType
 
     @property


### PR DESCRIPTION
将帖子时间戳从 updated_at 改为 created_at， 以正确显示帖子的创建时间而非最近评论时间

## Summary by Sourcery

在显示米游社帖子时间戳时，使用帖子创建时间而不是最后更新时间。

Bug 修复：
- 修正米游社帖子时间戳，改为显示创建时间，而不是最新评论时间。

增强：
- 为帖子字段 `updated_at` 添加说明，将其定义为“最新评论时间”。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Use the post creation time instead of the last updated time when displaying MiYouShe post timestamps.

Bug Fixes:
- Correct MiYouShe post timestamp to show creation time rather than time of the latest comment.

Enhancements:
- Document the meaning of the post updated_at field as the time of the latest comment.

</details>