### PR TITLE
feat(zlb): 添加`壁吧专楼吧`解析支持

### DIFF
--- a/src/nonebot_plugin_parser_lite/constants.py
+++ b/src/nonebot_plugin_parser_lite/constants.py
@@ -66,6 +66,7 @@ class PlatformEnum(str, Enum):
     DOUBAO = "doubao"
     LINUXDO = "linuxdo"
     WMPVP = "wmpvp"
+    ZLB = "zlb"
 
     def __str__(self) -> str:
         return self.value

--- a/src/nonebot_plugin_parser_lite/parsers/__init__.py
+++ b/src/nonebot_plugin_parser_lite/parsers/__init__.py
@@ -24,6 +24,7 @@ from .weibo import WeiBoParser
 from .wmpvp import WMPVPParser
 from .x import XParser
 from .zhihu import ZhiHuParser
+from .zlb import ZLBParser
 
 __all__ = [
     "AcfunParser",
@@ -51,5 +52,6 @@ __all__ = [
     "WMPVPParser",
     "WeiBoParser",
     "XParser",
+    "ZLBParser",
     "ZhiHuParser",
 ]

--- a/src/nonebot_plugin_parser_lite/parsers/zlb/__init__.py
+++ b/src/nonebot_plugin_parser_lite/parsers/zlb/__init__.py
@@ -1,0 +1,51 @@
+from typing import ClassVar
+
+from ...utils.format import format_num
+from ..base import (
+    DOWNLOADER,
+    BaseParser,
+    MatchWithParams,
+    ParseException,
+    Platform,
+    PlatformEnum,
+    handle,
+)
+from .topic import decoder as postDecoder
+
+
+class ZLBParser(BaseParser):
+    platform: ClassVar[Platform] = Platform(
+        name=PlatformEnum.ZLB, display_name="壁吧专楼吧"
+    )
+
+    @handle("zlb.ink", r"topic/(?P<topic_id>\d+)")
+    async def parse_topic(self, searched: MatchWithParams):
+        topic_id = searched["topic_id"]
+        res = await DOWNLOADER.client.get(
+            f"https://bb.zlb.ink/t/topic/{topic_id}.json",
+            use_curl_cffi=True,
+            headers=self.headers,
+        )
+        if not res.is_success:
+            try:
+                summary = res.json()
+            except Exception:
+                summary = res.text[:100]
+            raise ParseException(f"获取帖子失败: {summary}")
+        post = postDecoder.decode(res.content)
+        return self.result(
+            author=self.create_author(
+                name=post.detail.display_username or post.detail.username,
+                avatar_url=post.detail.avatar_url,
+            ),
+            url=f"https://bb.zlb.ink/t/topic/{post.id}",
+            title=post.title,
+            content=post.detail.content,
+            comments=post.comment_list,
+            stats=self.create_stats(
+                like_count=format_num(post.like_count),
+                view_count=format_num(post.views),
+                comment_count=format_num(post.posts_count - 1),
+            ),
+            timestamp=post.detail.timestamp,
+        )

--- a/src/nonebot_plugin_parser_lite/parsers/zlb/topic.py
+++ b/src/nonebot_plugin_parser_lite/parsers/zlb/topic.py
@@ -1,0 +1,76 @@
+from msgspec import Struct
+from msgspec.json import Decoder
+
+from ...creator import Creator
+from ...data import Comment
+from ...utils.format import format_num
+from .util import parse_date, parse_rich_content
+
+
+class Post(Struct):
+    username: str
+    """用户名"""
+    display_username: str
+    """昵称(可能没设置)"""
+    created_at: str
+    cooked: str
+    """html(空需要过滤)"""
+    avatar_template: str
+    reply_count: int
+    """该post的回复数"""
+    reaction_users_count: int
+    """可以当成该post的点赞数"""
+
+    @property
+    def timestamp(self) -> int:
+        return parse_date(self.created_at)
+
+    @property
+    def avatar_url(self) -> str:
+        return f"https://zlb.ink/{self.avatar_template.format(size=288)}"
+
+    @property
+    def content(self):
+        return parse_rich_content(self.cooked)
+
+
+class PostStream(Struct):
+    posts: list[Post]
+
+
+class Response(Struct):
+    post_stream: PostStream
+    title: str
+    id: int
+    posts_count: int
+    """跟帖数,包含主贴"""
+    reply_count: int
+    """所有跟贴的总回复数"""
+    views: int
+    """所有跟帖总浏览数"""
+    like_count: int
+
+    @property
+    def detail(self):
+        return self.post_stream.posts[0]
+
+    @property
+    def comment_list(self) -> list[Comment]:
+        return [
+            Creator.comment(
+                author=Creator.author(
+                    name=c.display_username or c.username, avatar_url=c.avatar_url
+                ),
+                content=c.content,
+                stats=Creator.stats(
+                    like_count=format_num(c.reaction_users_count),
+                    comment_count=format_num(c.reply_count),
+                ),
+                timestamp=c.timestamp,
+            )
+            for c in self.post_stream.posts[1:]
+            if c.cooked
+        ]
+
+
+decoder = Decoder(Response)

--- a/src/nonebot_plugin_parser_lite/parsers/zlb/util.py
+++ b/src/nonebot_plugin_parser_lite/parsers/zlb/util.py
@@ -1,0 +1,79 @@
+from datetime import datetime
+
+from bs4 import BeautifulSoup
+from bs4.element import NavigableString, Tag
+
+from ...creator import Creator
+from ...data import ContentItem
+
+
+def parse_rich_content(html: str) -> list[ContentItem]:
+    soup = BeautifulSoup(html.replace(r"\"", '"'), "html.parser")
+
+    result: list[ContentItem] = []
+    buffer: list[str] = []
+
+    for item in _iter_media_and_text(soup):
+        if isinstance(item, str):
+            buffer.append(item)
+        else:
+            if buffer:
+                text_block = "".join(buffer)
+                lines = [line.rstrip() for line in text_block.splitlines()]
+                if normalized := "\n".join(lines).strip():
+                    result.append(normalized)
+                buffer.clear()
+            result.append(item)
+
+    if buffer:
+        text_block = "".join(buffer)
+        lines = [line.rstrip() for line in text_block.splitlines()]
+        if normalized := "\n".join(lines).strip():
+            result.append(normalized)
+
+    return result
+
+
+def _iter_media_and_text(soup: BeautifulSoup):
+    skip_parent: Tag | None = None
+    for element in soup.descendants:
+        if skip_parent:
+            if element in skip_parent.descendants:
+                continue
+            else:
+                skip_parent = None
+        if isinstance(element, Tag):
+            if element.name == "span" and (
+                "filename" in (element.get("class") or [])
+                or "informations" in (element.get("class") or [])
+            ):
+                skip_parent = element
+                continue
+
+            if element.name in {"p", "br"}:
+                yield "\n"
+                continue
+
+            if element.name == "img":
+                attrs: dict[str, str] = {
+                    str(k): str(v[0] if isinstance(v, list) and v else v)
+                    for k, v in (element.attrs or {}).items()
+                    if v
+                }
+                if src := attrs.get("src"):
+                    if attrs.get("class") == "emoji":
+                        yield Creator.sticker(
+                            url=src,
+                            desc=attrs.get("alt"),
+                            size="small",
+                        )
+                    else:
+                        yield Creator.image(url=src)
+
+        elif isinstance(element, NavigableString):
+            if text := str(element).strip():
+                yield text
+
+
+def parse_date(s: str) -> int:
+    return int(datetime.strptime(s, "%Y-%m-%dT%H:%M:%S.%fZ").timestamp())

--- a/src/nonebot_plugin_parser_lite/parsers/zlb/util.py
+++ b/src/nonebot_plugin_parser_lite/parsers/zlb/util.py
@@ -61,7 +61,8 @@ def _iter_media_and_text(soup: BeautifulSoup):
                     if v
                 }
                 if src := attrs.get("src"):
-                    if attrs.get("class") == "emoji":
+                    classes = element.get("class") or []
+                    if "emoji" in classes:
                         yield Creator.sticker(
                             url=src,
                             desc=attrs.get("alt"),

--- a/src/nonebot_plugin_parser_lite/parsers/zlb/util.py
+++ b/src/nonebot_plugin_parser_lite/parsers/zlb/util.py
@@ -55,17 +55,13 @@ def _iter_media_and_text(soup: BeautifulSoup):
                 continue
 
             if element.name == "img":
-                attrs: dict[str, str] = {
-                    str(k): str(v[0] if isinstance(v, list) and v else v)
-                    for k, v in (element.attrs or {}).items()
-                    if v
-                }
-                if src := attrs.get("src"):
+                if src := element.get("src"):
+                    src = str(src)
                     classes = element.get("class") or []
                     if "emoji" in classes:
                         yield Creator.sticker(
                             url=src,
-                            desc=attrs.get("alt"),
+                            desc=element.get("alt", None), # pyright: ignore[reportArgumentType]
                             size="small",
                         )
                     else:


### PR DESCRIPTION
resolve #221

## Summary by Sourcery

为解析来自 壁吧专楼吧（zlb.ink）平台的主题内容提供支持，并将其集成到现有的解析框架中。

**新功能：**
- 引入 ZLB 平台枚举和解析器，用于处理 壁吧专楼吧 的主题 URL，并返回结构化的帖子数据、评论和统计信息。

**改进：**
- 为 壁吧专楼吧 添加工具函数，用于将富 HTML 内容解析为媒体/文本条目，并将 API 响应中的时间戳转换为 Unix 时间戳。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for parsing topics from the 壁吧专楼吧 (zlb.ink) platform and integrating it into the existing parser framework.

New Features:
- Introduce ZLB platform enum and parser to handle 壁吧专楼吧 topic URLs and return structured post data, comments, and stats.

Enhancements:
- Add utilities for 壁吧专楼吧 to parse rich HTML content into media/text items and convert timestamps from API responses into Unix timestamps.

</details>