### PR TITLE
feat(rednote): 新增 xhslink.cn 短链接解析支持

### DIFF
--- a/src/nonebot_plugin_parser_lite/parsers/rednote/__init__.py
+++ b/src/nonebot_plugin_parser_lite/parsers/rednote/__init__.py
@@ -35,6 +35,7 @@ class RedNoteParser(BaseParser):
             }
         )
 
+    @handle("xhslink.cn", r"xhslink\.cn/[A-Za-z0-9._?%&+=/#@-]+")
     @handle("xhslink.com", r"xhslink\.com/[A-Za-z0-9._?%&+=/#@-]+")
     async def _parse_short_link(self, searched: MatchWithParams):
         url = f"https://{searched.url}"


### PR DESCRIPTION
新增对 xhslink.cn 域名的短链接解析处理，
扩展了小红书链接解析器的功能范围

## Summary by Sourcery

新功能：
- 在现有域名的基础上，新增对使用 `xhslink.cn` 域名的 Rednote 短链接解析支持。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

New Features:
- Support parsing of Rednote short links using the xhslink.cn domain alongside existing domains.

</details>