### PR TITLE
fix(parsers): 修复解析时无法匹配子域名的问题

### DIFF
--- a/src/nonebot_plugin_parser_lite/parsers/base.py
+++ b/src/nonebot_plugin_parser_lite/parsers/base.py
@@ -100,7 +100,7 @@ def handle(
     - params: 可选，ParamRules，用于基于 query 的补充筛选（required/equals/default/one_of/as_int 等）
     - pattern 与 params 至少要指定一个（可以同时存在）：
         - 只有 pattern：纯正则匹配，不看 query
-        - 只有 params：regex 由 keyword 自动生成为 `https?://<keyword>[^\\s]*`
+        - 只有 params：regex 由 keyword 自动生成，并允许域名前存在子域名
         - pattern + params：
             * 先用 pattern 过滤
             * 若 pattern 没有匹配到末尾或追加 `$`，则自动在末尾补 `[^\\s]*`，以便 MatchWithParams 能看到查询参数部分
@@ -128,7 +128,7 @@ def handle(
 
     else:
         escaped = escape(keyword)
-        regex = rf"https?://{escaped}[^\s]*"
+        regex = rf"https?://(?:[A-Za-z0-9-]+\.)*{escaped}[^\s]*"
 
     param_rules = params or {}
 

--- a/src/nonebot_plugin_parser_lite/parsers/doubao/__init__.py
+++ b/src/nonebot_plugin_parser_lite/parsers/doubao/__init__.py
@@ -19,7 +19,7 @@ class DouBaoParser(BaseParser):
     )
 
     # https://www.doubao.com/video-sharing?source_type=mobile&share_id=49939181380407810&video_id=v0369cg10004d9867lqljht6t4tvhh30
-    @handle("www.doubao.com/video-sharing", params={"share_id": {}, "video_id": {}})
+    @handle("doubao.com/video-sharing", params={"share_id": {}, "video_id": {}})
     async def _parse(self, searched: MatchWithParams):
         share_id = searched["share_id"]
         video_id = searched["video_id"]

--- a/src/nonebot_plugin_parser_lite/parsers/netease.py
+++ b/src/nonebot_plugin_parser_lite/parsers/netease.py
@@ -69,7 +69,6 @@ class NCMParser(BaseParser):
     async def _parse_163cn(self, searched: MatchWithParams):
         return await self.parse_with_redirect(searched[0])
 
-    @handle("y.music.163.com", params={"id": {"as_int": True}})
     @handle("music.163.com", params={"id": {"as_int": True}})
     @handle("music.163.com", r"song/(?P<id>\d+)")
     async def _parse_netease(self, searched: MatchWithParams):


### PR DESCRIPTION
支持在域名前匹配子域名，使链接解析更加灵活； 移除网易云音乐重复的解析规则，统一使用标准域名； 更新豆包视频解析器使用简化域名配置。

## Summary by Sourcery

允许解析器的基于关键词的 URL 匹配处理子域名，并清理特定解析器的域名配置。

New Features:
- 支持在基于关键词的解析规则中匹配在已配置关键词之前带有可选子域名的 URL。

Bug Fixes:
- 修复在主域名前带有子域名的链接无法被基于关键词的解析器匹配的问题。

Enhancements:
- 简化 DouBao 视频解析器配置，使用基础域名关键词。
- 移除已由通用子域名支持覆盖的重复 NetEase Music 解析规则。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Allow parser keyword-based URL matching to handle subdomains and clean up domain configurations for specific parsers.

New Features:
- Support matching URLs with optional subdomains before configured keywords in keyword-based parsing rules.

Bug Fixes:
- Fix cases where links with subdomains before the main domain were not matched by keyword-based parsers.

Enhancements:
- Simplify DouBao video parser configuration to use a base domain keyword.
- Remove duplicated NetEase Music parsing rule now covered by generalized subdomain support.

</details>