### PR TITLE
fix(render): 修复发送的文本中的错误换行

### DIFF
--- a/src/nonebot_plugin_parser_lite/render/__init__.py
+++ b/src/nonebot_plugin_parser_lite/render/__init__.py
@@ -340,7 +340,7 @@ class Renderer:
             async def flush_text() -> None:
                 nonlocal text_buffer
                 if text_buffer:
-                    text = "\n".join(text_buffer).strip()
+                    text = "".join(text_buffer)
                     if text:
                         nodes.append(f"{author_name}：{text}")
                     text_buffer = []

--- a/src/nonebot_plugin_parser_lite/render/templates/macros.jinja
+++ b/src/nonebot_plugin_parser_lite/render/templates/macros.jinja
@@ -315,7 +315,7 @@
             {% if not is_repost %}
                 <div class="flex items-center space-x-1.5 px-4 py-2">
                     <img src="{{ result.platform.logo_path }}" class="w-4 h-4 rounded-[2px]" />
-                    <span class="text-xs font-black text-gray-500 dark:text-slate-300 uppercase tracking-widest">{{ result.platform.display_name }}</span>
+                    <span class="text-xs font-black text-gray-500 dark:text-slate-300 tracking-widest">{{ result.platform.display_name }}</span>
                 </div>
             {% endif %}
         </div>


### PR DESCRIPTION
移除文本缓冲区连接时换行操作，同时修正了平台名称显示样式中的大小写转换问题

## Summary by Sourcery

调整消息输出中的文本渲染和平台名称显示。

错误修复：
- 通过在连接缓冲片段时不插入换行符，防止渲染文本中出现非预期的换行。
- 通过移除模板中强制大写的样式，保留平台显示名称的原始大小写形式。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust text rendering and platform name display in message output.

Bug Fixes:
- Prevent unintended line breaks in rendered text by concatenating buffered segments without inserting newline characters.
- Preserve the original casing of platform display names by removing forced uppercase styling in the template.

</details>