### PR TITLE
feat(parsers): 优化内容解析逻辑并提取公共方法

### DIFF
--- a/src/nonebot_plugin_parser_lite/parsers/linuxdo/util.py
+++ b/src/nonebot_plugin_parser_lite/parsers/linuxdo/util.py
@@ -35,20 +35,22 @@ def parse_rich_content(html: str) -> list[ContentItem]:
 
 
 def _iter_media_and_text(soup: BeautifulSoup):
+    skip_parent: Tag | None = None
     for element in soup.descendants:
+        if skip_parent:
+            if element in skip_parent.descendants:
+                continue
+            else:
+                skip_parent = None
         if isinstance(element, Tag):
             if element.name == "span" and (
                 "filename" in (element.get("class") or [])
                 or "informations" in (element.get("class") or [])
             ):
-                element.clear()
+                skip_parent = element
                 continue
 
-            if element.name == "p":
-                yield "\n"
-                continue
-
-            if element.name == "br":
+            if element.name in {"p", "br"}:
                 yield "\n"
                 continue
 

--- a/src/nonebot_plugin_parser_lite/parsers/zhihu/util.py
+++ b/src/nonebot_plugin_parser_lite/parsers/zhihu/util.py
@@ -86,46 +86,64 @@ def _clean_soup(soup: BeautifulSoup) -> None:
         noscript.decompose()
 
 
+def _parse_img(element: Tag):
+    attrs: dict[str, str] = {
+        str(k): str(v[0] if isinstance(v, list) and v else v)
+        for k, v in (element.attrs or {}).items()
+        if v
+    }
+    src = (
+        attrs.get("data-original")
+        or attrs.get("data-actualsrc")
+        or attrs.get("data-default-watermark-src")
+        or attrs.get("src")
+    )
+    return Creator.graphic(url=src) if src else None
+
+
+def _is_video_box(element: Tag) -> bool:
+    return element.name == "a" and "video-box" in (element.get("class") or [])
+
+
+async def _yield_video_box(tag: Tag, content_type: str):
+    video = await _parse_video_box(tag, content_type)
+    if video:
+        yield video
+
+    data_name = tag.get("data-name")
+    if not data_name:
+        return
+    if text := str(data_name).strip():
+        yield text
+
+
 async def _iter_media_and_text(soup: BeautifulSoup, content_type: str):
     """
     按 DOM 顺序依次产出文本 / 图片 / 视频等内容。
     这是一个 async 生成器，方便内部按需 await。
     """
+    skip_parent: Tag | None = None
+
     for element in soup.descendants:
+        if skip_parent:
+            if element in skip_parent.descendants:
+                continue
+            else:
+                skip_parent = None
         if isinstance(element, Tag):
-            if element.name == "p":
+            if element.name in {"p", "br"}:
                 yield "\n"
                 continue
 
-            if element.name == "br":
-                yield "\n"
-                continue
-
-            if element.name == "a" and "video-box" in (element.get("class") or []):
-                video = await _parse_video_box(element, content_type)
-                if video:
-                    yield video
-
-                if data_name := element.get("data-name"):
-                    if text := str(data_name).strip():
-                        yield text
-
-                element.clear()
+            if _is_video_box(element):
+                skip_parent = element
+                async for item in _yield_video_box(element, content_type):
+                    yield item
                 continue
 
             if element.name == "img":
-                attrs: dict[str, str] = {
-                    str(k): str(v[0] if isinstance(v, list) and v else v)
-                    for k, v in (element.attrs or {}).items()
-                    if v
-                }
-                if src := (
-                    attrs.get("data-original")
-                    or attrs.get("data-actualsrc")
-                    or attrs.get("data-default-watermark-src")
-                    or attrs.get("src")
-                ):
-                    yield Creator.graphic(url=src)
+                if graphic := _parse_img(element):
+                    yield graphic
 
         elif isinstance(element, NavigableString):
             if text := str(element).strip():


### PR DESCRIPTION
- 在 linuxdo 和 zhihu 解析器中实现跳过父元素后代的逻辑， 避免重复处理已跳过的元素
- 提取图片解析为独立函数 _parse_img，简化代码结构
- 添加视频盒子检测函数 _is_video_box 和视频盒子处理函数 _yield_video_box
- 统一处理 p 标签和 br 标签的换行逻辑
- 优化媒体和文本迭代器中的元素跳过机制

## Summary by Sourcery

优化知乎与 LinuxDo 的富文本解析器，更好地处理媒体元素与换行，同时避免对嵌套节点的重复解析。

New Features:
- 引入共享的图片解析辅助函数，用于将图片来源解析为图像内容项。
- 在知乎解析器中新增针对 `video-box` 元素的检测与处理辅助函数。

Enhancements:
- 统一段落与换行处理逻辑，在两个解析器中将 `p` 和 `br` 标签作为统一的换行输出逻辑进行处理。
- 改进媒体/文本遍历逻辑，在知乎与 LinuxDo 解析器中跳过已处理的父元素及其子孙节点，防止重复解析。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine rich content parsers for Zhihu and LinuxDo to better handle media elements and line breaks while avoiding redundant processing of nested nodes.

New Features:
- Introduce shared image parsing helper for extracting image sources into graphic content items.
- Add dedicated detection and handling helpers for video-box elements in the Zhihu parser.

Enhancements:
- Unify paragraph and line break handling by treating p and br tags with a common newline emission logic in both parsers.
- Improve media/text iteration by skipping already-handled parent elements and their descendants in Zhihu and LinuxDo parsers to prevent duplicate processing.

</details>