### PR TITLE
fix(weibo): 修复微博长文本解析可能失败的问题

### DIFF
--- a/src/nonebot_plugin_parser_lite/parsers/weibo/auth.py
+++ b/src/nonebot_plugin_parser_lite/parsers/weibo/auth.py
@@ -7,7 +7,10 @@ from httpx import AsyncClient
 from nonebot import logger
 import ujson
 
-from ...constants import COMMON_TIMEOUT
+if __name__ == "__main__":
+    COMMON_TIMEOUT = 5  # pyright: ignore[reportGeneralTypeIssues]
+else:
+    from ...constants import COMMON_TIMEOUT
 
 callback_pattern = re.compile(r"visitor_gray_callback\((.*)\)")
 
@@ -56,7 +59,9 @@ class AuthHelper:
                         "https://www.weibo.com",
                         headers={"Referer": "https://visitor.passport.weibo.cn/"},
                     )
-                    cls.xsrf_token = cls.SESSION.cookies["XSRF-TOKEN"]
+                    cls.xsrf_token = (
+                        cls.SESSION.cookies.get("XSRF-TOKEN", domain=".weibo.com") or ""
+                    )
                     cls.xsrf_obtained_at = asyncio.get_event_loop().time()
         except Exception as e:
             logger.error(f"Weibo visitor auth initialization failed: {type(e)}:{e!r}")
@@ -109,7 +114,7 @@ if __name__ == "__main__":
 
     async def main():
         a = await AuthHelper.get(
-            "https://m.weibo.cn/comments/hotflow", params={"mid": "5181502771168068"}
+            "https://m.weibo.cn/statuses/extend", params={"id": "R9JSKvDoO"}
         )
         try:
             print(a.json())  # noqa: T201

--- a/src/nonebot_plugin_parser_lite/parsers/weibo/longText.py
+++ b/src/nonebot_plugin_parser_lite/parsers/weibo/longText.py
@@ -1,10 +1,15 @@
 from msgspec import Struct
 from msgspec.json import Decoder
 
+from .util import weibo_long_html_to_raw
+
 
 class LongData(Struct):
-    isMarkdown: bool
-    longTextContent_raw: str
+    longTextContent: str
+
+    @property
+    def raw(self) -> str:
+        return weibo_long_html_to_raw(self.longTextContent)
 
 
 class LongText(Struct):

--- a/src/nonebot_plugin_parser_lite/parsers/weibo/statuses.py
+++ b/src/nonebot_plugin_parser_lite/parsers/weibo/statuses.py
@@ -22,13 +22,13 @@ class Pic(Struct):
     original: OriginalPic
     pic_id: str
     type: str
-    """pic/livephoto"""
+    """pic/livephoto/gif"""
     video: str = ""
     """Live动图"""
 
     @property
     def content(self):
-        if self.video:
+        if self.type == "livephoto":
             return Creator.live_photo(
                 video_url=self.video,
                 image_url=self.original.url,
@@ -92,10 +92,10 @@ class WeiboData(Struct):
     async def get_content(self):
         if self.isLongText:
             res = await AuthHelper.get(
-                "https://weibo.com/ajax/statuses/longtext",
+                "https://m.weibo.cn/statuses/extend",
                 params={"id": self.idstr},
             )
-            text = longTextDecoder.decode(res.content).data.longTextContent_raw
+            text = longTextDecoder.decode(res.content).data.raw
         else:
             text = self.text_raw
         cleaned_text = _URL_PATTERN.sub("", text).strip()

--- a/src/nonebot_plugin_parser_lite/parsers/weibo/util.py
+++ b/src/nonebot_plugin_parser_lite/parsers/weibo/util.py
@@ -1,0 +1,72 @@
+import re
+
+from bs4 import BeautifulSoup, Comment, Tag
+from bs4.element import NavigableString, PageElement
+
+_CARD_ICON_RE = re.compile(r"timeline_card_small_([a-z0-9]+)", re.I)
+
+_ENTITY_CARD_LABELS = {
+    "super": "超话",
+}
+
+
+def _attr_str(value: str | list[str] | None) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, list):
+        return str(value[0]) if value else ""
+    return str(value)
+
+
+def _entity_label_from_card(a: Tag) -> str | None:
+    for img in a.find_all("img"):
+        src = _attr_str(img.get("src"))
+        if m := _CARD_ICON_RE.search(src):
+            return _ENTITY_CARD_LABELS.get(m.group(1).lower())
+    return None
+
+
+def weibo_long_html_to_raw(html: str) -> str:
+    """将微博 HTML 转为纯文本"""
+    soup = BeautifulSoup(html, "html.parser")
+    parts: list[str] = []
+
+    def walk(node: BeautifulSoup | PageElement) -> None:
+        if isinstance(node, Comment):
+            return
+        if isinstance(node, NavigableString):
+            parts.append(str(node))
+            return
+        if not isinstance(node, Tag):
+            return
+
+        if node.name == "br":
+            parts.append("\n")
+            return
+
+        if node.name == "img":
+            if alt := _attr_str(node.get("alt")):
+                parts.append(alt)
+            return
+
+        if node.name == "a":
+            surl = node.find("span", class_="surl-text")
+            if isinstance(surl, Tag):
+                title = surl.get_text(strip=True)
+                if title and (label := _entity_label_from_card(node)):
+                    parts.append(f"#{title}[{label}]#")
+                    return
+                data_url = _attr_str(node.get("data-url"))
+                if data_url.startswith(("http://t.cn/", "https://t.cn/")):
+                    parts.append(data_url)
+                    return
+                parts.append(title or node.get_text())
+                return
+            parts.append(node.get_text())
+            return
+
+        for child in node.children:
+            walk(child)
+
+    walk(soup)
+    return "".join(parts)


### PR DESCRIPTION
- 实现微博长文本HTML到纯文本的转换功能，支持表情、链接等元素处理
- 修复XSRF-TOKEN获取时的域名匹配问题，使用get方法避免KeyError
- 调整微博API端点从statuses/longtext改为statuses/extend
- 优化图片类型判断逻辑，区分livephoto与其他图片类型
- 添加调试模式下的默认超时配置，解决模块独立运行时的导入问题

## Summary by Sourcery

修复微博长文本解析的可靠性，并调整相关 API 与媒体处理。

New Features:
- 通过新增工具将微博长文本的 HTML 内容转换为规范化的纯文本，从而更好地支持表情符号、链接以及实体卡片。

Bug Fixes:
- 使用带域名范围的 `cookie.get` 并提供安全的默认值，避免在获取 `XSRF-TOKEN` 时出现失败。
- 将原先使用的原始字段替换为 HTML 转文本的方式，确保长文本内容被正确提取。

Enhancements:
- 将长文本 API 的使用从 `weibo.com` 的 ajax 状态端点切换到 `m.weibo.cn` 的 `statuses extend` 端点，以与当前微博 API 保持一致。
- 优化图片类型处理逻辑，使实况照片（live photos）与其他图片类型区分开来，并仅在合适的情况下使用实况照片渲染。
- 在独立运行微博认证模块时增加默认超时时间，以避免在调试模式下出现导入问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix Weibo long-text parsing reliability and adjust related APIs and media handling.

New Features:
- Convert Weibo long-text HTML content to normalized plain text via a new utility, improving support for emojis, links, and entity cards.

Bug Fixes:
- Prevent failures when obtaining the XSRF-TOKEN by using cookie.get with domain scoping and a safe default.
- Ensure long-text content is correctly extracted by replacing the previous raw field with HTML-to-text conversion.

Enhancements:
- Switch long-text API usage from weibo.com ajax status endpoint to m.weibo.cn statuses extend endpoint to align with current Weibo APIs.
- Refine image type handling so live photos are distinguished from other image types and only use live-photo rendering when appropriate.
- Add a default timeout when running the Weibo auth module standalone to avoid import issues in debug mode.

</details>