### PR TITLE
feat(linuxdo/cookie): 新增 LinuxDO 平台cookie配置

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,9 @@ plite_day_range=["6:00", "19:00"]
 # [可选] 知乎 cookie, 需要具有登录态的cookie才能完整获取回答内容
 # 必须包含 z_c0 项，建议包含 d_c0, _xsrf 项
 plite_zhihu_ck="z_c0=xxxx"
+
+# [可选] linuxdo cookie, 部分帖子需要登陆或有一定的阅读等级才可以查看
+plite_linuxdo_ck="d_c0=xxxx"
 ```
 
 </details>

--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ plite_day_range=["6:00", "19:00"]
 # 必须包含 z_c0 项，建议包含 d_c0, _xsrf 项
 plite_zhihu_ck="z_c0=xxxx"
 
-# [可选] linuxdo cookie, 部分帖子需要登陆或有一定的阅读等级才可以查看
+# [可选] linuxdo cookie, 部分帖子需要登录或有一定的阅读等级才可以查看
 plite_linuxdo_ck="d_c0=xxxx"
 ```
 

--- a/src/nonebot_plugin_parser_lite/config.py
+++ b/src/nonebot_plugin_parser_lite/config.py
@@ -28,6 +28,8 @@ class Config(BaseModel):
     """bilibili cookies"""
     plite_zhihu_ck: str | None = None
     """知乎 cookies"""
+    plite_linuxdo_ck: str | None = None
+    """linuxdo cookies"""
     plite_need_upload: bool = False
     """是否需要上传音视频文件（兼容旧配置）"""
     plite_need_upload_audio: bool = False
@@ -136,6 +138,11 @@ class Config(BaseModel):
     def zhihu_ck(self) -> str | None:
         """知乎 cookies"""
         return self.plite_zhihu_ck
+
+    @property
+    def linuxdo_ck(self) -> str | None:
+        """linuxdo cookies"""
+        return self.plite_linuxdo_ck
 
     @property
     def need_upload_audio(self) -> bool:

--- a/src/nonebot_plugin_parser_lite/download/client.py
+++ b/src/nonebot_plugin_parser_lite/download/client.py
@@ -252,7 +252,12 @@ class UniHttpClient:
                 ) as resp:
                     yield UniResponse(resp)
             else:
-                async with self._httpx.stream(method, url, headers=headers) as resp:
+                async with self._httpx.stream(
+                    method,
+                    url,
+                    headers=headers,
+                    cookies=cookies,
+                ) as resp:
                     yield UniResponse(resp)
         except (TransportError, RequestException) as e:
             raise RetryableDownloadError(e.__repr__()) from e

--- a/src/nonebot_plugin_parser_lite/download/client.py
+++ b/src/nonebot_plugin_parser_lite/download/client.py
@@ -155,17 +155,20 @@ class UniHttpClient:
         url: str,
         *,
         headers: dict[str, str],
+        cookies: dict[str, str] | None = None,
         use_curl_cffi: bool = False,
     ) -> UniResponse:
         if use_curl_cffi:
             resp = await self._curl.head(
                 url=url,
                 headers=headers,
+                cookies=cookies,
             )
         else:
             resp = await self._httpx.head(
                 url=url,
                 headers=headers,
+                cookies=cookies,
             )
         return UniResponse(resp)
 
@@ -175,6 +178,7 @@ class UniHttpClient:
         *,
         params: dict[str, Any] | None = None,
         headers: dict[str, str],
+        cookies: dict[str, str] | None = None,
         use_curl_cffi: bool = False,
     ) -> UniResponse:
         if use_curl_cffi:
@@ -182,12 +186,14 @@ class UniHttpClient:
                 url,
                 params=params,
                 headers=headers,
+                cookies=cookies,
             )
         else:
             resp = await self._httpx.get(
                 url,
                 params=params,
                 headers=headers,
+                cookies=cookies,
             )
         return UniResponse(resp)
 
@@ -200,6 +206,7 @@ class UniHttpClient:
         content: str | bytes | None = None,
         data: dict[str, Any] | None = None,
         json: Any | None = None,
+        cookies: dict[str, str] | None = None,
         use_curl_cffi: bool = False,
     ) -> UniResponse:
         if use_curl_cffi:
@@ -209,6 +216,7 @@ class UniHttpClient:
                 headers=headers,
                 data=content or data,
                 json=json,
+                cookies=cookies,
             )
         else:
             resp = await self._httpx.post(
@@ -218,6 +226,7 @@ class UniHttpClient:
                 content=content,
                 data=data,
                 json=json,
+                cookies=cookies,
             )
         return UniResponse(resp)
 
@@ -230,6 +239,7 @@ class UniHttpClient:
         url: str,
         *,
         headers: dict[str, str],
+        cookies: dict[str, str] | None = None,
         use_curl_cffi: bool = False,
     ) -> AsyncGenerator[UniResponse]:
         try:
@@ -238,6 +248,7 @@ class UniHttpClient:
                     method,
                     url,
                     headers=headers,
+                    cookies=cookies,
                 ) as resp:
                     yield UniResponse(resp)
             else:

--- a/src/nonebot_plugin_parser_lite/parsers/linuxdo/__init__.py
+++ b/src/nonebot_plugin_parser_lite/parsers/linuxdo/__init__.py
@@ -1,5 +1,6 @@
 from typing import ClassVar
 
+from ...utils.cookie import ck2dict
 from ...utils.format import format_num
 from ..base import (
     DOWNLOADER,
@@ -9,6 +10,7 @@ from ..base import (
     Platform,
     PlatformEnum,
     handle,
+    pconfig,
 )
 from .topic import decoder as postDecoder
 
@@ -17,6 +19,7 @@ class LinuxDoParser(BaseParser):
     platform: ClassVar[Platform] = Platform(
         name=PlatformEnum.LINUXDO, display_name="LINUX DO"
     )
+    linuxdo_ck = ck2dict(pconfig.linuxdo_ck) if pconfig.linuxdo_ck else {}
 
     @handle("linux.do", r"topic/(?P<topic_id>\d+)")
     async def parse_topic(self, searched: MatchWithParams):
@@ -25,6 +28,7 @@ class LinuxDoParser(BaseParser):
             f"https://linux.do/t/topic/{topic_id}.json",
             use_curl_cffi=True,
             headers=self.headers,
+            cookies=self.linuxdo_ck,
         )
         if not res.is_success:
             try:

--- a/src/nonebot_plugin_parser_lite/parsers/zhihu/__init__.py
+++ b/src/nonebot_plugin_parser_lite/parsers/zhihu/__init__.py
@@ -27,7 +27,7 @@ class ZhiHuParser(BaseParser):
     platform: ClassVar[Platform] = Platform(
         name=PlatformEnum.ZHIHU, display_name="知乎"
     )
-    zhihu_ck: dict[str, Any] = ck2dict(pconfig.zhihu_ck) if pconfig.zhihu_ck else {}
+    zhihu_ck = ck2dict(pconfig.zhihu_ck) if pconfig.zhihu_ck else {}
 
     @handle(
         "zhuanlan.zhihu.com/p",


### PR DESCRIPTION
新增 linuxdo cookie 配置项，用于访问需要登录态的帖子内容

resolve #233

- 在配置中添加 plite_linuxdo_ck 选项
- 更新 HTTP 客户端以支持传递 cookies 参数
- 实现 LinuxDO 平台的内容解析功能
- 在 README 中添加相关配置说明

## Summary by Sourcery

添加对 LinuxDO Cookie 的支持，并在整个 HTTP 客户端中传递 Cookie 处理逻辑，从而支持解析需要登录认证的 LinuxDO 内容。

新功能：
- 新增 `plite_linuxdo_ck` 配置项，并通过 `linuxdo_ck` 配置属性对外暴露。
- 让 LinuxDO 解析器在获取主题 JSON 时发送已配置的 Cookie，从而可以解析需要认证或有等级门槛的帖子。

改进：
- 扩展共享 HTTP 客户端（`head/get/post/stream`），使其在 `httpx` 和 `curl-cffi` 两种后端中都能接收并转发 Cookie。
- 将知乎解析器的 Cookie 处理类型注解与 Cookie 字典转换器对齐。

文档：
- 在 README 中记录可选的 `plite_linuxdo_ck` Cookie 配置，用于访问受限制的 LinuxDO 帖子。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add LinuxDO cookie support and propagate cookie handling through the HTTP client to enable parsing of authenticated LinuxDO content.

New Features:
- Add plite_linuxdo_ck configuration option and expose it via the linuxdo_ck config property.
- Enable the LinuxDO parser to send configured cookies when fetching topic JSON so authenticated or level-gated posts can be parsed.

Enhancements:
- Extend the shared HTTP client (head/get/post/stream) to accept and forward cookies for both httpx and curl-cffi backends.
- Align Zhihu parser cookie handling type annotation with the cookie dict converter.

Documentation:
- Document the optional plite_linuxdo_ck cookie configuration in the README for accessing restricted LinuxDO posts.

</details>