### PR TITLE
chore(deps): 更新cryptography依赖版本范围

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,5 +14,5 @@ playwright>=1.48.0,<2.0.0
 json_repair>=0.58.0,<1.0.0
 anyio>=4.0.0,<5.0.0
 ujson>=5.0.0,<6.0.0
-cryptography>=49.0.0,<50.0.0
+cryptography>=49.0.0
 qrcode>=8.0,<9.0


### PR DESCRIPTION
移除cryptography依赖的上界限制，从">=49.0.0,<50.0.0"改为">=49.0.0"， 以便兼容更高版本的cryptography库。