### PR TITLE
fix(parsers): 修复html内容遍历中存在的bug

### DIFF
--- a/src/nonebot_plugin_parser_lite/parsers/linuxdo/util.py
+++ b/src/nonebot_plugin_parser_lite/parsers/linuxdo/util.py
@@ -37,10 +37,11 @@ def parse_rich_content(html: str) -> list[ContentItem]:
 def _iter_media_and_text(soup: BeautifulSoup):
     for element in soup.descendants:
         if isinstance(element, Tag):
-            if element.name == "span":
-                classes = element.get("class") or []
-                if "filename" in classes or "informations" in classes:
-                    element.decompose()
+            if element.name == "span" and (
+                "filename" in (element.get("class") or [])
+                or "informations" in (element.get("class") or [])
+            ):
+                element.clear()
                 continue
 
             if element.name == "p":

--- a/src/nonebot_plugin_parser_lite/parsers/zhihu/util.py
+++ b/src/nonebot_plugin_parser_lite/parsers/zhihu/util.py
@@ -110,7 +110,7 @@ async def _iter_media_and_text(soup: BeautifulSoup, content_type: str):
                     if text := str(data_name).strip():
                         yield text
 
-                element.decompose()
+                element.clear()
                 continue
 
             if element.name == "img":
@@ -128,8 +128,7 @@ async def _iter_media_and_text(soup: BeautifulSoup, content_type: str):
                     yield Creator.graphic(url=src)
 
         elif isinstance(element, NavigableString):
-            text = str(element)
-            if text.strip():
+            if text := str(element).strip():
                 yield text
 
 


### PR DESCRIPTION
- 将linuxdo解析器中的span元素处理改为更简洁的条件判断，并使用clear()方法替代decompose()
- 统一zhihu解析器中对HTML元素的清理方式，全部使用clear()方法
- 优化zhihu解析器中的字符串处理逻辑，使用海象操作符简化代码

## Summary by Sourcery

在 linuxdo 和知乎解析器中对 HTML 内容遍历行为进行对齐，以修复 `span` 和文本处理相关的问题。

错误修复（Bug Fixes）:
- 防止在 linuxdo 解析器中过滤文件名和信息类元数据时，意外移除或错误处理 `span` 元素。
- 在知乎解析器进行媒体内容提取时，避免过于激进地移除元素，从而保持遍历行为的正确性。
- 确保知乎解析器在处理文本节点时，只输出去除首尾空白后的非空字符串。

功能改进（Enhancements）:
- 简化 linuxdo 和知乎解析器中对 `span` 类名的检查及文本提取逻辑，使 HTML 清理行为更加清晰且保持一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Align HTML content traversal behavior in linuxdo and Zhihu parsers to fix span and text handling issues.

Bug Fixes:
- Prevent unintended removal or misprocessing of span elements in the linuxdo parser when filtering filename and information metadata.
- Avoid overly aggressive element removal in the Zhihu parser during media extraction to preserve traversal correctness.
- Ensure Zhihu text node handling only yields non-empty, trimmed strings during HTML parsing.

Enhancements:
- Simplify span class checks and text extraction logic in both linuxdo and Zhihu parsers for clearer and more consistent HTML cleaning behavior.

</details>