### PR TITLE
feat(config): 更新主题切换配置为时间范围格式

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,12 +189,9 @@ plite_forward_text_threshold=1000
 # [可选] 最大下载重试次数
 plite_max_retries=3
 
-# 下面的设置用于主题颜色的自动切换
-# [可选] 白天开始时间(h)
-plite_day_start_hour=6
-
-# [可选] 夜间开始时间(h)
-plite_night_start_hour=19
+# [可选] 白天时间范围 [开始, 结束]，格式 h:m；范围内为浅色主题，范围外为夜间模式
+# 支持跨午夜范围，例如 ["22:30", "6:00"]
+plite_day_range=["6:00", "19:00"]
 ```
 
 </details>

--- a/src/nonebot_plugin_parser_lite/config.py
+++ b/src/nonebot_plugin_parser_lite/config.py
@@ -7,6 +7,22 @@ from .constants import PlatformEnum
 from .utils.bilibili.video import BiliVideoCodecs, BiliVideoQuality
 
 
+def parse_hm_to_minutes(value: str) -> int:
+    """将 h:m 或 hh:mm 解析为从 0 点起的分钟数"""
+    text = value.strip()
+    parts = text.split(":")
+    if len(parts) != 2:
+        raise ValueError(f"时间格式错误，应为 h:m，收到: {value!r}")
+    try:
+        hour = int(parts[0])
+        minute = int(parts[1])
+    except ValueError as e:
+        raise ValueError(f"时间格式错误，应为 h:m，收到: {value!r}") from e
+    if not (0 <= hour <= 23 and 0 <= minute <= 59):
+        raise ValueError(f"时间超出有效范围 (0:00-23:59)，收到: {value!r}")
+    return hour * 60 + minute
+
+
 class Config(BaseModel):
     plite_bili_ck: str | None = None
     """bilibili cookies"""
@@ -19,7 +35,7 @@ class Config(BaseModel):
     plite_use_base64: bool = False
     """是否使用 base64 编码发送图片，音频，视频"""
     plite_max_size: int = 90
-    """资源最大大小，默认 100 单位 MB"""
+    """资源最大大小，默认 90 单位 MB"""
     plite_duration_maximum: int = 480
     """视频/音频最大时长"""
     plite_append_url: bool = False
@@ -61,10 +77,8 @@ class Config(BaseModel):
     """纯文本文本长度阈值，超过此长度的文本将会强制转发(最大4500)"""
     plite_max_retries: int = 3
     """最大下载重试次数"""
-    plite_day_start_hour: int = 6
-    """白天开始时间(h)"""
-    plite_night_start_hour: int = 19
-    """黑夜开始时间(h)"""
+    plite_day_range: list[str] = ["6:00", "19:00"]
+    """白天时间范围 [开始, 结束]，格式 h:m；范围内为浅色主题，范围外为夜间模式"""
 
     @property
     def nickname(self) -> str:
@@ -202,14 +216,12 @@ class Config(BaseModel):
         return self.plite_max_retries
 
     @property
-    def day_start_hour(self) -> int:
-        """白天开始时间(h)"""
-        return self.plite_day_start_hour
-
-    @property
-    def night_start_hour(self) -> int:
-        """黑夜开始时间(h)"""
-        return self.plite_night_start_hour
+    def day_range_minutes(self) -> tuple[int, int]:
+        """白天时间范围，返回 (开始分钟, 结束分钟)"""
+        return (
+            parse_hm_to_minutes(self.plite_day_range[0]),
+            parse_hm_to_minutes(self.plite_day_range[1]),
+        )
 
 
 # 初始化配置实例

--- a/src/nonebot_plugin_parser_lite/render/__init__.py
+++ b/src/nonebot_plugin_parser_lite/render/__init__.py
@@ -51,7 +51,10 @@ def get_theme() -> Theme:
     start, end = pconfig.day_range_minutes
     now = datetime.now()
     current = now.hour * 60 + now.minute
-    if start < end:
+    if start == end:
+        # 为什么会有极夜
+        in_day = False
+    elif start < end:
         in_day = start <= current < end
     else:
         in_day = current >= start or current < end

--- a/src/nonebot_plugin_parser_lite/render/__init__.py
+++ b/src/nonebot_plugin_parser_lite/render/__init__.py
@@ -44,16 +44,18 @@ MAX_FORWARD_NODES = 90
 IS_DEBUG = gconfig.log_level in ["DEBUG", "TRACE", 10, 5]
 
 Theme = Literal["light", "dark"]
-DAY_START_HOUR = pconfig.day_start_hour
-NIGHT_START_HOUR = pconfig.night_start_hour
 
 
 def get_theme() -> Theme:
-    """Return the theme for the current local time."""
-    current_time = datetime.now()
-    if DAY_START_HOUR <= current_time.hour < NIGHT_START_HOUR:
-        return "light"
-    return "dark"
+    """根据配置的白天时间范围返回当前主题"""
+    start, end = pconfig.day_range_minutes
+    now = datetime.now()
+    current = now.hour * 60 + now.minute
+    if start < end:
+        in_day = start <= current < end
+    else:
+        in_day = current >= start or current < end
+    return "light" if in_day else "dark"
 
 
 def split_text_by_length_with_punct(text: str, max_len: int) -> list[str]:


### PR DESCRIPTION
- 将原有的 day_start_hour 和 night_start_hour 配置项替换为 day_range 配置项，支持更灵活的时间范围设置
- 新增 parse_hm_to_minutes 函数用于解析 h:m 格式时间为分钟数
- 支持跨午夜的时间范围，如 ["22:30", "6:00"]
- 更新默认资源最大大小从 100MB 调整为 90MB

## Summary by Sourcery

更新主题自动切换配置，以使用可配置的白天时间范围，并调整相关默认值。

New Features:
- 引入 `plite_day_range` 配置，用 `h:m` 字符串定义亮色主题的时间窗口，包括跨午夜范围。
- 新增 `day_range_minutes` 属性，以分钟形式暴露配置的白天时间范围，用于主题计算。
- 新增 `parse_hm_to_minutes` 工具函数，用于将 `h:m` 格式的时间字符串解析为自午夜起的分钟数。

Enhancements:
- 修改主题选择逻辑，使用基于分钟的白天时间范围，支持跨午夜的时间段。
- 将默认的最大资源大小配置从 100MB 调整为 90MB。

Documentation:
- 更新 README 的配置章节，文档化 `plite_day_range` 的用法，并提供昼夜主题切换示例。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update theme auto-switch configuration to use a configurable day time range and adjust related defaults.

New Features:
- Introduce plite_day_range configuration to define the light-theme time window using h:m strings, including跨午夜 ranges.
- Add day_range_minutes property to expose the configured day time range as minutes for theme calculation.
- Add parse_hm_to_minutes utility to parse h:m formatted time strings into minutes since midnight.

Enhancements:
- Change theme selection logic to use minute-based day ranges, supporting ranges that cross midnight.
- Adjust default maximum resource size configuration from 100MB to 90MB.

Documentation:
- Update README configuration section to document plite_day_range usage and examples for day/night theme switching.

</details>