### PR TITLE
feat(heybox-battery): 支持查看帖子作者受到的电击数⚡⚡⚡(不是

### DIFF
--- a/src/nonebot_plugin_parser_lite/parsers/heybox/__init__.py
+++ b/src/nonebot_plugin_parser_lite/parsers/heybox/__init__.py
@@ -84,6 +84,7 @@ class HeyBoxParser(BaseParser):
                 comment_count=format_num(data.link.comment_num),
                 share_count=format_num(data.link.forward_num),
                 collect_count=format_num(data.link.favour_count),
+                extra={"battery": format_num(data.link.battery.count)},
             ),
         )
 

--- a/src/nonebot_plugin_parser_lite/parsers/heybox/model.py
+++ b/src/nonebot_plugin_parser_lite/parsers/heybox/model.py
@@ -17,6 +17,8 @@ HEYBOX_PATTERN = re.compile(r"\[(?P<name>[^]]+)\]")
 def size_resolver(name: str) -> Literal["small", "medium"]:
     return "medium" if "bigemoji" in name else "small"
 
+class Battery(Struct):
+    count: int | None = None
 
 class User(Struct):
     avatar: str
@@ -96,6 +98,7 @@ class Link(Struct):
     forward_num: int
     """转发数"""
     user: User
+    battery: Battery
     video_url: str | None = None
     video_thumb: str | None = None
 

--- a/src/nonebot_plugin_parser_lite/render/templates/icon.css
+++ b/src/nonebot_plugin_parser_lite/render/templates/icon.css
@@ -6,6 +6,8 @@
   --icon-color-comment: #0ea5e9;
   --icon-color-collect: #eab308;
   --icon-color-share: #10b981;
+  --icon-color-battery: #d97706;
+  --icon-color-battery-dark: #facc15;
   --icon-color-overlay: #ffffff;
   --icon-color-comment-meta: #9ca3af;
   --icon-color-comment-meta-dark: #64748b;
@@ -64,6 +66,11 @@
   --icon-color: var(--icon-color-share);
 }
 
+.stat-icon.fa-battery {
+  --icon-color: var(--icon-color-battery);
+  --icon-color-dark: var(--icon-color-battery-dark);
+}
+
 .comment .fa-heart,
 .comment .fa-comment-dots {
   color: var(--icon-color-comment-meta);
@@ -92,6 +99,10 @@
 
 .fa-eye {
   mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 640"><!--!Font Awesome Free v7.2.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2026 Fonticons, Inc.--><path d="M320 96C239.2 96 174.5 132.8 127.4 176.6C80.6 220.1 49.3 272 34.4 307.7C31.1 315.6 31.1 324.4 34.4 332.3C49.3 368 80.6 420 127.4 463.4C174.5 507.1 239.2 544 320 544C400.8 544 465.5 507.2 512.6 463.4C559.4 419.9 590.7 368 605.6 332.3C608.9 324.4 608.9 315.6 605.6 307.7C590.7 272 559.4 220 512.6 176.6C465.5 132.9 400.8 96 320 96zM176 320C176 240.5 240.5 176 320 176C399.5 176 464 240.5 464 320C464 399.5 399.5 464 320 464C240.5 464 176 399.5 176 320zM320 256C320 291.3 291.3 320 256 320C244.5 320 233.7 317 224.3 311.6C223.3 322.5 224.2 333.7 227.2 344.8C240.9 396 293.6 426.4 344.8 412.7C396 399 426.4 346.3 412.7 295.1C400.5 249.4 357.2 220.3 311.6 224.3C316.9 233.6 320 244.4 320 256z"/></svg>');
+}
+
+.fa-battery {
+  mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 60 60"><path fill-rule="evenodd" d="M20 3h20a4 4 0 0 1 4 4v3H16V7a4 4 0 0 1 4-4zM13 12h34a7 7 0 0 1 7 7v32a7 7 0 0 1-7 7H13a7 7 0 0 1-7-7V19a7 7 0 0 1 7-7zm0 7v32h34V19H13zm19-1L18 36h10l-1 14 15-20H32V18z"/></svg>');
 }
 
 .fa-play {


### PR DESCRIPTION
- 在HeyBox解析器中添加电池数据解析和展示功能
- 新增Battery模型用于存储电池数量信息
- 添加电池图标样式和颜色配置
- 将电池数量作为额外信息显示在统计数据中

## Summary by Sourcery

在解析输出和 UI 统计中新增对 HeyBox 帖子电量数的展示支持。

新功能：
- 在 HeyBox 链接上引入 Battery 模型，用于存储电量计数元数据。
- 在 HeyBox 解析器输出中，将格式化后的电量计数作为额外统计信息展示。
- 在图标 UI 中添加电池图标，并为其提供专用颜色和 SVG 遮罩，用于渲染电池统计信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for displaying HeyBox post battery count in parsed outputs and UI stats.

New Features:
- Introduce a Battery model on HeyBox links to store battery count metadata.
- Display formatted battery count as extra statistics in HeyBox parser output.
- Add a battery icon with dedicated colors and SVG mask for rendering battery stats in the icon UI.

</details>