### PR TITLE
fix(bilibili): 修改评论区排序不正确的问题

### DIFF
--- a/src/nonebot_plugin_parser_lite/parsers/bilibili/__init__.py
+++ b/src/nonebot_plugin_parser_lite/parsers/bilibili/__init__.py
@@ -1042,7 +1042,6 @@ class BilibiliParser(BaseParser):
                     type=type,
                     page_index=1,
                     page_size=pconfig.max_comments,
-                    nohot=True,
                     credential=await self.credential,
                 )
             except BiliHelperException as e:

--- a/src/nonebot_plugin_parser_lite/utils/bilibili/comment.py
+++ b/src/nonebot_plugin_parser_lite/utils/bilibili/comment.py
@@ -52,7 +52,7 @@ async def get_comments(
     page_index: int = 1,
     page_size: int = 7,
     nohot: bool = False,
-    order: OrderType = OrderType.HOT,
+    order: OrderType = OrderType.LIKE,
     credential: Credential | None = None,
 ) -> dict[str, Any]:
     """
@@ -63,7 +63,7 @@ async def get_comments(
     :param page_index: 页码, defaults to 1
     :param page_size: 每页项数, defaults to 7
     :param nohot: 是否不显示热评, defaults to False
-    :param order: 	排序方式, defaults to OrderType.HOT
+    :param order: 	排序方式, defaults to OrderType.LIKE
     :param credential: 凭证, defaults to None
     :raises BiliHelperError: _description_
     :return: 调用 API 返回的结果
@@ -83,7 +83,7 @@ async def get_comments(
                 "oid": oid,
                 "sort": order.value,
                 "ps": page_size,
-                "nohot": nohot,
+                "nohot": int(nohot),
             },
             cookies=credential.get_cookies(),
         )


### PR DESCRIPTION
- 将默认排序方式从 HOT 改为 LIKE
- 修复 nohot 参数类型转换问题，确保其被正确传递给API

## 由 Sourcery 提供的总结

调整 Bilibili 评论获取的默认设置和参数处理方式，以修复排序行为不正确的问题。

错误修复：
- 将评论默认排序方式从 HOT 更改为 LIKE，以符合预期行为。
- 在发送给 Bilibili API 之前，将 `nohot` 标志转换为整数，确保该参数被正确解析。
- 不再在 Bilibili 解析器中强制将 `nohot` 设置为 `true`，从而使 API 能够遵循已配置的默认行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust Bilibili comment fetching defaults and parameter handling to fix incorrect sorting behavior.

Bug Fixes:
- Change the default comment sort order from HOT to LIKE to align with expected behavior.
- Convert the nohot flag to an integer before sending it to the Bilibili API to ensure the parameter is correctly interpreted.
- Stop forcibly setting nohot to true in the Bilibili parser so that the API respects the configured default behavior.

</details>