### PR TITLE
refactor(heybox): 移除设备id缓存逻辑

### DIFF
--- a/src/nonebot_plugin_parser_lite/parsers/heybox/__init__.py
+++ b/src/nonebot_plugin_parser_lite/parsers/heybox/__init__.py
@@ -13,7 +13,6 @@ from ..base import (
     Platform,
     PlatformEnum,
     handle,
-    pconfig,
 )
 from .encrypt import build_url
 from .model import BaseResult
@@ -34,28 +33,21 @@ class HeyBoxParser(BaseParser):
                 "Accept": "application/json, text/plain, */*",
             }
         )
-        self.device_path = pconfig.config_dir / "heybox_device.txt"
         self.device_id: str = ""
 
     async def ensure_token(self):
         if self.device_id:
             return
-        if await self.device_path.exists():
-            self.device_id = (
-                await self.device_path.read_text(encoding="utf-8")
-            ).strip()
-        else:
-            tab = await BrowserManager.new_tab()
-            tab.set.load_mode.none()
-            tab.listen.start(targets="fp.min.js", method="get", res_type="Script")
-            tab.get("https://www.xiaoheihe.cn/")
-            tab.listen.wait()
-            tab.listen.stop()
-            tab.stop_loading()
-            self.device_id = tab.run_js("window.SMSdk.getDeviceId()", as_expr=True)
-            tab.close()
-            logger.info(f"成功获取到小黑盒tokenid: {self.device_id[:5]}...")
-            await self.device_path.write_text(self.device_id.strip())
+        tab = await BrowserManager.new_tab()
+        tab.set.load_mode.none()
+        tab.listen.start(targets="fp.min.js", method="get", res_type="Script")
+        tab.get("https://www.xiaoheihe.cn/")
+        tab.listen.wait()
+        tab.listen.stop()
+        tab.stop_loading()
+        self.device_id = tab.run_js("window.SMSdk.getDeviceId()", as_expr=True)
+        tab.close()
+        logger.info(f"成功获取到小黑盒tokenid: {self.device_id[:5]}...")
 
     @handle("api.xiaoheihe.cn/v3/bbs/app/api/web/share", params={"link_id": {}})
     @handle("xiaoheihe.cn/bbs/post_share", params={"link_id": {}})


### PR DESCRIPTION
移除了pconfig依赖和设备路径配置，不再将设备ID保存到本地文件， 改为每次启动时重新获取设备ID以确保时效性

## Summary by Sourcery

重构 Heybox 解析器，使其在启动时始终获取新的设备 ID，而不是使用本地缓存的值。

改进内容：
- 从 Heybox 解析器中移除对 pconfig 的依赖以及相关的设备路径配置。
- 通过移除基于文件系统的设备 ID 缓存，并仅依赖通过浏览器管理器在运行时获取设备 ID，简化令牌获取流程。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor Heybox parser to always retrieve a fresh device ID on startup instead of using a locally cached value.

Enhancements:
- Remove the pconfig dependency and associated device path configuration from the Heybox parser.
- Simplify token acquisition by dropping filesystem-based device ID caching and relying solely on runtime retrieval via the browser manager.

</details>

增强内容：
- 移除 Heybox 设备 ID 的本地缓存，在启动时始终获取最新 ID，以确保时效性。
- 消除 Heybox 解析器对 pconfig 以及相关设备路径配置的依赖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

重构 Heybox 解析器，使其在启动时始终获取新的设备 ID，而不是使用本地缓存的值。

改进内容：
- 从 Heybox 解析器中移除对 pconfig 的依赖以及相关的设备路径配置。
- 通过移除基于文件系统的设备 ID 缓存，并仅依赖通过浏览器管理器在运行时获取设备 ID，简化令牌获取流程。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor Heybox parser to always retrieve a fresh device ID on startup instead of using a locally cached value.

Enhancements:
- Remove the pconfig dependency and associated device path configuration from the Heybox parser.
- Simplify token acquisition by dropping filesystem-based device ID caching and relying solely on runtime retrieval via the browser manager.

</details>

</details>