### PR TITLE
feat(bilibili): 移除遗留的对`pycryptodomex`的依赖

### DIFF
--- a/src/nonebot_plugin_parser_lite/utils/bilibili/credential.py
+++ b/src/nonebot_plugin_parser_lite/utils/bilibili/credential.py
@@ -4,11 +4,13 @@ import random
 import re
 import struct
 import time
+from typing import cast
 import urllib.parse
 import uuid
 
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import padding
+from cryptography.hazmat.primitives.asymmetric.rsa import RSAPublicKey
 import ujson
 
 from .client import CLIENT, HEADERS
@@ -18,20 +20,24 @@ from .exceptions import (
     CookiesRefreshException,
 )
 
-CORRESPOND_KEY = serialization.load_pem_public_key(
-    b"""\
+CORRESPOND_KEY = cast(
+    RSAPublicKey,
+    serialization.load_pem_public_key(
+        b"""\
 -----BEGIN PUBLIC KEY-----
 MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDLgd2OAkcGVtoE3ThUREbio0Eg
 Uc/prcajMKXvkCKFCWhJYJcLkcM2DKKcSeFpD/j6Boy538YXnR6VhcuUJOhH2x71
 nzPjfdTcqMz7djHum0qSZA0AyCBDABUqCrfNgCiJ00Ra7GmRj+YCK1NJEuewlb40
 JNrRuoEUXpabUzGB8QIDAQAB
 -----END PUBLIC KEY-----"""
+    ),
 )
 CORRESPOND_PADDING = padding.OAEP(
     mgf=padding.MGF1(algorithm=hashes.SHA256()),
     algorithm=hashes.SHA256(),
     label=None,
 )
+# 对摘要和 MGF1 都使用 SHA256
 
 LAST_CHECK_TIME = 0
 
@@ -286,9 +292,7 @@ async def _check_refresh(credential: Credential) -> bool:
 
 def _getCorrespondPath() -> str:
     ts = round(time.time() * 1000)
-    encrypted = CORRESPOND_KEY.encrypt(  # pyright: ignore[reportAttributeAccessIssue]
-        f"refresh_{ts}".encode(), CORRESPOND_PADDING
-    )
+    encrypted = CORRESPOND_KEY.encrypt(f"refresh_{ts}".encode(), CORRESPOND_PADDING)
     return binascii.b2a_hex(encrypted).decode()
 
 

--- a/src/nonebot_plugin_parser_lite/utils/bilibili/credential.py
+++ b/src/nonebot_plugin_parser_lite/utils/bilibili/credential.py
@@ -7,9 +7,8 @@ import time
 import urllib.parse
 import uuid
 
-from Cryptodome.Cipher import PKCS1_OAEP
-from Cryptodome.Hash import SHA256
-from Cryptodome.PublicKey import RSA
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import padding
 import ujson
 
 from .client import CLIENT, HEADERS
@@ -19,8 +18,8 @@ from .exceptions import (
     CookiesRefreshException,
 )
 
-CORRESPOND_KEY = RSA.importKey(
-    """\
+CORRESPOND_KEY = serialization.load_pem_public_key(
+    b"""\
 -----BEGIN PUBLIC KEY-----
 MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDLgd2OAkcGVtoE3ThUREbio0Eg
 Uc/prcajMKXvkCKFCWhJYJcLkcM2DKKcSeFpD/j6Boy538YXnR6VhcuUJOhH2x71
@@ -28,7 +27,11 @@ nzPjfdTcqMz7djHum0qSZA0AyCBDABUqCrfNgCiJ00Ra7GmRj+YCK1NJEuewlb40
 JNrRuoEUXpabUzGB8QIDAQAB
 -----END PUBLIC KEY-----"""
 )
-CORRESPOND_CIPHER = PKCS1_OAEP.new(CORRESPOND_KEY, SHA256)
+CORRESPOND_PADDING = padding.OAEP(
+    mgf=padding.MGF1(algorithm=hashes.SHA256()),
+    algorithm=hashes.SHA256(),
+    label=None,
+)
 
 LAST_CHECK_TIME = 0
 
@@ -283,7 +286,9 @@ async def _check_refresh(credential: Credential) -> bool:
 
 def _getCorrespondPath() -> str:
     ts = round(time.time() * 1000)
-    encrypted = CORRESPOND_CIPHER.encrypt(f"refresh_{ts}".encode())
+    encrypted = CORRESPOND_KEY.encrypt(  # pyright: ignore[reportAttributeAccessIssue]
+        f"refresh_{ts}".encode(), CORRESPOND_PADDING
+    )
     return binascii.b2a_hex(encrypted).decode()
 
 


### PR DESCRIPTION
- 将RSA加密相关的导入从pyxryptodomez替换为cryptography库
- 使用cryptography.hazmat.primitives替代原有的PKCS1_OAEP加密方式
- 重构CORRESPOND_KEY的初始化方法，使用serialization.load_pem_public_key
- 创建新的CORRESPOND_PADDING配置来替代原有的PKCS1_OAEP配置
- 更新_encrypt方法使用新的加密API进行数据加密操作

## Summary by Sourcery

将 Bilibili 凭证的 RSA 加密实现从 `pycryptodomex` 替换为使用 `cryptography` 库。

Enhancements:
- 使用 `serialization.load_pem_public_key` 初始化 Bilibili 公钥，并通过 `cryptography.hazmat.primitives` 配置 OAEP 填充。
- 更新凭证路径的加密逻辑，使用新的 RSA 公钥和 OAEP 填充配置，替代旧的 PKCS1_OAEP 加密器。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Replace the Bilibili credential RSA encryption implementation to use the `cryptography` library instead of `pycryptodomex`.

Enhancements:
- Initialize the Bilibili public key using `serialization.load_pem_public_key` and configure OAEP padding via `cryptography.hazmat.primitives`.
- Update the credential path encryption logic to use the new RSA public key and OAEP padding configuration in place of the legacy PKCS1_OAEP cipher.

</details>