### PR TITLE
fix(douyin): 修复抖音图文bgm可能为空

### DIFF
--- a/src/nonebot_plugin_parser_lite/parsers/douyin/note.py
+++ b/src/nonebot_plugin_parser_lite/parsers/douyin/note.py
@@ -88,11 +88,12 @@ class Aweme(Struct):
                     )
                 )
         if music := (self.music or self.detail.music):
-            content.append(
-                Creator.audio(
-                    url=music.playUrl.uri,
+            if uri := music.playUrl.uri:
+                content.append(
+                    Creator.audio(
+                        url=uri,
+                    )
                 )
-            )
         return content
 
     @property


### PR DESCRIPTION
当抖音视频的音乐链接为空时，避免创建无效的音频元素， 通过检查音乐链接是否存在来防止错误

## Summary by Sourcery

Bug Fixes:
- 当抖音笔记背景音乐 URI 为空时，跳过创建音频内容，以防止在解析过程中出现错误。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Skip creating audio content when the Douyin note background music URI is empty to prevent errors during parsing.

</details>