### PR TITLE
feat(kugou): 新增对酷狗概念版的支持

### DIFF
--- a/src/nonebot_plugin_parser_lite/parsers/kugou.py
+++ b/src/nonebot_plugin_parser_lite/parsers/kugou.py
@@ -53,6 +53,8 @@ class PlayInfo(Struct):
     """歌曲时长，单位秒"""
     url: str = ""
     """歌曲下载地址"""
+    album_audio_id: int = 0
+    """音频id"""
 
 
 class CandidatesList(Struct):
@@ -112,6 +114,14 @@ class KuGouParser(BaseParser):
                     return smarty_data[0].get("hash", "").upper()
         return ""
 
+    @handle("t1.kugou.com", r"https?://t1\.kugou\.com/[a-zA-Z0-9]+")
+    async def _parse_kugou_t1(self, searched: MatchWithParams):
+        return await self.parse_with_redirect(searched.url)
+
+    @handle("t1.kugou.com", params={"hash": {}})
+    async def _parse_kugou_t1_hash(self, searched: MatchWithParams):
+        return await self.parse_by_hash(searched["hash"])
+
     @handle(
         "kugou.com",
         r"https?://[^\s]*?kugou\.com.*?(?:/(?:share|mixsong)/[a-zA-Z0-9]+\.html|(?:id|chain)=[a-zA-Z0-9]+)",
@@ -123,14 +133,15 @@ class KuGouParser(BaseParser):
         response.raise_for_status()
         html_text = response.text
 
-        # 提取歌曲hash
-        _hash = self._extract_hash(html_text)
-
-        if not _hash:
+        if _hash := self._extract_hash(html_text):
+            return await self.parse_by_hash(_hash)
+        else:
             raise ParseException(f"未找到歌曲hash: {share_url}")
 
+    async def parse_by_hash(self, hash: str):
+
         response = await self.httpx.get(
-            f"https://m.kugou.com/app/i/getSongInfo.php?cmd=playInfo&hash={_hash}"
+            f"https://m.kugou.com/app/i/getSongInfo.php?cmd=playInfo&hash={hash}"
         )
         playinfo = Decoder(PlayInfo).decode(response.content)
         if playinfo.errcode != 0:
@@ -190,7 +201,7 @@ class KuGouParser(BaseParser):
         return self.result(
             title=playinfo.songName,
             author=author,
-            url=share_url,
+            url=f"https://h5.kugou.com/v2/v-5a15aeb1/index.html?album_audio_id={playinfo.album_audio_id}",
             content=contents,
             extra=extra,
         )


### PR DESCRIPTION
- 添加album_audio_id字段用于构建正确分享链接
- 增加对t1.kugou.com域名的解析处理
- 重构解析逻辑，提取hash后直接调用parse_by_hash方法
- 更新分享链接格式为包含album_audio_id的新格式

## 由 Sourcery 提供的摘要

为 Kugou 概念版链接添加支持，并更新分享链接生成逻辑，改为使用基于 album_audio_id 的格式。

新功能：
- 支持解析和处理 t1.kugou.com（Kugou 概念版）分享链接，包括基于 hash 的解析。

改进：
- 扩展 PlayInfo 数据模型，新增 album_audio_id 字段，用于构造正确的分享链接。
- 重构 Kugou 解析流程，用于提取 hash 并委托给可复用的 `parse_by_hash` 方法。
- 将生成的 Kugou 分享链接更新为新的 `h5.kugou.com` 格式，该格式包含 `album_audio_id`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for Kugou concept edition URLs and update share link generation to use album_audio_id-based format.

New Features:
- Support parsing and handling of t1.kugou.com (Kugou concept edition) share URLs, including hash-based resolution.

Enhancements:
- Extend PlayInfo data model with album_audio_id to support constructing correct share links.
- Refactor Kugou parsing flow to extract hash and delegate to a reusable parse_by_hash method.
- Update generated Kugou share URL to the new h5.kugou.com format that includes album_audio_id.

</details>