### PR TITLE
chore(python): 更新Python版本配置从3.10到3.11

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -1,5 +1,5 @@
 line-length = 88
-target-version = "py310"
+target-version = "py311"
 
 [format]
 line-ending = "lf"

--- a/sourcery.yaml
+++ b/sourcery.yaml
@@ -1,2 +1,2 @@
 rule_settings:
-  python_version: "3.10"
+  python_version: "3.11"


### PR DESCRIPTION
更新ruff.toml和sourcery.yaml中的Python目标版本配置， 将python_version从"3.10"升级到"3.11"以支持新的Python版本。

## Summary by Sourcery

在各类工具中将 Python 目标版本配置从 3.10 更新为 3.11。

构建：
- 将 Ruff 配置中的 `target-version` 从 `py310` 提升为 `py311`。
- 将 Sourcery 的 `rule_settings` 中的 `python_version` 从 `3.10` 更新为 `3.11`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update Python target version configuration across tooling from 3.10 to 3.11.

Build:
- Bump Ruff configuration target-version from py310 to py311.
- Update Sourcery rule_settings python_version from 3.10 to 3.11.

</details>