### PR TITLE
refactor: 重构插件架构以支持独立运行模式

### DIFF
--- a/src/nonebot_plugin_parser_lite/__init__.py
+++ b/src/nonebot_plugin_parser_lite/__init__.py
@@ -1,50 +1,16 @@
-from .utils._flags import _STANDALONE, _get_flag  # noqa: F401
+from nonebot import require
 
-if _STANDALONE:
-    from logging import getLogger as _getLogger
-
-    logger = _getLogger("parser-lite")
-    PluginMetadata = None  # type: ignore
-    inherit_supported_adapters = None  # type: ignore
-
-    from apscheduler.schedulers.asyncio import AsyncIOScheduler
-
-    scheduler = AsyncIOScheduler()
-    scheduler.configure({"apscheduler.timezone": "Asia/Shanghai"})
-    try:
-        scheduler.start()
-    except RuntimeError:
-        pass  # no event loop yet — consumer calls scheduler.start() later
-
-    def clear_result_cache() -> None:
-        pass
-
-    class BrowserManager:
-        @staticmethod
-        def clear_cache() -> None:
-            pass
-
-        @staticmethod
-        def reconnect() -> None:
-            pass
-
-else:
-    from nonebot import logger, require
-    from nonebot.plugin import PluginMetadata, inherit_supported_adapters
-
-    require("nonebot_plugin_alconna")
-    require("nonebot_plugin_uninfo")
-    require("nonebot_plugin_htmlrender")
-    require("nonebot_plugin_apscheduler")
-    require("nonebot_plugin_localstore")
-
-    from nonebot_plugin_apscheduler import scheduler
-    from .matchers import clear_result_cache
-    from .utils.browser import BrowserManager
+require("nonebot_plugin_alconna")
+require("nonebot_plugin_uninfo")
+require("nonebot_plugin_htmlrender")
+require("nonebot_plugin_localstore")
+from nonebot.plugin import PluginMetadata, inherit_supported_adapters
 
 from .config import Config
-
+from .utils.browser import BrowserManager
 from .utils.cache import CacheManager
+from .utils.log import logger
+from .utils.schedule import scheduler
 
 __plugin_meta__ = PluginMetadata(
     name="链接分享解析 Lite 版",
@@ -62,20 +28,21 @@ __plugin_meta__ = PluginMetadata(
         "version": "1.3.1",
         "plugin_type": "NORMAL",
     },
-) if not _STANDALONE else None
+)
 
 
-if scheduler is not None:
+from .matchers import clear_result_cache
 
-    @scheduler.scheduled_job("interval", hours=2, id="parser-clean-local-cache")
-    async def clean_plugin_cache() -> None:
-        """周期性清理过期缓存文件，并重置解析状态。"""
 
-        try:
-            await CacheManager.clean_expired()
-        except Exception as e:
-            logger.exception(f"清理缓存文件时发生异常: {e!r}")
+@scheduler.scheduled_job("interval", hours=2, id="parser-clean-local-cache")
+async def clean_plugin_cache() -> None:
+    """周期性清理过期缓存文件，并重置解析状态。"""
 
-        clear_result_cache()
-        BrowserManager.clear_cache()
-        BrowserManager.reconnect()
+    try:
+        await CacheManager.clean_expired()
+    except Exception as e:
+        logger.exception(f"清理缓存文件时发生异常: {e!r}")
+
+    clear_result_cache()
+    BrowserManager.clear_cache()
+    BrowserManager.reconnect()

--- a/src/nonebot_plugin_parser_lite/config.py
+++ b/src/nonebot_plugin_parser_lite/config.py
@@ -226,14 +226,14 @@ class Config(BaseModel):
 
 
 if IS_STANDALONE:
-    import asyncio
+    from pathlib import Path as PathSync
 
-    base_dir = Path(os.environ.get("PARSER_LITE_BASE_DIR", asyncio.run(Path().cwd())))
+    base_dir = Path(os.environ.get("PARSER_LITE_BASE_DIR", PathSync().cwd()))
     _cache_dir: Path = Path(base_dir / "cache")
     _config_dir: Path = Path(base_dir / "config")
     _data_dir: Path = Path(base_dir / "data")
     for d in [_cache_dir, _config_dir, _data_dir]:
-        asyncio.run(d.mkdir(parents=True, exist_ok=True))
+        PathSync(d).mkdir(parents=True, exist_ok=True)
     pconfig: Config = Config()
 
     class GlobalConfig(BaseModel):

--- a/src/nonebot_plugin_parser_lite/config.py
+++ b/src/nonebot_plugin_parser_lite/config.py
@@ -1,11 +1,11 @@
 import os
-from pathlib import Path as _Path
+
 from anyio import Path
 from pydantic import BaseModel
 
 from .constants import PlatformEnum
-from .utils._flags import _get_flag, _STANDALONE
 from .utils.bilibili.video import BiliVideoCodecs, BiliVideoQuality
+from .utils.env import IS_STANDALONE
 
 
 def parse_hm_to_minutes(value: str) -> int:
@@ -225,21 +225,22 @@ class Config(BaseModel):
         )
 
 
-if _STANDALONE:
-    base_dir = _Path(
-        os.environ.get(
-            "PARSER_LITE_BASE_DIR",
-            _Path(__file__).resolve().parent.parent,
-        )
-    )
-    _cache_dir: Path = Path(str(base_dir / "cache"))
-    _config_dir: Path = Path(str(base_dir / "config"))
-    _data_dir: Path = Path(str(base_dir / "data"))
-    for d in (_Path(_cache_dir), _Path(_config_dir), _Path(_data_dir)):
-        d.mkdir(parents=True, exist_ok=True)
+if IS_STANDALONE:
+    import asyncio
+
+    base_dir = Path(os.environ.get("PARSER_LITE_BASE_DIR", asyncio.run(Path().cwd())))
+    _cache_dir: Path = Path(base_dir / "cache")
+    _config_dir: Path = Path(base_dir / "config")
+    _data_dir: Path = Path(base_dir / "data")
+    for d in [_cache_dir, _config_dir, _data_dir]:
+        asyncio.run(d.mkdir(parents=True, exist_ok=True))
     pconfig: Config = Config()
-    gconfig = None
-    _nickname: str = "parser-lite"
+
+    class GlobalConfig(BaseModel):
+        log_level: str | int = "INFO"
+        nickname: list[str] = ["parser-lite"]
+
+    gconfig = GlobalConfig()
 else:
     from nonebot import get_driver, get_plugin_config
     import nonebot_plugin_localstore as _store
@@ -252,5 +253,5 @@ else:
     """插件配置"""
     gconfig = _driver.config
     """全局配置"""
-    _nickname: str = next(iter(gconfig.nickname), "nonebot-plugin-parser")
-    """机器人昵称"""
+_nickname: str = next(iter(gconfig.nickname), "nonebot-plugin-parser")
+"""机器人昵称"""

--- a/src/nonebot_plugin_parser_lite/data.py
+++ b/src/nonebot_plugin_parser_lite/data.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
 from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Any, Literal, TypedDict
@@ -223,7 +224,7 @@ class Comment:
 
     author: Author
     """作者信息"""
-    content: list[ContentItem]
+    content: Sequence[ContentItem]
     """评论内容，可以是文本或媒体对象"""
     timestamp: int | None
     """发布时间戳，单位秒"""
@@ -267,7 +268,7 @@ class ParseResult:
     """作者信息"""
     url: str
     """来源链接"""
-    content: list[ContentItem]
+    content: Sequence[ContentItem]
     """资源/文本内容"""
     title: str | None = field(default=None)
     """标题"""

--- a/src/nonebot_plugin_parser_lite/download/__init__.py
+++ b/src/nonebot_plugin_parser_lite/download/__init__.py
@@ -9,7 +9,6 @@ from urllib.parse import urljoin
 
 import aiofiles
 from anyio import Path
-from ..utils.log import logger
 from rich.progress import (
     BarColumn,
     DownloadColumn,
@@ -25,6 +24,7 @@ from ..exception import DownloadException, SizeLimitException, ZeroSizeException
 from ..utils.cache import CacheManager
 from ..utils.common import generate_file_name, make_filename, safe_unlink
 from ..utils.ffmpeg import FFmpeg
+from ..utils.log import logger
 from .client import RetryableDownloadError, UniHttpClient, UniResponse
 from .task import auto_task
 
@@ -200,7 +200,7 @@ class StreamDownloader:
                 delay = min(2**retry, 8)
                 logger.warning(
                     f"下载失败，{delay} 秒后重试 ({retry + 1}/"
-                    f"{self.MAX_RETRIES}): {last_error !r}"
+                    f"{self.MAX_RETRIES}): {last_error!r}"
                 )
                 await asyncio.sleep(delay)
 

--- a/src/nonebot_plugin_parser_lite/helper.py
+++ b/src/nonebot_plugin_parser_lite/helper.py
@@ -3,7 +3,6 @@ from functools import wraps
 from typing import Any, Literal
 
 from anyio import Path
-from nonebot import logger
 from nonebot.adapters import Event
 from nonebot.matcher import current_bot, current_event
 from nonebot_plugin_alconna import SupportAdapter, uniseg
@@ -22,6 +21,7 @@ from nonebot_plugin_alconna.uniseg import (
 from .config import pconfig
 from .constants import EMOJI_MAP
 from .exception import TipException
+from .utils.log import logger
 
 ForwardNodeInner = str | Segment | UniMessage
 """转发消息节点内部允许的类型"""

--- a/src/nonebot_plugin_parser_lite/matchers/rule.py
+++ b/src/nonebot_plugin_parser_lite/matchers/rule.py
@@ -3,7 +3,6 @@ from typing import Literal
 
 from msgspec import DecodeError, Struct
 from msgspec.json import Decoder
-from nonebot import logger
 from nonebot.matcher import Matcher
 from nonebot.params import Depends
 from nonebot.plugin.on import get_matcher_source
@@ -13,6 +12,7 @@ from nonebot_plugin_alconna.uniseg import Hyper, UniMsg
 from nonebot_plugin_uninfo import Uninfo
 
 from ..constants import MatchWithParams, ParamRules
+from ..utils.log import logger
 from .filter import is_enabled
 
 # 统一的状态键

--- a/src/nonebot_plugin_parser_lite/parsers/base.py
+++ b/src/nonebot_plugin_parser_lite/parsers/base.py
@@ -2,7 +2,7 @@
 
 from abc import ABC
 import asyncio
-from collections.abc import Callable, Coroutine
+from collections.abc import Callable, Coroutine, Sequence
 from re import Pattern, compile, escape
 from typing import (
     TYPE_CHECKING,
@@ -308,7 +308,7 @@ class BaseParser:
         cls,
         author: Author,
         url: str,
-        content: list[ContentItem],
+        content: Sequence[ContentItem],
         **kwargs: Unpack[ParseResultKwargs],
     ) -> ParseResult:
         """构建解析结果"""

--- a/src/nonebot_plugin_parser_lite/parsers/bilibili/__init__.py
+++ b/src/nonebot_plugin_parser_lite/parsers/bilibili/__init__.py
@@ -7,7 +7,6 @@ from typing import Any, ClassVar
 import aiofiles
 from anyio import Path
 from msgspec import convert
-from ...utils.log import logger
 import ujson
 
 from ...exception import DownloadException, TipException
@@ -29,6 +28,7 @@ from ...utils.bilibili.user import get_black_list
 from ...utils.bilibili.video import Video, VideoDownloadURLDataDetecter
 from ...utils.cookie import ck2dict
 from ...utils.format import format_num
+from ...utils.log import logger
 from ..base import (
     DOWNLOADER,
     Author,

--- a/src/nonebot_plugin_parser_lite/parsers/buff/__init__.py
+++ b/src/nonebot_plugin_parser_lite/parsers/buff/__init__.py
@@ -1,9 +1,9 @@
 from typing import Any, ClassVar, TypeVar
 
 from msgspec import convert
-from ...utils.log import logger
 
 from ...utils.format import format_num
+from ...utils.log import logger
 from ..base import (
     BaseParser,
     Comment,

--- a/src/nonebot_plugin_parser_lite/parsers/coolapk/__init__.py
+++ b/src/nonebot_plugin_parser_lite/parsers/coolapk/__init__.py
@@ -1,9 +1,8 @@
 import re
 from typing import ClassVar
 
-from ...utils.log import logger
-
 from ...utils.format import format_num
+from ...utils.log import logger
 from ..base import (
     BaseParser,
     MatchWithParams,

--- a/src/nonebot_plugin_parser_lite/parsers/douban/__init__.py
+++ b/src/nonebot_plugin_parser_lite/parsers/douban/__init__.py
@@ -1,7 +1,6 @@
 from typing import ClassVar
 
 from ...utils.log import logger
-
 from ..base import BaseParser, MatchWithParams, Platform, PlatformEnum, handle, pconfig
 from .comment import decoder as commentDecoder
 from .post import decoder as postDecoder

--- a/src/nonebot_plugin_parser_lite/parsers/douyin/__init__.py
+++ b/src/nonebot_plugin_parser_lite/parsers/douyin/__init__.py
@@ -2,10 +2,10 @@ import re
 from typing import ClassVar
 
 from msgspec import convert
-from ...utils.log import logger
 
 from ...utils.browser import BrowserManager
 from ...utils.format import format_num
+from ...utils.log import logger
 from ..base import (
     BaseParser,
     ContentItem,

--- a/src/nonebot_plugin_parser_lite/parsers/heybox/__init__.py
+++ b/src/nonebot_plugin_parser_lite/parsers/heybox/__init__.py
@@ -1,9 +1,9 @@
 from typing import ClassVar
 
 from msgspec import convert
-from ...utils.log import logger
 
 from ...utils.format import format_num
+from ...utils.log import logger
 from ..base import (
     BaseParser,
     Comment,

--- a/src/nonebot_plugin_parser_lite/parsers/hupu/__init__.py
+++ b/src/nonebot_plugin_parser_lite/parsers/hupu/__init__.py
@@ -2,8 +2,8 @@ from hashlib import md5
 from typing import ClassVar, TypeVar
 
 from msgspec.json import Decoder
-from ...utils.log import logger
 
+from ...utils.log import logger
 from ..base import (
     BaseParser,
     MatchWithParams,

--- a/src/nonebot_plugin_parser_lite/parsers/lofter/__init__.py
+++ b/src/nonebot_plugin_parser_lite/parsers/lofter/__init__.py
@@ -1,9 +1,9 @@
 from typing import ClassVar
 
 from msgspec import convert
-from ...utils.log import logger
 
 from ...utils.format import format_num
+from ...utils.log import logger
 from ..base import (
     BaseParser,
     ContentItem,

--- a/src/nonebot_plugin_parser_lite/parsers/miyoushe/__init__.py
+++ b/src/nonebot_plugin_parser_lite/parsers/miyoushe/__init__.py
@@ -1,7 +1,6 @@
 from typing import ClassVar
 
 from ...utils.log import logger
-
 from ..base import BaseParser, MatchWithParams, Platform, PlatformEnum, handle, pconfig
 from .comment import decoder as commentDecoder
 from .post import decoder as postDecoder

--- a/src/nonebot_plugin_parser_lite/parsers/weibo/__init__.py
+++ b/src/nonebot_plugin_parser_lite/parsers/weibo/__init__.py
@@ -1,10 +1,10 @@
 from math import ceil
 from typing import ClassVar
 
-from ...utils.log import logger
 import ujson
 
 from ...utils.format import format_num
+from ...utils.log import logger
 from ..base import (
     BaseParser,
     MatchWithParams,

--- a/src/nonebot_plugin_parser_lite/parsers/weibo/auth.py
+++ b/src/nonebot_plugin_parser_lite/parsers/weibo/auth.py
@@ -4,13 +4,10 @@ import re
 from typing import Any
 
 from httpx import AsyncClient
-from ...utils.log import logger
 import ujson
 
-if __name__ == "__main__":
-    COMMON_TIMEOUT = 5  # pyright: ignore[reportGeneralTypeIssues]
-else:
-    from ...constants import COMMON_TIMEOUT
+from ...constants import COMMON_TIMEOUT
+from ...utils.log import logger
 
 callback_pattern = re.compile(r"visitor_gray_callback\((.*)\)")
 

--- a/src/nonebot_plugin_parser_lite/parsers/wmpvp/__init__.py
+++ b/src/nonebot_plugin_parser_lite/parsers/wmpvp/__init__.py
@@ -1,8 +1,8 @@
 from typing import ClassVar, TypeVar
 
 from msgspec.json import Decoder
-from nonebot.log import logger
 
+from ...utils.log import logger
 from ..base import (
     BaseParser,
     MatchWithParams,

--- a/src/nonebot_plugin_parser_lite/render/__init__.py
+++ b/src/nonebot_plugin_parser_lite/render/__init__.py
@@ -9,12 +9,14 @@ import uuid
 from anyio import Path
 import qrcode
 
-from ..utils._flags import _get_flag, _STANDALONE
-if _STANDALONE:
-    from logging import getLogger as _getLogger
-    logger = _getLogger("parser_lite.render")
+from ..utils.env import IS_STANDALONE
+from ..utils.log import logger
+
+if IS_STANDALONE:
+
+    async def template_to_pic(*arg, **kwargs) -> bytes:
+        raise NotImplementedError()
 else:
-    from nonebot import logger
     from nonebot_plugin_htmlrender import template_to_pic
 
 from ..config import _nickname, gconfig, pconfig
@@ -34,32 +36,7 @@ from ..exception import (
     DurationLimitException,
     SizeLimitException,
 )
-if _STANDALONE:
-
-    class _StandaloneGuard:
-        """Base for types unavailable in standalone mode.
-
-        Any attempt to instantiate these types triggers a clear
-        RuntimeError instead of silently producing wrong results.
-        """
-
-        def __init__(self, *args, **kwargs):
-            raise RuntimeError(
-                "render types are not available in standalone mode "
-                f"(PARSER_LITE_STANDALONE=1). "
-                "Run under NoneBot with nonebot_plugin_htmlrender installed."
-            )
-
-    class ForwardNodeInner(_StandaloneGuard):  # type: ignore[misc]
-        pass
-
-    class UniMessage(_StandaloneGuard):  # type: ignore[misc]
-        pass
-
-    class UniHelper(_StandaloneGuard):  # type: ignore[misc]
-        pass
-else:
-    from ..helper import ForwardNodeInner, UniHelper, UniMessage
+from ..helper import ForwardNodeInner, UniHelper, UniMessage
 from ..utils.cache import CacheManager
 
 PLACEHOLDER_IMAGE = (
@@ -72,7 +49,7 @@ MAX_FORWARD_TEXT_LEN = 30000
 MAX_FORWARD_NODES = 90
 """单个 forward 节点数上限"""
 
-IS_DEBUG = gconfig.log_level in ["DEBUG", "TRACE", 10, 5] if gconfig else False
+IS_DEBUG = gconfig.log_level in ["DEBUG", "TRACE", 10, 5]
 
 Theme = Literal["light", "dark"]
 
@@ -462,7 +439,7 @@ class Renderer:
 
     async def render_image(self, result: ParseResult, *, theme: Theme) -> bytes:
         """使用 HTML 绘制通用社交媒体帖子卡片"""
-        if _STANDALONE:
+        if IS_STANDALONE:
             raise RuntimeError(
                 "卡片渲染在独立模式下不可用。请安装 nonebot_plugin_htmlrender "
                 "并在 NoneBot 环境中运行。"

--- a/src/nonebot_plugin_parser_lite/utils/browser.py
+++ b/src/nonebot_plugin_parser_lite/utils/browser.py
@@ -9,17 +9,17 @@ from anyio import Path
 from DrissionPage import Chromium, ChromiumOptions
 from DrissionPage._units.listener import DataPacket as DataPacket
 
-from ._flags import _get_flag, _STANDALONE
-if _STANDALONE:
+from .env import IS_STANDALONE
+
+if IS_STANDALONE:
     driver = None
-    from logging import getLogger as _getLogger
-    logger = _getLogger("parser_lite.browser")
 else:
     from nonebot import get_driver
-    from nonebot.log import logger
+
     driver = get_driver()
 
 from ..config import pconfig
+from ..utils.log import logger
 
 system = platform.system()
 
@@ -257,7 +257,7 @@ class BrowserManager:
                 cls._idle_task = None
 
 
-if driver is not None:
+if driver:
 
     @driver.on_shutdown
     def close_browser():

--- a/src/nonebot_plugin_parser_lite/utils/cache.py
+++ b/src/nonebot_plugin_parser_lite/utils/cache.py
@@ -5,10 +5,10 @@ import time
 from typing import ClassVar
 
 from anyio import Path
-from .log import logger
 
 from ..config import pconfig
 from .common import safe_unlink
+from .log import logger
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/nonebot_plugin_parser_lite/utils/common.py
+++ b/src/nonebot_plugin_parser_lite/utils/common.py
@@ -5,6 +5,7 @@ from typing import TypeVar
 from urllib.parse import urlparse
 
 from anyio import Path
+
 from .log import logger
 
 K = TypeVar("K")

--- a/src/nonebot_plugin_parser_lite/utils/env.py
+++ b/src/nonebot_plugin_parser_lite/utils/env.py
@@ -1,12 +1,7 @@
-"""Shared standalone mode flag detection.
-
-All modules import _get_flag and _STANDALONE from here
-to avoid duplicating env-var parsing logic.
-"""
 import os
 
 
-def _get_flag(name: str) -> bool:
+def get_env(name: str) -> bool:
     """Parse boolean-like env var: "1"/"true"/"yes" → True.
 
     Treats "1", "true", "yes" (case-insensitive, whitespace ignored)
@@ -16,4 +11,7 @@ def _get_flag(name: str) -> bool:
     return os.environ.get(name, "").strip().lower() in {"1", "true", "yes"}
 
 
-_STANDALONE = _get_flag("PARSER_LITE_STANDALONE")
+IS_STANDALONE = get_env("PARSER_LITE_STANDALONE")
+
+
+__all__ = ["IS_STANDALONE"]

--- a/src/nonebot_plugin_parser_lite/utils/ffmpeg.py
+++ b/src/nonebot_plugin_parser_lite/utils/ffmpeg.py
@@ -2,10 +2,10 @@ import asyncio
 import hashlib
 
 from anyio import Path
-from .log import logger
 
 from .cache import CacheManager
 from .common import fmt_size
+from .log import logger
 
 
 class FFmpeg:

--- a/src/nonebot_plugin_parser_lite/utils/log.py
+++ b/src/nonebot_plugin_parser_lite/utils/log.py
@@ -1,9 +1,8 @@
-"""Conditional logger: uses nonebot.logger or stdlib logging."""
 from logging import getLogger
 
-from ._flags import _STANDALONE
+from .env import IS_STANDALONE
 
-if _STANDALONE:
+if IS_STANDALONE:
     logger = getLogger("parser-lite")
 else:
-    from nonebot import logger  # noqa: F401
+    from nonebot.log import logger as logger

--- a/src/nonebot_plugin_parser_lite/utils/schedule.py
+++ b/src/nonebot_plugin_parser_lite/utils/schedule.py
@@ -1,0 +1,19 @@
+from apscheduler.schedulers.asyncio import AsyncIOScheduler
+from nonebot import get_driver
+
+scheduler = AsyncIOScheduler()
+scheduler.configure({"apscheduler.timezone": "Asia/Shanghai"})
+
+driver = get_driver()
+
+
+@driver.on_startup
+async def _():
+    if not scheduler.running:
+        scheduler.start()
+
+
+@driver.on_shutdown
+async def _():
+    if scheduler.running:
+        scheduler.shutdown()


### PR DESCRIPTION
移除原有的_flags模块，改用env模块管理环境变量； 统一日志记录器导入方式，从各个模块集中到utils.log； 调整定时任务调度器初始化逻辑； 修改配置文件中的路径处理和全局配置结构； 更新数据模型中的content字段类型为Sequence； 调整浏览器管理和缓存清理相关代码； 适配standalone模式下的功能限制和错误处理

## 由 Sourcery 生成的总结

重构插件，以集中管理环境、日志和调度设置，同时简化独立模式（standalone mode）的处理。

增强内容：
- 用统一的环境辅助工具和 `IS_STANDALONE` 标志替换旧的独立模式标志模块。
- 通过共享的 `utils.log` 日志记录器，将 logging 集中化，统一用于 NoneBot 模式和独立模式。
- 将调度器初始化过程抽取并标准化到专门的 `utils.schedule` 模块中，并通过驱动器生命周期钩子进行集成。
- 简化独立模式下在渲染和配置方面的行为，提供最小化的默认设置，并在功能不支持时给出清晰的运行时错误。
- 使用支持异步的 anyio `Path`，调整独立模式下的配置路径和全局配置处理方式。
- 将数据模型和解析器基础 API 中的内容字段泛化为接受通用 `Sequence`，而不是具体的列表类型。
- 整理浏览器管理和关闭逻辑，以在存在 NoneBot 驱动器时正确协同工作，并统一使用共享日志记录器。
- 在解析器、辅助工具和通用工具中进行小规模代码风格和导入顺序清理，统一使用共享的日志工具。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor the plugin to centralize environment, logging, and scheduling setup while simplifying standalone-mode handling.

Enhancements:
- Replace the legacy standalone flag module with a unified environment helper and IS_STANDALONE flag.
- Centralize logging through a shared utils.log logger for both NoneBot and standalone modes.
- Extract and standardize scheduler initialization into a dedicated utils.schedule module with driver lifecycle hooks.
- Simplify standalone-mode behavior for rendering and configuration, providing minimal defaults and clear runtime errors where features are unsupported.
- Adjust configuration paths and global config handling for standalone mode using async-capable anyio Paths.
- Generalize content fields in data models and parser base APIs to accept generic Sequences instead of concrete lists.
- Clean up browser management and shutdown handling to respect the presence of a NoneBot driver and shared logger.
- Minor code style and import ordering cleanups across parsers, helpers, and utilities to use the shared logging utilities consistently.

</details>