### PR TITLE
feat(bilibili): 添加评论获取数量限制和点赞重排序功能

### DIFF
--- a/src/nonebot_plugin_parser_lite/parsers/bilibili/__init__.py
+++ b/src/nonebot_plugin_parser_lite/parsers/bilibili/__init__.py
@@ -1012,13 +1012,14 @@ class BilibiliParser(BaseParser):
                 data = await get_comments(
                     oid=oid,
                     type=type,
+                    number=pconfig.max_comments,
                     credential=await self.credential,
                 )
             except BiliHelperException as e:
                 logger.warning(f"bili评论返回数据错误: {e.msg}")
                 return []
 
-            upper_top = data.get("upper", {}).get("top")
+            upper_top = data.get("top", {}).get("upper")
             replies_raw: list[dict[str, Any]] = data.get("replies") or []
 
             upper_list: list[dict[str, Any]] = [upper_top] if upper_top else []
@@ -1053,6 +1054,21 @@ class BilibiliParser(BaseParser):
             logger.debug(
                 f"bili获得评论: upper={len(upper_list)}, replies={len(replies_raw)}, merged={len(merged)}",  # noqa: E501
             )
+            # upper 置顶评论始终首位，其余按 like 数降序排序
+            if merged:
+                if has_upper and len(merged) > 1:
+                    head = merged[0]
+                    tail = merged[1:]
+                    tail.sort(
+                        key=lambda item: int(item.get("like") or 0),
+                        reverse=True,
+                    )
+                    merged = [head, *tail]
+                else:
+                    merged.sort(
+                        key=lambda item: int(item.get("like") or 0),
+                        reverse=True,
+                    )
             return self._process_reply_list(merged)
 
         except Exception as e:
@@ -1159,7 +1175,7 @@ class BilibiliParser(BaseParser):
 
         processed_comments: list[Comment] = []
 
-        for comment in replies[:10]:
+        for comment in replies:
             comment_obj = _build_single_comment(comment)
             # 子回复
             child_posts: list[Comment] = []

--- a/src/nonebot_plugin_parser_lite/utils/bilibili/comment.py
+++ b/src/nonebot_plugin_parser_lite/utils/bilibili/comment.py
@@ -1,4 +1,5 @@
 from enum import IntEnum
+import json
 from typing import Any
 
 from .client import CLIENT
@@ -51,6 +52,8 @@ async def get_comments(
     oid: int,
     type: CommentResourceType,
     order: OrderType = OrderType.ONLY_HOT,
+    number: int = 20,
+    pagination_str: str | None = None,
     credential: Credential | None = None,
 ) -> dict[str, Any]:
     """
@@ -59,18 +62,26 @@ async def get_comments(
     :param oid: 资源 ID
     :param type_: 资源类枚举
     :param order: 	排序方式, defaults to OrderType.ONLY_HOT
+    :param number: 获取数量, defaults to 20
+    :param pagination_str: 翻页信息，用于懒加载分页 首次请求时不传，后续请求使用上次响应中的 data.cursor.pagination_reply.next_offset, defaults to None
     :param credential: 凭证, defaults to None
     :raises BiliHelperError: _description_
     :return: 调用 API 返回的结果, 未登录 3 , 登录 20, 现在不想写翻页
-    """
+    """  # noqa: E501
     credential = credential or Credential()
     params = {
         "type": type.value,
         "oid": oid,
         "mode": order.value,
-        "pagination_str": '{"offset":""}',
+        "plat": 1,
+        "seek_rpid": "",
+        "number": number,
         "web_location": 1315875,
     }
+    if pagination_str:
+        params["pagination_str"] = json.dumps({"offset": pagination_str})
+    else:
+        params["pagination_str"] = json.dumps({"offset": ""})
     result = (
         await CLIENT.get(
             url="https://api.bilibili.com/x/v2/reply/wbi/main",


### PR DESCRIPTION
- 添加 max_comments 配置项来限制获取的评论数量
- 修改评论API调用以支持number参数
- 修复评论数据结构中upper top的获取路径
- 实现评论按点赞数排序功能，置顶评论始终排在首位
- 支持评论分页加载功能

## Summary by Sourcery

根据配置限制和排序 B 站评论，并在评论 API 中支持分页。

新功能：
- 引入可配置的 `max_comments` 选项，用于控制获取的 B 站评论数量。
- 在 B 站评论 API 中通过 `pagination_str` 参数支持评论分页获取。
- 添加基于点赞数的评论排序，同时保持置顶的 UP 主评论始终在顶部。

缺陷修复：
- 更正 B 站评论响应数据中置顶 UP 主评论的访问路径。

增强改进：
- 在 B 站评论 API 中暴露 `number` 参数以控制批量大小，并在构建评论列表时移除硬编码的限制。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Limit and sort Bilibili comments based on configuration while supporting pagination in the comment API.

New Features:
- Introduce a configurable max_comments option to control the number of fetched Bilibili comments.
- Support comment retrieval pagination via a pagination_str parameter in the Bilibili comment API.
- Add like-count-based sorting for comments, keeping the pinned upper comment at the top.

Bug Fixes:
- Correct the access path for the upper top comment in the Bilibili comment response data.

Enhancements:
- Expose the number parameter in the Bilibili comment API to control batch size and remove the hardcoded limit when building the comment list.

</details>