### PR TITLE
fix(netease-spa): 修复部分网易云音乐链接无法解析

### DIFF
--- a/src/nonebot_plugin_parser_lite/constants.py
+++ b/src/nonebot_plugin_parser_lite/constants.py
@@ -90,6 +90,11 @@ class MatchWithParams:
         self.url = match.group(0)
         parsed = urlparse(self.url)
         qs = parse_qs(parsed.query, keep_blank_values=True)
+        # SPA hash routes may contain their own query, e.g. ``#/song?id=123``.
+        fragment_qs = parse_qs(
+            urlparse(parsed.fragment).query, keep_blank_values=True
+        )
+        qs.update(fragment_qs)
         # 只取第一个
         self.params: dict[str, str] = {k: v[0] for k, v in qs.items()}
         self.param_rules: ParamRules = {}


### PR DESCRIPTION
支持解析SPA哈希路由中的查询参数，当URL包含SPA哈希路由时， 现在能够正确解析哈希片段中的查询参数并合并到主查询参数中。 eg: https://music.163.com/#/song?id=3326021479

## Summary by Sourcery

Bug Fixes:
- 修复对 Netease SPA 哈希路由 URL 的解析问题：通过从 URL 片段中提取查询参数并将其合并到主参数映射中来完成。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix parsing of Netease SPA hash-route URLs by extracting and merging query parameters from the URL fragment into the main parameter map.

</details>