### PR TITLE
fix(weibo-region): 修复微博推文ip归属地可能为空

### DIFF
--- a/src/nonebot_plugin_parser_lite/parsers/weibo/statuses.py
+++ b/src/nonebot_plugin_parser_lite/parsers/weibo/statuses.py
@@ -73,7 +73,6 @@ class WeiboData(Struct):
     idstr: str
     created_at: str
     """`Thu Oct 02 14:39:33 +0800 2025`"""
-    region_name: str
     reposts_count: int
     """转发数"""
     comments_count: int
@@ -83,6 +82,7 @@ class WeiboData(Struct):
     isLongText: bool
     """是否需要请求长文"""
     pic_num: int
+    region_name: str | None = None
     pic_infos: dict[str, Pic] | None = None
     page_info: PageInfo | None = None
     """视频信息"""


### PR DESCRIPTION
- 将region_name字段从WeiboData类的第76行移至第85行
- 为region_name字段添加Optional类型注解和None默认值
- test_url: https://weibo.com/1789681642/RbOvSwVr8

## Summary by Sourcery

错误修复：
- 通过在 `WeiboData` 中将 `region_name` 属性设为可选，来处理微博数据中缺失或为 null 的 `region_name` 字段。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Handle missing or null Weibo region_name fields by making the attribute optional in WeiboData.

</details>