### PR TITLE
fix(bilibili-qr-login): 修复哔哩哔哩扫码登陆失败的问题

### DIFF
--- a/src/nonebot_plugin_parser_lite/matchers/__init__.py
+++ b/src/nonebot_plugin_parser_lite/matchers/__init__.py
@@ -1,4 +1,5 @@
 import asyncio
+import contextlib
 from dataclasses import dataclass
 import re
 from typing import ClassVar, TypeVar
@@ -15,7 +16,7 @@ from nonebot_plugin_alconna import (
     on_alconna,
 )
 from nonebot_plugin_alconna.extension import cache_msg
-from nonebot_plugin_alconna.uniseg import get_message_id, reply_fetch
+from nonebot_plugin_alconna.uniseg import Receipt, get_message_id, reply_fetch
 from nonebot_plugin_uninfo import Uninfo
 from tarina import LRU
 
@@ -209,10 +210,14 @@ async def register_bili_matcher():
             Alconna("blogin"), block=True, permission=SUPERUSER, rule=to_me()
         ).handle()
         async def _():
+            last_receipt: Receipt | None = None
             qrcode = await bilip.login_with_qrcode()
-            await UniMessage(await UniHelper.img_seg(qrcode)).send()
+            last_receipt = await UniMessage(await UniHelper.img_seg(qrcode)).send()
             async for msg in bilip.check_qr_state():
-                await UniMessage(msg).send()
+                if last_receipt is not None:
+                    with contextlib.suppress(Exception):
+                        await last_receipt.recall()
+                last_receipt = await UniMessage(msg).send()
 
 
 if pconfig.lazy_download:

--- a/src/nonebot_plugin_parser_lite/matchers/__init__.py
+++ b/src/nonebot_plugin_parser_lite/matchers/__init__.py
@@ -1,5 +1,4 @@
 import asyncio
-import contextlib
 from dataclasses import dataclass
 import re
 from typing import ClassVar, TypeVar
@@ -215,8 +214,10 @@ async def register_bili_matcher():
             last_receipt = await UniMessage(await UniHelper.img_seg(qrcode)).send()
             async for msg in bilip.check_qr_state():
                 if last_receipt is not None:
-                    with contextlib.suppress(Exception):
+                    try:
                         await last_receipt.recall()
+                    except Exception:
+                        logger.exception("尝试撤回上一条消息失败")
                 last_receipt = await UniMessage(msg).send()
 
 

--- a/src/nonebot_plugin_parser_lite/parsers/bilibili/__init__.py
+++ b/src/nonebot_plugin_parser_lite/parsers/bilibili/__init__.py
@@ -185,7 +185,7 @@ class BilibiliParser(BaseParser):
                 extra={
                     "danmaku": format_num(bangumi_info.stat.danmakus),
                     "coin": format_num(bangumi_info.stat.coins),
-                }
+                },
             ),
             title=bangumi_info.title,
             url=bangumi_info.share_url,

--- a/src/nonebot_plugin_parser_lite/utils/bilibili/login.py
+++ b/src/nonebot_plugin_parser_lite/utils/bilibili/login.py
@@ -84,12 +84,11 @@ class QrCodeLogin:
 
         :return: 二维码登录状态
         """
-        result = (
-            await CLIENT.get(
-                url="https://passport.bilibili.com/x/passport-login/web/qrcode/poll",
-                params={"qrcode_key": self.__qr_key, "source": "main-fe-header"},
-            )
-        ).json()
+        resp = await CLIENT.get(
+            url="https://passport.bilibili.com/x/passport-login/web/qrcode/poll",
+            params={"qrcode_key": self.__qr_key, "source": "main-fe-header"},
+        )
+        result = resp.json()
         if result["code"] != 0:
             raise BiliHelperException(result)
         events = result["data"]
@@ -101,19 +100,11 @@ class QrCodeLogin:
         elif code == 86038:
             return QrCodeLoginEvents.TIMEOUT
         else:
-            cred_url = events["url"]
             ac_time_value = events["refresh_token"]
-            cookies_list = cred_url.split("?")[1].split("&")
-            sessdata = ""
-            bili_jct = ""
-            dedeuserid = ""
-            for cookie in cookies_list:
-                if cookie[:8] == "SESSDATA":
-                    sessdata = cookie[9:]
-                if cookie[:8] == "bili_jct":
-                    bili_jct = cookie[9:]
-                if cookie[:11].upper() == "DEDEUSERID=":
-                    dedeuserid = cookie[11:]
+            cookies = resp.cookies
+            sessdata = cookies.get("SESSDATA", domain=".bilibili.com")
+            bili_jct = cookies.get("bili_jct", domain=".bilibili.com")
+            dedeuserid = cookies.get("DedeUserID", domain=".bilibili.com")
             self.__credential = Credential(
                 sessdata=sessdata,
                 bili_jct=bili_jct,


### PR DESCRIPTION
- 添加Receipt类型导入以支持消息撤回功能
- 在B站登录过程中实现消息更新机制，新消息发送前撤回旧消息
- 优化B站登录API响应处理，直接从cookies中提取认证信息
- 修复B站解析器配置中的语法错误

## Summary by Sourcery

通过更新凭证处理方式并改进二维码登录提示，修复 B 站（Bilibili）二维码登录失败问题。

Bug 修复：
- 直接从响应的 cookies 中提取 B 站登录凭证，而不是从重定向 URL 的查询字符串中解析。
- 修正 B 站解析器配置中关于番剧（bangumi）额外元数据的语法错误。

增强：
- 在 B 站二维码登录交互中引入消息撤回流程，使每一次新的状态更新都会替换上一条状态消息。
- 引入并使用 `Receipt` 类型和 `contextlib` 工具，以便在二维码登录状态更新过程中安全地撤回消息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix Bilibili QR-code login failures by updating credential handling and improving QR login messaging.

Bug Fixes:
- Extract Bilibili login credentials directly from response cookies instead of parsing them from the redirect URL query string.
- Correct a syntax error in the Bilibili parser configuration for bangumi extra metadata.

Enhancements:
- Introduce a message recall flow in the Bilibili QR login interaction so that each new status update replaces the previous one.
- Import and use the Receipt type and contextlib utilities to support safe message recall during QR login updates.

</details>