### PR TITLE
feat(zhihu): 优化请求头签名

### DIFF
--- a/src/nonebot_plugin_parser_lite/parsers/zhihu/__init__.py
+++ b/src/nonebot_plugin_parser_lite/parsers/zhihu/__init__.py
@@ -27,6 +27,7 @@ class ZhiHuParser(BaseParser):
     platform: ClassVar[Platform] = Platform(
         name=PlatformEnum.ZHIHU, display_name="知乎"
     )
+    zhihu_ck: dict[str, Any] = ck2dict(pconfig.zhihu_ck) if pconfig.zhihu_ck else {}
 
     @handle(
         "zhuanlan.zhihu.com/p",
@@ -224,10 +225,10 @@ class ZhiHuParser(BaseParser):
             url,
             headers={
                 **self.headers,
-                **sign_zhihu_fetch_request(url),
+                **sign_zhihu_fetch_request(url=url, dc0=self.zhihu_ck.get("d_c0", "")),
                 **(ext_header or {}),
-            },
-            cookies=ck2dict(pconfig.zhihu_ck) if pconfig.zhihu_ck else None,
+            },  # dc0其实可以传空，也不影响结果获取，不过既然ck有就传进去吧
+            cookies=self.zhihu_ck,
         )
         if res.status_code != 200:
             raise ParseException(res.text)


### PR DESCRIPTION
- 初始化时将知乎cookie转换为字典格式存储
- 在zhihu_fetch函数中使用实例化的cookie而不是重新转换
- 传递dc0参数给sign_zhihu_fetch_request函数用于请求签名(虽然没什么用)

## Summary by Sourcery

通过重用已解析的 cookie，并在请求签名函数中传递 `dc0` cookie 的值，优化知乎解析器的请求处理。

新特性：
- 将配置好的知乎 cookie 以解析后的字典形式存储在解析器实例上，以便在多个请求之间复用。

增强点：
- 对外发起请求时使用实例级已解析的知乎 cookie，而不是在每次获取时重新解析。
- 在为知乎数据获取请求生成签名时，加入已存储知乎 cookie 中的 `d_c0` 值。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Optimize Zhihu parser request handling by reusing parsed cookies and passing the dc0 cookie value into the request signing function.

New Features:
- Store the configured Zhihu cookie as a parsed dictionary on the parser instance for reuse across requests.

Enhancements:
- Use the instance-level parsed Zhihu cookie for outgoing requests instead of recomputing it on each fetch.
- Include the d_c0 value from the stored Zhihu cookie when signing Zhihu fetch requests.

</details>