### PR TITLE
bilibili(block-pcdn): 更新PCDN主机正则表达式

### DIFF
--- a/src/nonebot_plugin_parser_lite/utils/bilibili/video.py
+++ b/src/nonebot_plugin_parser_lite/utils/bilibili/video.py
@@ -221,7 +221,7 @@ class Video:
             "platform": "pc",
             "from_client": "BROWSER",
             "web_location": 1315873,
-            "try_look": 1
+            "try_look": 1,
         }
         if html5:
             params["platform"] = "html5"
@@ -280,7 +280,8 @@ class Video:
 
 
 RE_PCDN_HOST = re.compile(
-    r"\.mcdn\.bilivideo\.cn|szbdyd\.com|cos\.bilibili\.com/.+pcdn", re.IGNORECASE
+    r"\.mcdn\.bilivideo\.cn|szbdyd\.com|cos\.bilibili\.com/.+pcdn|\.edge\.mountaintoys\.cn",
+    re.IGNORECASE,
 )
 RE_PCDN_PATH = re.compile(r"xy\d+x\d+x\d+x\d+xy|/pcdn/|/mcdn/", re.IGNORECASE)
 RE_PRIVATE_IP = re.compile(


### PR DESCRIPTION
- 修复了video.py中params字典末尾缺少逗号的格式问题
- 更新了RE_PCDN_HOST正则表达式，添加了新的PCDN主机域名.edge.mountaintoys.cn
- 改进了代码可读性和维护性

## Summary by Sourcery

更新 Bilibili PCDN 主机检测，并进行了少量代码清理。

错误修复：
- 修复了视频请求参数字典中遗漏尾随逗号的问题。

改进：
- 扩展 PCDN 主机的正则表达式，以匹配 `.edge.mountaintoys.cn` 域名的 URL。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update Bilibili PCDN host detection and perform minor code cleanup.

Bug Fixes:
- Fix a trailing comma omission in the video request parameters dictionary.

Enhancements:
- Extend the PCDN host regular expression to cover the .edge.mountaintoys.cn domain for URL matching.

</details>