### PR TITLE
fix(linux.do|zlb): 修复用户昵称字段可能为空

### DIFF
--- a/src/nonebot_plugin_parser_lite/parsers/linuxdo/topic.py
+++ b/src/nonebot_plugin_parser_lite/parsers/linuxdo/topic.py
@@ -10,7 +10,7 @@ from .util import parse_date, parse_rich_content
 class Post(Struct):
     username: str
     """用户名"""
-    display_username: str
+    display_username: str | None
     """昵称(可能没设置)"""
     created_at: str
     cooked: str

--- a/src/nonebot_plugin_parser_lite/parsers/zlb/topic.py
+++ b/src/nonebot_plugin_parser_lite/parsers/zlb/topic.py
@@ -10,7 +10,7 @@ from .util import parse_date, parse_rich_content
 class Post(Struct):
     username: str
     """用户名"""
-    display_username: str
+    display_username: str | None
     """昵称(可能没设置)"""
     created_at: str
     cooked: str


### PR DESCRIPTION
将 LinuxDO 和 ZLB 解析器中 Post 结构体的 display_username 字段 从必填字符串类型修改为可选字符串类型（str | None），以处理 用户未设置昵称的情况

## Summary by Sourcery

Enhancements:
- 放宽 LinuxDO 和 ZLB 解析器中 post 的 `display_username` 字段类型，以支持用户未设置昵称的情况。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Relax post display_username field type in LinuxDO and ZLB parsers to support cases where user nickname is not set.

</details>