### PR TITLE
refactor(client): 移除贴吧和X的独立http客户端

### DIFF
--- a/src/nonebot_plugin_parser_lite/matchers/__init__.py
+++ b/src/nonebot_plugin_parser_lite/matchers/__init__.py
@@ -24,7 +24,6 @@ from ..download import DOWNLOADER
 from ..helper import UniHelper
 from ..parsers import BilibiliParser
 from ..parsers.base import BaseParser, ParseResult
-from ..parsers.tieba.utils import close_client as close_tieba_client
 from ..parsers.weibo.auth import AuthHelper as WeiboAuthHelper
 from ..render import RENDERER
 from ..utils.common import LimitedSizeDict
@@ -126,7 +125,6 @@ async def close_httpx() -> None:
     await asyncio.gather(
         *(parser.aclose() for parser in _ALL_PARSERS),
         DOWNLOADER.aclose(),
-        close_tieba_client(),
         WeiboAuthHelper.aclose(),
     )
 

--- a/src/nonebot_plugin_parser_lite/parsers/tieba/utils.py
+++ b/src/nonebot_plugin_parser_lite/parsers/tieba/utils.py
@@ -3,11 +3,11 @@ from pathlib import Path
 
 from google.protobuf import descriptor_pb2, descriptor_pool
 from google.protobuf.message_factory import GetMessageClass
-from httpx import AsyncClient
 
 from ...constants import STICKER_CDN
 from ...creator import Creator
 from ...data import Comment, ContentItem
+from ...download import DOWNLOADER
 from .models import (
     Contents,
     FragAt,
@@ -20,8 +20,6 @@ from .models import (
     Posts,
 )
 
-_CLIENT = AsyncClient()
-
 
 @lru_cache(maxsize=2)
 def get_message(name: str):
@@ -33,10 +31,6 @@ def get_message(name: str):
 
     msg_descriptor = pool.FindMessageTypeByName(name)
     return GetMessageClass(msg_descriptor)
-
-
-async def close_client() -> None:
-    await _CLIENT.aclose()
 
 
 def make_req(tid: int) -> bytes:
@@ -74,7 +68,7 @@ async def pack_req(data: bytes) -> bytes:
     )
 
     # 设置 Content-Type，带上固定 boundary
-    response = await _CLIENT.post(
+    response = await DOWNLOADER.client.post(
         "http://tiebac.baidu.com/c/f/pb/page",
         headers={
             "x_bd_data_type": "protobuf",

--- a/src/nonebot_plugin_parser_lite/parsers/x/__init__.py
+++ b/src/nonebot_plugin_parser_lite/parsers/x/__init__.py
@@ -1,10 +1,10 @@
 from typing import ClassVar
 
-from curl_cffi import AsyncSession
 from msgspec import convert
 
 from ...utils.format import format_num
 from ..base import (
+    DOWNLOADER,
     BaseParser,
     ContentItem,
     MatchWithParams,
@@ -19,13 +19,6 @@ from .model import TweetEntry
 
 class XParser(BaseParser):
     platform: ClassVar[Platform] = Platform(name=PlatformEnum.X, display_name="X")
-
-    def __init__(self):
-        super().__init__()
-        self.session = AsyncSession(impersonate="chrome146")
-        self.headers.update(
-            {"Host": "easycomment.ai", "Content-Type": "application/json"}
-        )
 
     def collect_data(self, raw: TweetEntry, is_repost: bool = False) -> ParseResult:
         tweet = raw.result.as_tweet
@@ -99,10 +92,12 @@ class XParser(BaseParser):
     async def _parse(self, searched: MatchWithParams) -> ParseResult:
         tweet_id = searched[1]
 
-        response = await self.session.post(
+        response = await DOWNLOADER.client.post(
             "https://easycomment.ai/api/twitter/v1/free/get-tweet-detail",
             json={"pid": tweet_id},
-            headers=self.headers,
+            headers=self.headers
+            | {"Host": "easycomment.ai", "Content-Type": "application/json"},
+            use_curl_cffi=True,
         )
         try:
             response.raise_for_status()


### PR DESCRIPTION
统一使用全局下载器实例

BREAKING CHANGE: 贴吧和X解析器不再使用独立的HTTP客户端实例， 改为使用全局DOWNLOADER.client进行网络请求

## Summary by Sourcery

统一 X 和贴吧解析器的 HTTP 网络逻辑，使其使用共享的全局下载器客户端，而不是各自独立的客户端实例。

Enhancements:
- 重构 X 解析器，使推文详情请求通过全局 `DOWNLOADER` 客户端发送，而不是使用其独立的 `curl_cffi` 会话。
- 重构贴吧的 protobuf 页面请求，使其使用全局 `DOWNLOADER` 客户端，而不是单独的 `httpx.AsyncClient`，从而移除专用的贴吧客户端生命周期。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify HTTP networking for X and Tieba parsers to use the shared global downloader client instead of dedicated client instances.

Enhancements:
- Refactor the X parser to send tweet detail requests via the global DOWNLOADER client rather than its own curl_cffi session.
- Refactor Tieba protobuf page requests to use the global DOWNLOADER client instead of a separate httpx.AsyncClient, removing the dedicated Tieba client lifecycle.

</details>