### PR TITLE
fix(miyoushe): 修复没有分区的帖子解析失败

### DIFF
--- a/src/nonebot_plugin_parser_lite/parsers/miyoushe/post.py
+++ b/src/nonebot_plugin_parser_lite/parsers/miyoushe/post.py
@@ -74,7 +74,7 @@ class Stat(Struct):
 
 class PostData(Struct):
     post: Post
-    forum: Forum
+    forum: Forum | None
     user: User
     stat: Stat
 


### PR DESCRIPTION
修复部分不存在forum信息的帖子，序列化失败的问题

## Summary by Sourcery

Bug Fixes:
- 修复在解析不包含论坛信息的米游社帖子时出现的序列化失败问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix serialization failures when parsing Miyoushe posts that do not include forum information.

</details>