### PR TITLE
feat(ds): 新增大神平台解析器

### DIFF
--- a/api_txt/ds/article.json
+++ b/api_txt/ds/article.json
@@ -1,0 +1,68 @@
+{
+  "result": {
+    "feed": {
+      "id": "5c0601af8ec3326ecc6ac82f",
+      "uid": "ad4f1f6d030f4d0abc17c6250002ac2d",
+      "type": 6,
+      "content": "{\"type\":6,\"body\":{\"text\":\"#炉石传说# #拉斯塔哈的大乱斗# 威兹班18套卡组预览。这次更新加入了很多新卡，不少卡组的强度非常高哦！另外，我们还附上了代码，如果明天不知道玩啥的小伙伴们，抄（开心）就完事儿了！\",\"media\":[{\"url\":\"https://ok.166.net/reunionpub/kol_20181204_aeafe6c010e03583ba4cfbafa5c6bffc\",\"mimeType\":\"image/png\",\"size\":256894,\"width\":389,\"height\":219}],\"subTitle\":\"\",\"title\":\"炉石拉斯塔哈的大乱斗威兹班卡组汇总（附代码）\",\"longText\":\"<p>明天就是新版本了，我们一起来看看威兹班的的预构筑卡组吧！多套卡组的强度都非常高哦！</p><p align=\\\"center\\\"><img src=\\\"https://ok.166.net/reunionpub/kol_20181204_7685d354ea9d2492500b4e1d2ad7ecce\\\" alt=\\\"\\\" width=\\\"1500\\\" height=\\\"1334\\\"></p><p>大乱斗-德鲁伊-野性狂乱-威兹班</p><p>AAECAZICBpkC/M0CmdMCm+gC9fwCwYYDDEC0BeYFmgjrwgKHzgKY0gKm7wKYhgPAhgPGhgPPiQMA</p><p>大乱斗-德鲁伊-绿树成荫-威兹班</p><p>AAECAZICAiTF/QIO/QLtA/cD5gWxCIbBAqTCAuvCAtfvAsHzAt/7Ar/9AtWDA7SJAwA=</p><p align=\\\"center\\\"><img src=\\\"https://ok.166.net/reunionpub/kol_20181204_21e9eee963395986b74255bd12515e74\\\" alt=\\\"\\\" width=\\\"1500\\\" height=\\\"1334\\\"></p><p>大乱斗-法师-巨龙之母-威兹班</p><p>AAECAf0EBNACm9MCo+sCr4cDDU2KAckD7Af7DMrDApbHAtvTAtXhAtfhApbkAtfrAs2JAwA=</p><p>大乱斗-法师-龙鹰之力-威兹班</p><p>AAECAf0ECNACxQT7DNPFApvTAu72Ap74AqiHAwvsB5vCAuvCAsrDAtfhApbkArfxAr36AqSHA6aHA82JAwA=</p><p align=\\\"center\\\"><img src=\\\"https://ok.166.net/reunionpub/kol_20181204_119ae0c0cfc5c3daab44606be468e5f3\\\" alt=\\\"\\\" width=\\\"1500\\\" height=\\\"1334\\\"></p><p>大乱斗-盗贼-海狼斗士-威兹班</p><p>AAECAaIHBM0D18oCzfQC1owDDbQBiAfnB4YJ3NEC2+MC3+8CovcCqv8CroUDz4kDzowD24wDAA==</p><p>大乱斗-盗贼-死金试炼-威兹班</p><p>AAECAaIHBvYEi+ECz+ECnOICn/gCi4oDDLQBjAKGCYHCAqvCAuvCAtvjArT2At76Auz8AtGBA86MAwA=</p><p align=\\\"center\\\"><img src=\\\"https://ok.166.net/reunionpub/kol_20181204_93ad0f3b04c41bbad43a44e6dc0f758b\\\" alt=\\\"\\\" width=\\\"1500\\\" height=\\\"1334\\\"></p><p>大乱斗-猎人-独自狩猎-威兹班</p><p>AAECAR8IhwTFCN3SAunSAobTAvLqApuFA6KKAwuoArUDyQSXCNsJ/gzf0gLj0gLh4wLq4wKH+wIA</p><p>大乱斗-猎人-动物本能-威兹班</p><p>AAECAR8G7QmG0wKA8wLqiQOiigPjiwMMqAK1A+sH2wmBCo7DAtfNAt3SAovlAqCFA7CLA+SLAwA=</p><p align=\\\"center\\\"><img src=\\\"https://ok.166.net/reunionpub/kol_20181204_619751a7d1a36029a4a1a848b28b87f7\\\" alt=\\\"\\\" width=\\\"1500\\\" height=\\\"1334\\\"></p><p>大乱斗-牧师-疯入膏肓-威兹班</p><p>AAECAa0GBpvCAsnHAsrLApziAqeHA8CPAwzlBPIM+wzKwwKbywLo0ALL5gKJ8QLeggPqiAOwiQPsiQMA</p><p>大乱斗-牧师-疯庞然大物-威兹班</p><p>AAECAa0GAqUJvsgCDvgC5QT2B9EK0gryDPsM0cEC2MEC5fcC5ogDi4kD0okD64oDAA==</p><p align=\\\"center\\\"><img src=\\\"https://ok.166.net/reunionpub/kol_20181204_082acf71d6cb147bf983ecb30371c69f\\\" alt=\\\"\\\" width=\\\"1500\\\" height=\\\"1334\\\"></p><p>大乱斗-骑士-猛虎之选-威兹班</p><p>AAECAZ8FBuPjApvwAv37Atn+Ar2GA+OGAwzcA/QFrwf2B8rDAojHAuPLAvnsAt6GA+aGA+yGA++GAwA=</p><p>大乱斗-骑士-无尽大军-威兹班</p><p>AAECAZ8FBvQF+ga5wQLx/gKggAPehgMM3AOPCbPBAuPLAp/1AqX1Atb+Atn+AuH+ApGAA9GAA8yBAwA=</p><p align=\\\"center\\\"><img src=\\\"https://ok.166.net/reunionpub/kol_20181204_a8ab60b62940e9f687172b555e3e6a3f\\\" alt=\\\"\\\" width=\\\"1500\\\" height=\\\"1334\\\"></p><p>大乱斗-萨满-女巫觉醒-威兹班</p><p>AAECAaoIDN4F7QX/BYoHwAfPxwLCzgLD6gKn7gLv9wLq+gLzigMJgQT1BP4Fx8ECm8sC8+cCm/8CioADl4ADAA==</p><p>大乱斗-萨满-终极巫毒-威兹班</p><p>AAECAaoIBpMJ688CsPAC4vgCmfsCy4UDDPAHkcEC68ICysMCm8sC+9MC3+kCm/8CnP8CvYUD24kD5YkDAA==</p><p align=\\\"center\\\"><img src=\\\"https://ok.166.net/reunionpub/kol_20181204_8c76f18901a559bf2c005b407cab508d\\\" alt=\\\"\\\" width=\\\"1500\\\" height=\\\"1334\\\"></p><p>大乱斗-术士-蝙蝠降临-威兹班</p><p>AAECAf0GApfTAvKGAw4w9wTCCPYI68ICm8sC980C8dAC8tAC9PcC0/gCw/0C6YYD3YkDAA==</p><p>大乱斗-术士-鲁莽仪式-威兹班</p><p>AAECAf0GBJTHArjQAo+CA/CGAw0w0AT3BM4HwgjrwgKRxwKSzQL3zQLx0ALy0ALWhgOvjQMA</p><p align=\\\"center\\\"><img src=\\\"https://ok.166.net/reunionpub/kol_20181204_5ff017f4c575f09b28850984ccaae8d2\\\" alt=\\\"\\\" width=\\\"1500\\\" height=\\\"1334\\\"></p><p>大乱斗-战士-战争之翼-威兹班</p><p>AAECAQcGkAf/B6IJ+wz4hgOShwMMogTJxwLMzQKJ8QKb8wL09QKBhwOLhwPoiQPsiQOqiwPolAMA</p><p>大乱斗-战士-砰砰计划-威兹班</p><p>AAECAQcEze8Cm/ACkvgCoIADDczNArrsAp3wApfzAp/1AqX1AuT3Ao74AoP7Aqj7ArP8AsyBA/iGAwA=</p>\"}}",
+      "target": "null",
+      "origin": "null",
+      "deleteTime": 0,
+      "createTime": 1543897519981,
+      "updateTime": 1543897519981,
+      "clientType": 72,
+      "record": {
+        "id": "5c0601af8ec3326ecc6ac82f",
+        "repostCount": 5,
+        "commentCount": 16,
+        "likeCount": 19,
+        "shareCount": 0,
+        "favCount": 21,
+        "createTime": 1543897557695
+      }
+    },
+    "userInfos": [
+      {
+        "user": {
+          "uid": "ad4f1f6d030f4d0abc17c6250002ac2d",
+          "nick": "炉边聚会",
+          "icon": "https://ok.166.net/reunionpub/pr_tytqyw2dbnuwkfcu06vyoa==_50_1532489414_15311",
+          "intro": "水友交流：830192238（欢迎加入讨论）",
+          "gender": 1,
+          "birth": "1995-12-23",
+          "identityAuthenticInfo": "",
+          "identityType": "",
+          "followerLevel": 1,
+          "frame": "5c4134060053810f24f38112",
+          "medal": "5eba4f88db01f0199c25901f",
+          "deleteTime": 0,
+          "createTime": 1527644375846,
+          "updateTime": 1655977390943
+        },
+        "record": {
+          "uid": "ad4f1f6d030f4d0abc17c6250002ac2d",
+          "feedCount": 2981,
+          "followerCount": 111309,
+          "followingCount": 266,
+          "roleCount": 1,
+          "squareCount": 6,
+          "likeCount": 12892,
+          "lastPostIpLocation": "江苏"
+        }
+      }
+    ],
+    "tdk": {
+      "title": "炉石拉斯塔哈的大乱斗威兹班卡组汇总（附代码）_炉石传说 | 大神",
+      "desc": "明天就是新版本了，我们一起来看看威兹班的的预构筑卡组吧！多套卡组的强度都非常高哦",
+      "keywords": ""
+    },
+    "squareBasicInfo": {
+      "squareId": "5bed591cd545681d1421bd58",
+      "icon": "https://img.166.net/reunionpub/100_20240926_1922e41e591791556.png",
+      "name": "炉石传说",
+      "tag": "5b02940cd545685882af85db"
+    }
+  },
+  "code": 200,
+  "errmsg": "OK"
+}

--- a/api_txt/ds/comment.json
+++ b/api_txt/ds/comment.json
@@ -1,0 +1,598 @@
+{
+  "result": {
+    "nextPageBound": 1760360496393,
+    "feedComments": [
+      {
+        "id": "69305b3c4228697897b238f7",
+        "uid": "24195c79a6974c06b24898ad9744c192",
+        "type": 1,
+        "content": "扫码得200积分 [查看图片]",
+        "commentRich": {
+          "mimeType": "image/jpeg",
+          "url": "https://ok.166.net/reunionpub/2_20251203_19ae4e4619d427339.jpeg",
+          "name": "查看图片",
+          "width": 1170,
+          "height": 2532,
+          "imageType": "NORMAL_IMAGE",
+          "mediumBlock": false
+        },
+        "feedId": "68e909d0d15e6d211787f0e8",
+        "feedUid": "7cb4e15e7167435da7312137522c2f21",
+        "tier": 1,
+        "deleteType": 0,
+        "deleteTime": 0,
+        "createTime": 1764776764723,
+        "updateTime": 1764776764723,
+        "clientType": 51,
+        "appRole": "{\"appKey\":\"h55\",\"roleId\":\"394800106\",\"server\":\"10001\",\"game\":\"第五人格\",\"nick\":\"碣石普信男\",\"icon\":\"https://app-res.ds.163.com/appresource/h55/498.png\",\"serverName\":\"正式服\",\"tags\":[{\"tag\":\"求生者段位\",\"value\":\"求生者三阶Ⅳ\"},{\"tag\":\"监管者段位\",\"value\":\"监管者零阶0\"}]}",
+        "traceId": "d263ff50b5c24430b440b511dc8c06d0",
+        "displayIpInfo": {
+          "ipLocationName": "广东"
+        },
+        "top": false,
+        "record": {
+          "repostCount": 0,
+          "commentCount": 0,
+          "likeCount": 0,
+          "authorLike": false,
+          "authorReplies": false,
+          "handpick": false,
+          "deleteTime": 0,
+          "createTime": 1764776764723,
+          "updateTime": 1764776764723
+        }
+      },
+      {
+        "id": "690dc742d5aa8b7f0a69576c",
+        "uid": "bdeb68c10580482baeaa797919b23b0a",
+        "type": 0,
+        "content": "好温馨好美好啊🥺看的人暖暖",
+        "feedId": "68e909d0d15e6d211787f0e8",
+        "feedUid": "7cb4e15e7167435da7312137522c2f21",
+        "tier": 1,
+        "deleteType": 0,
+        "deleteTime": 0,
+        "createTime": 1762510658175,
+        "updateTime": 1762510658175,
+        "clientType": 51,
+        "appRole": "{\"appKey\":\"h55\",\"roleId\":\"423399002\",\"server\":\"10001\",\"game\":\"第五人格\",\"nick\":\"汉堡的脚趾\",\"icon\":\"https://app-res.ds.163.com/appresource/h55/1176.png\",\"serverName\":\"正式服\"}",
+        "traceId": "de2a4bf485a94ba8a84f42211eee3b9a",
+        "displayIpInfo": {
+          "ipLocationName": "河南"
+        },
+        "top": false,
+        "record": {
+          "repostCount": 0,
+          "commentCount": 0,
+          "likeCount": 0,
+          "authorLike": false,
+          "authorReplies": false,
+          "handpick": false,
+          "deleteTime": 0,
+          "createTime": 1762510658175,
+          "updateTime": 1762510658175
+        }
+      },
+      {
+        "id": "68f3558568d2b744d20a5cdb",
+        "uid": "29074c37c8eb49c7a06a401406aa16ee",
+        "type": 1,
+        "content": "99 [查看图片]",
+        "commentRich": {
+          "mimeType": "image/png",
+          "url": "https://ok.166.net/reunionpub/2_20251018_199f6860f19710640.png",
+          "name": "查看图片",
+          "width": 1039,
+          "height": 1081,
+          "imageType": "NORMAL_IMAGE"
+        },
+        "feedId": "68e909d0d15e6d211787f0e8",
+        "feedUid": "7cb4e15e7167435da7312137522c2f21",
+        "tier": 1,
+        "deleteType": 0,
+        "deleteTime": 0,
+        "createTime": 1760777605865,
+        "updateTime": 1760777605865,
+        "clientType": 50,
+        "appRole": "{\"appKey\":\"h55\",\"roleId\":\"274318458\",\"server\":\"10001\",\"game\":\"第五人格\",\"nick\":\"青嚮\",\"icon\":\"https://app-res.ds.163.com/appresource/h55/654.png\",\"serverName\":\"正式服\"}",
+        "traceId": "6c0bcdeb749e40d4ad55e5b19fa58a35",
+        "displayIpInfo": {
+          "ipLocationName": "湖北"
+        },
+        "top": false,
+        "record": {
+          "repostCount": 0,
+          "commentCount": 0,
+          "likeCount": 0,
+          "authorLike": false,
+          "authorReplies": false,
+          "handpick": false,
+          "deleteTime": 0,
+          "createTime": 1760777605865,
+          "updateTime": 1760777605865
+        }
+      },
+      {
+        "id": "68f2dd7728eea900517a57f2",
+        "uid": "579eac56cb56420a9cce171adc975fe7",
+        "type": 0,
+        "content": "老师画的好美！好治愈！早上刷到这个感觉太好了！",
+        "feedId": "68e909d0d15e6d211787f0e8",
+        "feedUid": "7cb4e15e7167435da7312137522c2f21",
+        "tier": 1,
+        "deleteType": 0,
+        "deleteTime": 0,
+        "createTime": 1760746871047,
+        "updateTime": 1760746871047,
+        "clientType": 50,
+        "appRole": "{\"appKey\":\"h55\",\"roleId\":\"326762681\",\"server\":\"10001\",\"game\":\"第五人格\",\"nick\":\"残响未偿\",\"icon\":\"https://app-res.ds.163.com/appresource/h55/813.png\",\"serverName\":\"正式服\"}",
+        "traceId": "85471693ccf1496e839c11b3ad013de2",
+        "displayIpInfo": {
+          "ipLocationName": "山东"
+        },
+        "top": false,
+        "record": {
+          "repostCount": 0,
+          "commentCount": 0,
+          "likeCount": 1,
+          "authorLike": true,
+          "authorReplies": false,
+          "handpick": false,
+          "deleteTime": 0,
+          "createTime": 1760746871047,
+          "updateTime": 1761136066853
+        }
+      },
+      {
+        "id": "68ee701753f7351ed64e29fd",
+        "uid": "d7bb492b6da0463dbe845da6e2f1aa4a",
+        "type": 0,
+        "content": "好萌",
+        "feedId": "68e909d0d15e6d211787f0e8",
+        "feedUid": "7cb4e15e7167435da7312137522c2f21",
+        "tier": 1,
+        "deleteType": 0,
+        "deleteTime": 0,
+        "createTime": 1760456727657,
+        "updateTime": 1760456727657,
+        "clientType": 51,
+        "appRole": "{\"appKey\":\"h55\",\"roleId\":\"66819822\",\"server\":\"10001\",\"game\":\"第五人格\",\"nick\":\"春色温柔\",\"icon\":\"https://app-res.ds.163.com/appresource/h55/410.png\",\"serverName\":\"正式服\"}",
+        "traceId": "c696f5de9d6e48278f7046af48eb08c5",
+        "displayIpInfo": {
+          "ipLocationName": "马来西亚"
+        },
+        "top": false,
+        "record": {
+          "repostCount": 0,
+          "commentCount": 0,
+          "likeCount": 0,
+          "authorLike": false,
+          "authorReplies": false,
+          "handpick": false,
+          "deleteTime": 0,
+          "createTime": 1760456727657,
+          "updateTime": 1760456727657
+        }
+      },
+      {
+        "id": "68ee66ba9f25316326fbc713",
+        "uid": "c7e0f0fea7ab41c480b70ff90b56c1ae",
+        "type": 0,
+        "content": "好看",
+        "feedId": "68e909d0d15e6d211787f0e8",
+        "feedUid": "7cb4e15e7167435da7312137522c2f21",
+        "tier": 1,
+        "deleteType": 0,
+        "deleteTime": 0,
+        "createTime": 1760454330324,
+        "updateTime": 1760454330324,
+        "clientType": 51,
+        "appRole": "{\"appKey\":\"h55\",\"roleId\":\"11020455\",\"server\":\"10001\",\"game\":\"第五人格\",\"nick\":\"比格与猫\",\"icon\":\"https://app-res.ds.163.com/appresource/h55/1054.png\",\"serverName\":\"正式服\"}",
+        "traceId": "b89eb7596418430f913287e2ad37766e",
+        "displayIpInfo": {
+          "ipLocationName": "上海"
+        },
+        "top": false,
+        "record": {
+          "repostCount": 0,
+          "commentCount": 0,
+          "likeCount": 0,
+          "authorLike": false,
+          "authorReplies": false,
+          "handpick": false,
+          "deleteTime": 0,
+          "createTime": 1760454330324,
+          "updateTime": 1760454330324
+        }
+      },
+      {
+        "id": "68ee549ca0292b5b3a0b4f67",
+        "uid": "f3c0651ae64f4b3ab8f13f6dd421d906",
+        "type": 0,
+        "content": "99",
+        "feedId": "68e909d0d15e6d211787f0e8",
+        "feedUid": "7cb4e15e7167435da7312137522c2f21",
+        "tier": 1,
+        "deleteType": 0,
+        "deleteTime": 0,
+        "createTime": 1760449692881,
+        "updateTime": 1760449694406,
+        "fold": true,
+        "clientType": 51,
+        "appRole": "{\"appKey\":\"h55\",\"roleId\":\"308521571\",\"server\":\"10001\",\"game\":\"第五人格\",\"nick\":\"来抓本大王\",\"icon\":\"https://app-res.ds.163.com/appresource/h55/379.png\",\"serverName\":\"正式服\"}",
+        "traceId": "fd32e103a14244768655c2d1d0aa2b86",
+        "displayIpInfo": {
+          "ipLocationName": "广西"
+        },
+        "top": false,
+        "record": {
+          "repostCount": 0,
+          "commentCount": 0,
+          "likeCount": 0,
+          "authorLike": false,
+          "authorReplies": false,
+          "handpick": false,
+          "deleteTime": 0,
+          "createTime": 1760449692881,
+          "updateTime": 1760449692881
+        }
+      },
+      {
+        "id": "68ee51c9e38f87353593e099",
+        "uid": "2c28c4f0d7c0433e844105a3b6c48663",
+        "type": 0,
+        "content": "99",
+        "feedId": "68e909d0d15e6d211787f0e8",
+        "feedUid": "7cb4e15e7167435da7312137522c2f21",
+        "tier": 1,
+        "deleteType": 0,
+        "deleteTime": 0,
+        "createTime": 1760448969478,
+        "updateTime": 1760449205627,
+        "fold": true,
+        "clientType": 51,
+        "appRole": "{\"appKey\":\"h55\",\"roleId\":\"308424865\",\"server\":\"10001\",\"game\":\"第五人格\",\"nick\":\"跑不过我吧p\",\"icon\":\"https://app-res.ds.163.com/appresource/h55/1240.png\",\"serverName\":\"正式服\"}",
+        "traceId": "5e9d09c5d3864df392629266f4d6f120",
+        "displayIpInfo": {
+          "ipLocationName": "广西"
+        },
+        "top": false,
+        "record": {
+          "repostCount": 0,
+          "commentCount": 0,
+          "likeCount": 0,
+          "authorLike": false,
+          "authorReplies": false,
+          "handpick": false,
+          "deleteTime": 0,
+          "createTime": 1760448969478,
+          "updateTime": 1760448969478
+        }
+      },
+      {
+        "id": "68ed25467ffb5a6e84832ed5",
+        "uid": "b2506afca74145ad8dc29971f6c09f02",
+        "type": 0,
+        "content": "99",
+        "feedId": "68e909d0d15e6d211787f0e8",
+        "feedUid": "7cb4e15e7167435da7312137522c2f21",
+        "tier": 1,
+        "deleteType": 0,
+        "deleteTime": 0,
+        "createTime": 1760372038150,
+        "updateTime": 1760372041353,
+        "fold": true,
+        "clientType": 51,
+        "appRole": "{\"appKey\":\"h55\",\"roleId\":\"237435911\",\"server\":\"10001\",\"game\":\"第五人格\",\"nick\":\"朴成训是饭团兔\",\"icon\":\"https://app-res.ds.163.com/appresource/h55/822.png\",\"serverName\":\"正式服\"}",
+        "traceId": "f875d04100f74e50bb702c497e38308e",
+        "displayIpInfo": {
+          "ipLocationName": "广东"
+        },
+        "top": false,
+        "record": {
+          "repostCount": 0,
+          "commentCount": 0,
+          "likeCount": 0,
+          "authorLike": false,
+          "authorReplies": false,
+          "handpick": false,
+          "deleteTime": 0,
+          "createTime": 1760372038150,
+          "updateTime": 1760372038150
+        }
+      },
+      {
+        "id": "68ecf8309cfd9e289465533f",
+        "uid": "ee4ec1705393410fb4f0295dc999c6c4",
+        "type": 0,
+        "content": "99",
+        "feedId": "68e909d0d15e6d211787f0e8",
+        "feedUid": "7cb4e15e7167435da7312137522c2f21",
+        "tier": 1,
+        "deleteType": 0,
+        "deleteTime": 0,
+        "createTime": 1760360496393,
+        "updateTime": 1760360497330,
+        "fold": true,
+        "clientType": 50,
+        "appRole": "{\"appKey\":\"h55\",\"roleId\":\"343539566\",\"server\":\"10001\",\"game\":\"第五人格\",\"nick\":\"菜到被当m鞑\",\"icon\":\"https://app-res.ds.163.com/appresource/h55/1206.png\",\"serverName\":\"正式服\"}",
+        "traceId": "4bf4c7b95d284ffda67356f214217fbf",
+        "displayIpInfo": {
+          "ipLocationName": "重庆"
+        },
+        "top": false,
+        "record": {
+          "repostCount": 0,
+          "commentCount": 0,
+          "likeCount": 0,
+          "authorLike": false,
+          "authorReplies": false,
+          "handpick": false,
+          "deleteTime": 0,
+          "createTime": 1760360496393,
+          "updateTime": 1760360496393
+        }
+      }
+    ],
+    "featuredReplies": [],
+    "likes": [],
+    "userInfos": [
+      {
+        "user": {
+          "uid": "24195c79a6974c06b24898ad9744c192",
+          "nick": "游戏玩家61139814",
+          "icon": "https://ok.166.net/reunionpub/3_20250228_1954d148235540950.jpeg",
+          "intro": "",
+          "gender": 2,
+          "deleteTime": 0,
+          "createTime": 1740754941171,
+          "updateTime": 1740754944836
+        },
+        "record": {
+          "uid": "24195c79a6974c06b24898ad9744c192",
+          "feedCount": 5,
+          "followerCount": 46,
+          "followingCount": 110,
+          "roleCount": 1,
+          "squareCount": 3,
+          "likeCount": 1,
+          "lastPostIpLocation": "广东"
+        }
+      },
+      {
+        "user": {
+          "uid": "bdeb68c10580482baeaa797919b23b0a",
+          "nick": "我想要吃蟑螂",
+          "icon": "https://ok.166.net/reunionpub/3_20250725_19841686704372362.jpeg",
+          "intro": "",
+          "gender": 2,
+          "deleteTime": 0,
+          "createTime": 1753444008273,
+          "updateTime": 1753444182720
+        },
+        "record": {
+          "uid": "bdeb68c10580482baeaa797919b23b0a",
+          "feedCount": 42,
+          "followerCount": 1,
+          "followingCount": 29,
+          "roleCount": 1,
+          "squareCount": 1,
+          "likeCount": 0,
+          "lastPostIpLocation": "河南"
+        }
+      },
+      {
+        "user": {
+          "uid": "ee4ec1705393410fb4f0295dc999c6c4",
+          "nick": "游戏玩家95913840",
+          "icon": "https://ok.166.net/reunionpub/3_20240725_190ea5e93d4954849.png",
+          "intro": "",
+          "gender": 1,
+          "deleteTime": 0,
+          "createTime": 1716092657736,
+          "updateTime": 1728781404501
+        },
+        "record": {
+          "uid": "ee4ec1705393410fb4f0295dc999c6c4",
+          "feedCount": 4,
+          "followerCount": 3,
+          "followingCount": 9,
+          "roleCount": 2,
+          "squareCount": 3,
+          "likeCount": 1,
+          "lastPostIpLocation": "重庆"
+        }
+      },
+      {
+        "user": {
+          "uid": "29074c37c8eb49c7a06a401406aa16ee",
+          "nick": "小弗重度依赖",
+          "icon": "https://ok.166.net/reunionpub/3_20250914_1994642549d911545.jpeg",
+          "intro": "青取之于蓝，而青于蓝；冰水为之",
+          "gender": 2,
+          "birth": "1995-05-12",
+          "deleteTime": 0,
+          "createTime": 1705490252855,
+          "updateTime": 1757820422754
+        },
+        "record": {
+          "uid": "29074c37c8eb49c7a06a401406aa16ee",
+          "followingCount": 4,
+          "roleCount": 1,
+          "squareCount": 2,
+          "likeCount": 0,
+          "lastPostIpLocation": "湖北"
+        }
+      },
+      {
+        "user": {
+          "uid": "7cb4e15e7167435da7312137522c2f21",
+          "nick": "clokfrez",
+          "icon": "https://ok.166.net/reunionpub/3_20241208_193a254767c914127.jpeg",
+          "intro": "id：clokfrez/乖乖",
+          "gender": 2,
+          "birth": "2004-12-25",
+          "identityAuthenticInfo": "第五人格活跃创作者",
+          "identityType": "5",
+          "frame": "64b92f13db5e2e0001e826b5",
+          "medal": "5e7ab760a54a0010e4f01901",
+          "deleteTime": 0,
+          "createTime": 1672295118061,
+          "updateTime": 1760460964577
+        },
+        "record": {
+          "uid": "7cb4e15e7167435da7312137522c2f21",
+          "feedCount": 6,
+          "followerCount": 67,
+          "followingCount": 5,
+          "roleCount": 2,
+          "squareCount": 2,
+          "likeCount": 38966,
+          "lastPostIpLocation": "江苏"
+        }
+      },
+      {
+        "user": {
+          "uid": "2c28c4f0d7c0433e844105a3b6c48663",
+          "nick": "跑不过我吧p",
+          "icon": "https://ok.166.net/reunionpub/3_20240330_18e8d93abf3746230.jpeg",
+          "intro": "",
+          "gender": 2,
+          "birth": "2003-01-22",
+          "deleteTime": 0,
+          "createTime": 1711772185175,
+          "updateTime": 1711772486577
+        },
+        "record": {
+          "uid": "2c28c4f0d7c0433e844105a3b6c48663",
+          "feedCount": 21,
+          "followerCount": 5,
+          "followingCount": 10,
+          "roleCount": 1,
+          "squareCount": 1,
+          "likeCount": 6,
+          "lastPostIpLocation": "广西"
+        }
+      },
+      {
+        "user": {
+          "uid": "b2506afca74145ad8dc29971f6c09f02",
+          "nick": "一只冷酷画画",
+          "icon": "https://ok.166.net/reunionpub/3_20240917_191fba42fa6136985.jpeg",
+          "intro": "",
+          "gender": 2,
+          "state": "NORMAL",
+          "deleteTime": 0,
+          "createTime": 1719591640328,
+          "updateTime": 1747381634271
+        },
+        "record": {
+          "uid": "b2506afca74145ad8dc29971f6c09f02",
+          "feedCount": 34,
+          "followerCount": 84,
+          "followingCount": 103,
+          "roleCount": 1,
+          "squareCount": 2,
+          "likeCount": 108,
+          "lastPostIpLocation": "广东"
+        }
+      },
+      {
+        "user": {
+          "uid": "579eac56cb56420a9cce171adc975fe7",
+          "nick": "残响未偿",
+          "icon": "https://ok.166.net/reunionpub/3_20250805_19878719553156404.png",
+          "intro": "",
+          "gender": 1,
+          "birth": "1900-01-01",
+          "deleteTime": 0,
+          "createTime": 1753436387107,
+          "updateTime": 1754367367148
+        },
+        "record": {
+          "uid": "579eac56cb56420a9cce171adc975fe7",
+          "followerCount": 14,
+          "followingCount": 83,
+          "roleCount": 2,
+          "squareCount": 2,
+          "likeCount": 0,
+          "lastPostIpLocation": "山东"
+        }
+      },
+      {
+        "user": {
+          "uid": "c7e0f0fea7ab41c480b70ff90b56c1ae",
+          "nick": "羊肉青菜煲",
+          "icon": "https://ok.166.net/reunionpub/3_20250211_194f587f331697923.jpeg",
+          "intro": "",
+          "gender": 2,
+          "birth": "2006-04-06",
+          "deleteTime": 0,
+          "createTime": 1739286094178,
+          "updateTime": 1739286131945
+        },
+        "record": {
+          "uid": "c7e0f0fea7ab41c480b70ff90b56c1ae",
+          "feedCount": 36,
+          "followerCount": 23,
+          "followingCount": 19,
+          "roleCount": 1,
+          "squareCount": 1,
+          "likeCount": 7,
+          "lastPostIpLocation": "福建"
+        }
+      },
+      {
+        "user": {
+          "uid": "d7bb492b6da0463dbe845da6e2f1aa4a",
+          "nick": "不知鹤饼",
+          "icon": "https://ok.166.net/reunionpub/3_20221201_184ca85584a400008.jpeg",
+          "intro": "东京菜狗",
+          "gender": 2,
+          "birth": "2000-07-19",
+          "location": "Setagaya",
+          "medal": "5e7ab776a54a0030783fa3a7",
+          "squareMedals": [],
+          "chatBubble": "",
+          "deleteTime": 0,
+          "createTime": 1564057065655,
+          "updateTime": 1750787459369
+        },
+        "record": {
+          "uid": "d7bb492b6da0463dbe845da6e2f1aa4a",
+          "feedCount": 73,
+          "followerCount": 391,
+          "followingCount": 437,
+          "roleCount": 9,
+          "squareCount": 19,
+          "likeCount": 27,
+          "lastPostIpLocation": "河南"
+        }
+      },
+      {
+        "user": {
+          "uid": "f3c0651ae64f4b3ab8f13f6dd421d906",
+          "nick": "我开的火箭",
+          "icon": "https://ok.166.net/reunionpub/3_20240427_18f1da41021463120.jpeg",
+          "intro": "",
+          "gender": 2,
+          "deleteTime": 0,
+          "createTime": 1714189238641,
+          "updateTime": 1714189242904
+        },
+        "record": {
+          "uid": "f3c0651ae64f4b3ab8f13f6dd421d906",
+          "feedCount": 19,
+          "followerCount": 5,
+          "followingCount": 12,
+          "roleCount": 1,
+          "squareCount": 3,
+          "likeCount": 2,
+          "lastPostIpLocation": "广西"
+        }
+      }
+    ]
+  },
+  "code": 200,
+  "errmsg": "OK"
+}

--- a/api_txt/ds/hot_comment.json
+++ b/api_txt/ds/hot_comment.json
@@ -1,0 +1,214 @@
+{
+  "result": {
+    "feedComments": [
+      {
+        "id": "68eab7805623454f6b691d64",
+        "uid": "7cb4e15e7167435da7312137522c2f21",
+        "type": 0,
+        "content": "艾玛",
+        "feedId": "68e909d0d15e6d211787f0e8",
+        "feedUid": "7cb4e15e7167435da7312137522c2f21",
+        "tier": 1,
+        "deleteType": 0,
+        "deleteTime": 0,
+        "createTime": 1760212864212,
+        "updateTime": 1760212864212,
+        "clientType": 50,
+        "appRole": "{\"appKey\":\"h55\",\"roleId\":\"265566703\",\"server\":\"10001\",\"game\":\"第五人格\",\"nick\":\"春夜十话\",\"icon\":\"https://app-res.ds.163.com/appresource/h55/1119.png\",\"serverName\":\"正式服\"}",
+        "traceId": "5b96ae9f4f5047189fa2449de71f4fd3",
+        "displayIpInfo": {
+          "ipLocationName": "江苏"
+        },
+        "top": false,
+        "record": {
+          "repostCount": 0,
+          "commentCount": 0,
+          "likeCount": 0,
+          "authorLike": false,
+          "authorReplies": false,
+          "handpick": false,
+          "deleteTime": 0,
+          "createTime": 1760212864212,
+          "updateTime": 1760212864212
+        }
+      },
+      {
+        "id": "68ea46781149f95a4e7c3fe2",
+        "uid": "b247e12f972845298ee83a0e18b07c25",
+        "type": 0,
+        "content": "第一次在网易大神看见流量这么多的视频",
+        "feedId": "68e909d0d15e6d211787f0e8",
+        "feedUid": "7cb4e15e7167435da7312137522c2f21",
+        "tier": 1,
+        "deleteType": 0,
+        "deleteTime": 0,
+        "createTime": 1760183928287,
+        "updateTime": 1760183928287,
+        "clientType": 50,
+        "appRole": "{\"appKey\":\"h55\",\"roleId\":\"348724037\",\"server\":\"10001\",\"game\":\"第五人格\",\"nick\":\"恋緀\",\"icon\":\"https://app-res.ds.163.com/appresource/h55/827.png\",\"serverName\":\"正式服\"}",
+        "traceId": "9724cbc7c29f42cf8b60ab32af05aa34",
+        "displayIpInfo": {
+          "ipLocationName": "辽宁"
+        },
+        "top": false,
+        "record": {
+          "repostCount": 0,
+          "commentCount": 5,
+          "likeCount": 16,
+          "authorLike": true,
+          "authorReplies": false,
+          "handpick": false,
+          "deleteTime": 0,
+          "createTime": 1760183928287,
+          "updateTime": 1764769070705
+        }
+      }
+    ],
+    "featuredReplies": [
+      {
+        "id": "68eb33cdb9520518a13a9c38",
+        "uid": "273f89bd33d64293b8c24053d70f15fa",
+        "type": 0,
+        "content": "回复@clokfrez: 包的[哇]",
+        "feedId": "68e909d0d15e6d211787f0e8",
+        "feedUid": "7cb4e15e7167435da7312137522c2f21",
+        "replyType": 1,
+        "replyId": "68eab66ea9a26b41d1597798",
+        "replyUid": "7cb4e15e7167435da7312137522c2f21",
+        "parent": "7cb4e15e7167435da7312137522c2f21.68e909d0d15e6d211787f0e8.68ea46781149f95a4e7c3fe2",
+        "tier": 2,
+        "deleteType": 0,
+        "deleteTime": 0,
+        "createTime": 1760244685876,
+        "updateTime": 1760244685876,
+        "clientType": 50,
+        "appRole": "{\"appKey\":\"h55\",\"roleId\":\"335882657\",\"server\":\"10001\",\"game\":\"第五人格\",\"nick\":\"刘枭枭枭v\",\"icon\":\"https://app-res.ds.163.com/appresource/h55/1240.png\",\"serverName\":\"正式服\"}",
+        "traceId": "210be7cddf764036893bf5464f240e66",
+        "displayIpInfo": {
+          "ipLocationName": "浙江"
+        },
+        "record": {
+          "repostCount": 0,
+          "commentCount": 0,
+          "likeCount": 1,
+          "authorLike": false,
+          "authorReplies": false,
+          "handpick": false,
+          "deleteTime": 0,
+          "createTime": 1760244685876,
+          "updateTime": 1760341915897
+        }
+      },
+      {
+        "id": "68eab66ea9a26b41d1597798",
+        "uid": "7cb4e15e7167435da7312137522c2f21",
+        "type": 0,
+        "content": "很恐怖大家都是活人吗",
+        "feedId": "68e909d0d15e6d211787f0e8",
+        "feedUid": "7cb4e15e7167435da7312137522c2f21",
+        "replyType": 1,
+        "replyId": "68ea46781149f95a4e7c3fe2",
+        "replyUid": "b247e12f972845298ee83a0e18b07c25",
+        "parent": "7cb4e15e7167435da7312137522c2f21.68e909d0d15e6d211787f0e8.68ea46781149f95a4e7c3fe2",
+        "tier": 2,
+        "deleteType": 0,
+        "deleteTime": 0,
+        "createTime": 1760212590549,
+        "updateTime": 1760212590549,
+        "clientType": 50,
+        "appRole": "{\"appKey\":\"h55\",\"roleId\":\"265566703\",\"server\":\"10001\",\"game\":\"第五人格\",\"nick\":\"春夜十话\",\"icon\":\"https://app-res.ds.163.com/appresource/h55/1119.png\",\"serverName\":\"正式服\"}",
+        "traceId": "1f95a9fd7d0c408ca6baa2015534e523",
+        "displayIpInfo": {
+          "ipLocationName": "江苏"
+        },
+        "record": {
+          "repostCount": 0,
+          "commentCount": 0,
+          "likeCount": 13,
+          "authorLike": false,
+          "authorReplies": false,
+          "handpick": false,
+          "deleteTime": 0,
+          "createTime": 1760212590549,
+          "updateTime": 1764769071599
+        }
+      }
+    ],
+    "likes": [],
+    "userInfos": [
+      {
+        "user": {
+          "uid": "7cb4e15e7167435da7312137522c2f21",
+          "nick": "clokfrez",
+          "icon": "https://ok.166.net/reunionpub/3_20241208_193a254767c914127.jpeg",
+          "intro": "id：clokfrez/乖乖",
+          "gender": 2,
+          "birth": "2004-12-25",
+          "identityAuthenticInfo": "第五人格活跃创作者",
+          "identityType": "5",
+          "frame": "64b92f13db5e2e0001e826b5",
+          "medal": "5e7ab760a54a0010e4f01901",
+          "deleteTime": 0,
+          "createTime": 1672295118061,
+          "updateTime": 1760460964577
+        },
+        "record": {
+          "uid": "7cb4e15e7167435da7312137522c2f21",
+          "feedCount": 6,
+          "followerCount": 67,
+          "followingCount": 5,
+          "roleCount": 2,
+          "squareCount": 2,
+          "likeCount": 38966,
+          "lastPostIpLocation": "江苏"
+        }
+      },
+      {
+        "user": {
+          "uid": "273f89bd33d64293b8c24053d70f15fa",
+          "nick": "游戏玩家38505233",
+          "icon": "https://ok.166.net/reunionpub/3_20250215_195099b803d710802.jpeg",
+          "intro": "",
+          "gender": 2,
+          "deleteTime": 0,
+          "createTime": 1730477149380,
+          "updateTime": 1739622944948
+        },
+        "record": {
+          "uid": "273f89bd33d64293b8c24053d70f15fa",
+          "followerCount": 3,
+          "followingCount": 57,
+          "roleCount": 2,
+          "squareCount": 2,
+          "likeCount": 0,
+          "lastPostIpLocation": "浙江"
+        }
+      },
+      {
+        "user": {
+          "uid": "b247e12f972845298ee83a0e18b07c25",
+          "nick": "恋緀",
+          "icon": "https://ok.166.net/reunionpub/3_20250518_196e1634d4b348092.jpeg",
+          "intro": "",
+          "gender": 2,
+          "medal": "5e7ab760a54a0010e4f01901",
+          "deleteTime": 0,
+          "createTime": 1733918069074,
+          "updateTime": 1777639376661
+        },
+        "record": {
+          "uid": "b247e12f972845298ee83a0e18b07c25",
+          "feedCount": 2,
+          "followerCount": 30,
+          "followingCount": 142,
+          "roleCount": 1,
+          "squareCount": 1,
+          "likeCount": 6,
+          "lastPostIpLocation": "辽宁"
+        }
+      }
+    ]
+  },
+  "code": 200,
+  "errmsg": "OK"
+}

--- a/api_txt/ds/image.json
+++ b/api_txt/ds/image.json
@@ -1,0 +1,88 @@
+{
+  "result": {
+    "feed": {
+      "id": "6a72c0978ae5b5008129d034",
+      "uid": "f286ea88872c4273a283cd9d8f3f7068",
+      "type": 2,
+      "content": "{\"type\":2,\"body\":{\"text\":\"重磅福利！惊喜加倍！官服蛋仔福利必领榜迎来更新——8月7日（周五）-8月20日，蛋仔天官暑期福利狂送上亿蛋币，每人230枚限时蛋币好礼速来抱走！仅限官服蛋仔！\\n\\n🎉天官限时福利大放送：官服蛋仔累计登录5天，即可领取100枚限时蛋币；前往网易大神还可再领30枚限时蛋币！共计130枚蛋币轻松收入囊中！\\n🎉加倍奖励来袭：仅需1元可额外解锁共计100枚限时蛋币的加倍奖励！前往网易大神领取0.9元代金券，到手价低至0.1元！\\n#蛋仔派对# #玩蛋仔就来官服# #用官服就领蛋币#\",\"media\":[{\"name\":\"天宫.png\",\"url\":\"https://ok.166.net/reunionpub/1_kol_20260805_5e6074522c8e395b2345f636199ac358\",\"mimeType\":\"image/png\",\"size\":1606196,\"width\":1518,\"height\":1006,\"watermark\":true}]}}",
+      "deleteTime": 0,
+      "createTime": 1785905299567,
+      "updateTime": 1785905303903,
+      "clientType": 152,
+      "tagList": ["60054d66d5456877d2268a7e"],
+      "attributeInfoList": [],
+      "topicInfoList": [
+        {
+          "topicName": "蛋仔派对",
+          "type": "DEFAULT"
+        },
+        {
+          "topicName": "玩蛋仔就来官服",
+          "type": "DEFAULT"
+        },
+        {
+          "topicName": "用官服就领蛋币",
+          "type": "DEFAULT"
+        }
+      ],
+      "pendant": {},
+      "interactOption": {
+        "comment": "DEFAULT",
+        "repost": "DEFAULT",
+        "handpick": false,
+        "contentStatementOption": "DEFAULT"
+      },
+      "displayIpInfo": {
+        "ipLocationName": "浙江"
+      },
+      "record": {
+        "id": "6a72c0978ae5b5008129d034",
+        "repostCount": 1,
+        "commentCount": 513,
+        "likeCount": 498,
+        "shareCount": 34,
+        "favCount": 154,
+        "createTime": 1785905339887
+      }
+    },
+    "userInfos": [
+      {
+        "user": {
+          "uid": "f286ea88872c4273a283cd9d8f3f7068",
+          "nick": "蛋仔派对",
+          "icon": "https://ok.166.net/reunionpub/3_20260729_19fa97c33ad712538.jpeg",
+          "intro": "咔咔~欢迎各位光临蛋仔岛！(*╹▽╹*)",
+          "gender": 1,
+          "identityAuthenticInfo": "《蛋仔派对》官方号",
+          "identityType": "1",
+          "followerLevel": 1,
+          "deleteTime": 0,
+          "createTime": 1639474576165,
+          "updateTime": 1785254918509
+        },
+        "record": {
+          "uid": "f286ea88872c4273a283cd9d8f3f7068",
+          "feedCount": 5416,
+          "followerCount": 659278,
+          "followingCount": 2,
+          "squareCount": 1,
+          "likeCount": 842368,
+          "lastPostIpLocation": "浙江"
+        }
+      }
+    ],
+    "tdk": {
+      "title": "重磅福利！惊喜加倍_蛋仔派对 | 大神",
+      "desc": "重磅福利！惊喜加倍！官服蛋仔福利必领榜迎来更新——8月7日（周五）-8月20日，蛋仔天官暑期福利狂送上亿蛋币，每人230枚限时蛋币好礼速来抱走！仅限官服蛋仔",
+      "keywords": ""
+    },
+    "squareBasicInfo": {
+      "squareId": "60054a7dd5456877d226706e",
+      "icon": "https://img.166.net/reunionpub/100_20260515_19e29a8892b606375.png",
+      "name": "蛋仔派对",
+      "tag": "60054d66d5456877d2268a7e"
+    }
+  },
+  "code": 200,
+  "errmsg": "OK"
+}

--- a/api_txt/ds/video.json
+++ b/api_txt/ds/video.json
@@ -1,0 +1,88 @@
+{
+  "result": {
+    "feed": {
+      "id": "6a747089ed602c039ed03cd5",
+      "uid": "f286ea88872c4273a283cd9d8f3f7068",
+      "type": 3,
+      "content": "{\"type\":3,\"body\":{\"text\":\"今日蛋闻：主播提醒你领88电竞节福利啦！\\n• 想要限时蛋币？120枚都给你！8月8日登录先领60枚，8月9日-9日巅峰派对、逃出惊魂夜总冠军决出后再分别领30枚！\\n• 想要彩虹币？8月7日-9日每日20：00，彩虹币红包雨来袭，保底12枚，最高666枚彩虹币！\\n• 想要典藏外观？8月8日起，参与活动直接拿下典藏外观及幻想时装！\\n• 想要更多外观？参与活动攒抽奖券，8月8日起巅峰拍档外观、惊魂夜外观统统免费抽！\\n\\n同时，《蛋仔派对》第三届全国总决赛即将开赛！8月8日-9日14：00，锁定官方直播间，见证冠军实力登顶，更有未来版本爆料抢先看！\\n#蛋仔派对# #蛋仔电竞节# #蛋仔派对全国总决赛#\",\"media\":[{\"name\":\"电竞节蛋闻联播v4.mp4\",\"url\":\"https://vod.cc.163.com/file/6a746f2c8896cbf7d0f2aaca.mp4?client_type=ios&protocol=https\",\"text\":\"【电竞节】8月8日福利来袭！\",\"mimeType\":\"video/mp4\",\"size\":69117023,\"duration\":45350,\"width\":1920,\"height\":1080,\"videoWidth\":1920,\"videoHeight\":1080,\"cover\":\"https://ok.166.net/reunionpub/1_kol_20260806_85d13a6035452ecce975d5e57293753b\",\"coverStyle\":{\"style\":0.0,\"width\":1920.0,\"height\":1080.0},\"previewVideoUrl\":\"http://api.cc.163.com/v1/vodapi/preview/82115d4021072187f76a493d6008e80a.mp4\",\"ldPreview\":false,\"watermark\":true,\"videoCheckToken\":0,\"mediaId\":\"6a746f2c8896cbf7d0f2aaca\",\"sourceMediaId\":\"6a746f2c8896cbf7d0f2aaca\"}],\"mediaId\":\"6a746f2c8896cbf7d0f2aaca\"}}",
+      "deleteTime": 0,
+      "createTime": 1786015881235,
+      "updateTime": 1786015881235,
+      "clientType": 152,
+      "tagList": ["60054d66d5456877d2268a7e"],
+      "attributeInfoList": [],
+      "topicInfoList": [
+        {
+          "topicName": "蛋仔派对",
+          "type": "DEFAULT"
+        },
+        {
+          "topicName": "蛋仔电竞节",
+          "type": "DEFAULT"
+        },
+        {
+          "topicName": "蛋仔派对全国总决赛",
+          "type": "DEFAULT"
+        }
+      ],
+      "pendant": {},
+      "interactOption": {
+        "comment": "DEFAULT",
+        "repost": "DEFAULT",
+        "handpick": false,
+        "contentStatementOption": "DEFAULT"
+      },
+      "displayIpInfo": {
+        "ipLocationName": "浙江"
+      },
+      "record": {
+        "id": "6a747089ed602c039ed03cd5",
+        "repostCount": 1,
+        "commentCount": 38,
+        "likeCount": 5178,
+        "shareCount": 0,
+        "favCount": 9,
+        "createTime": 1786015937294
+      }
+    },
+    "userInfos": [
+      {
+        "user": {
+          "uid": "f286ea88872c4273a283cd9d8f3f7068",
+          "nick": "蛋仔派对",
+          "icon": "https://ok.166.net/reunionpub/3_20260729_19fa97c33ad712538.jpeg",
+          "intro": "咔咔~欢迎各位光临蛋仔岛！(*╹▽╹*)",
+          "gender": 1,
+          "identityAuthenticInfo": "《蛋仔派对》官方号",
+          "identityType": "1",
+          "followerLevel": 1,
+          "deleteTime": 0,
+          "createTime": 1639474576165,
+          "updateTime": 1785254918509
+        },
+        "record": {
+          "uid": "f286ea88872c4273a283cd9d8f3f7068",
+          "feedCount": 5416,
+          "followerCount": 659281,
+          "followingCount": 2,
+          "squareCount": 1,
+          "likeCount": 842372,
+          "lastPostIpLocation": "浙江"
+        }
+      }
+    ],
+    "tdk": {
+      "title": "电竞节】8月8日福利来袭！_蛋仔派对 | 大神",
+      "desc": "今日蛋闻：主播提醒你领88电竞节福利啦！• 想要限时蛋币？120枚都给你！8月8日登录先领60枚，8月9日-9日巅峰派对、逃出惊魂夜总冠军决出后再分别领30枚！• 想要彩虹币",
+      "keywords": ""
+    },
+    "squareBasicInfo": {
+      "squareId": "60054a7dd5456877d226706e",
+      "icon": "https://img.166.net/reunionpub/100_20260515_19e29a8892b606375.png",
+      "name": "蛋仔派对",
+      "tag": "60054d66d5456877d2268a7e"
+    }
+  },
+  "code": 200,
+  "errmsg": "OK"
+}

--- a/src/nonebot_plugin_parser_lite/constants.py
+++ b/src/nonebot_plugin_parser_lite/constants.py
@@ -68,6 +68,7 @@ class PlatformEnum(str, Enum):
     WMPVP = "wmpvp"
     ZLB = "zlb"
     TAPTAP = "taptap"
+    DS = "ds"
 
     def __str__(self) -> str:
         return self.value

--- a/src/nonebot_plugin_parser_lite/parsers/__init__.py
+++ b/src/nonebot_plugin_parser_lite/parsers/__init__.py
@@ -5,6 +5,7 @@ from .coolapk import CoolapkParser
 from .douban import DoubanParser
 from .doubao import DouBaoParser
 from .douyin import DouyinParser
+from .ds import DsParser
 from .duitang import DuiTangParser
 from .fiveeplay import FiveEPlayParser
 from .heybox import HeyBoxParser
@@ -35,6 +36,7 @@ __all__ = [
     "DouBaoParser",
     "DoubanParser",
     "DouyinParser",
+    "DsParser",
     "DuiTangParser",
     "FiveEPlayParser",
     "HeyBoxParser",

--- a/src/nonebot_plugin_parser_lite/parsers/ds/__init__.py
+++ b/src/nonebot_plugin_parser_lite/parsers/ds/__init__.py
@@ -1,0 +1,88 @@
+from typing import ClassVar, TypeVar
+
+from msgspec import convert
+from nonebot.log import logger
+
+from ...data import Comment
+from ..base import (
+    BaseParser,
+    MatchWithParams,
+    ParseException,
+    Platform,
+    PlatformEnum,
+    handle,
+    pconfig,
+)
+from .comment import Result as CommentResult
+from .feed import Result as FeedResult
+
+T = TypeVar("T")
+
+
+class DsParser(BaseParser):
+    platform: ClassVar[Platform] = Platform(name=PlatformEnum.DS, display_name="大神")
+
+    async def fetch(self, url: str, model: type[T]) -> T:
+        resp = await self.httpx.get(url)
+        if not resp.is_success:
+            raise ParseException(
+                f"Failed to fetch {url}, status code: {resp.status_code}, "
+                f"text: {resp.text}"
+            )
+        data = resp.json()
+        if data["code"] != 200:
+            raise ParseException(
+                f"Failed to fetch {url}, code: {data['code']}, data: {data}"
+            )
+        return convert(data["result"], model)
+
+    @staticmethod
+    def _merge_comments(results: list[CommentResult]) -> list[Comment]:
+        merged = CommentResult()
+        for result in results:
+            merged.feedComments.extend(result.feedComments)
+            merged.featuredReplies.extend(result.featuredReplies)
+            merged.userInfos.extend(result.userInfos)
+        return merged.comment_list
+
+    @handle("ds.163.com", r"article/(?P<feed_id>[A-Za-z0-9]+)")
+    @handle("ds.163.com", r"feed/(?P<feed_id>[A-Za-z0-9]+)")
+    async def parse_feed(self, searched: MatchWithParams):
+        feed_id = searched["feed_id"]
+        feed = await self.fetch(
+            f"https://inf.ds.163.com/v1/web/feed/basic/facade?feedId={feed_id}",
+            FeedResult,
+        )
+        sid = f"{feed.feed.uid}.{feed_id}"
+        comment_results: list[CommentResult] = []
+
+        try:
+            handpicked = await self.fetch(
+                "https://inf.ds.163.com/v1/web/comment/getCommentsByHandpicked"
+                f"?sid={sid}&tier=1",
+                CommentResult,
+            )
+            comment_results.append(handpicked)
+        except Exception:
+            logger.exception("获取大神精选评论失败")
+
+        try:
+            latest = await self.fetch(
+                "https://inf.ds.163.com/v1/web/comment/page"
+                f"?sid={sid}&tier=1&sortDirection=DESC"
+                f"&count={pconfig.max_comments}",
+                CommentResult,
+            )
+            comment_results.append(latest)
+        except Exception:
+            logger.exception("获取大神评论失败")
+
+        return self.result(
+            author=feed.author,
+            url=f"https://ds.163.com/feed/{feed_id}",
+            title=feed.feed.title,
+            content=feed.feed.content,
+            stats=feed.feed.stats,
+            comments=self._merge_comments(comment_results),
+            timestamp=feed.feed.timestamp,
+        )

--- a/src/nonebot_plugin_parser_lite/parsers/ds/comment.py
+++ b/src/nonebot_plugin_parser_lite/parsers/ds/comment.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+from itertools import chain
+
+from msgspec import Struct, field
+from msgspec.json import Decoder
+
+from ...creator import Creator
+from ...data import Author, Comment, ContentItem
+from ...utils.format import format_num
+from .feed import DisplayIpInfo, UserInfo
+
+
+class CommentRich(Struct):
+    url: str
+    name: str = ""
+
+
+class CommentRecord(Struct):
+    likeCount: int = 0
+    commentCount: int = 0
+
+
+class FeedComment(Struct):
+    id: str
+    uid: str
+    createTime: int
+    text: str = field(name="content", default="")
+    record: CommentRecord = field(default_factory=CommentRecord)
+    displayIpInfo: DisplayIpInfo | None = None
+    commentRich: CommentRich | None = None
+    replyId: str | None = None
+    replyUid: str | None = None
+    parent: str | None = None
+
+    @property
+    def content(self) -> list[ContentItem]:
+        text = self.text
+        result: list[ContentItem] = []
+
+        if rich := self.commentRich:
+            if rich.name:
+                text = text.replace(f"[{rich.name}]", "", 1).strip()
+            if text:
+                result.append(text)
+            result.append(Creator.image(url=rich.url))
+        elif text:
+            result.append(text)
+
+        return result
+
+    @property
+    def timestamp(self) -> int:
+        return self.createTime // 1000
+
+    @property
+    def root_id(self) -> str | None:
+        """parent 格式为 feedId.feedAuthorId.commentId。"""
+        return self.parent.rsplit(".", 1)[-1] if self.parent else None
+
+
+FeaturedReply = FeedComment
+
+
+class Result(Struct):
+    feedComments: list[FeedComment] = field(default_factory=list)
+    featuredReplies: list[FeaturedReply] = field(default_factory=list)
+    userInfos: list[UserInfo] = field(default_factory=list)
+
+    @property
+    def user_info_by_uid(self) -> dict[str, UserInfo]:
+        return {info.user.uid: info for info in self.userInfos}
+
+    def _author(
+        self,
+        comment: FeedComment,
+        user_info_by_uid: dict[str, UserInfo],
+    ) -> Author:
+        info = user_info_by_uid.get(comment.uid)
+        location = (
+            comment.displayIpInfo.ipLocationName
+            if comment.displayIpInfo is not None
+            else None
+        )
+        if info is None:
+            return Creator.author(name=comment.uid, id=comment.uid, location=location)
+
+        user = info.user
+        return Creator.author(
+            id=user.uid,
+            name=user.nick,
+            avatar_url=user.icon,
+            description=user.intro or None,
+            location=location,
+        )
+
+    def _to_comment(
+        self,
+        comment: FeedComment,
+        user_info_by_uid: dict[str, UserInfo],
+    ) -> Comment:
+        return Creator.comment(
+            author=self._author(comment, user_info_by_uid),
+            content=comment.content,
+            timestamp=comment.timestamp,
+            stats=Creator.stats(
+                like_count=format_num(comment.record.likeCount),
+                comment_count=format_num(comment.record.commentCount),
+            ),
+        )
+
+    def _build_nodes(
+        self,
+        raw_comments: list[FeedComment],
+    ) -> tuple[dict[str, Comment], dict[str, Author]]:
+        """创建评论节点及作者索引。"""
+        user_info_by_uid = self.user_info_by_uid
+        nodes: dict[str, Comment] = {}
+        author_by_uid: dict[str, Author] = {}
+
+        for raw in raw_comments:
+            if raw.id not in nodes:
+                node = self._to_comment(raw, user_info_by_uid)
+                nodes[raw.id] = node
+                author_by_uid.setdefault(raw.uid, node.author)
+
+        return nodes, author_by_uid
+
+    def _attach_replies(
+        self,
+        nodes: dict[str, Comment],
+        author_by_uid: dict[str, Author],
+    ) -> None:
+        """将回复压平挂到根评论，同时保留实际回复对象。"""
+        attached: set[str] = set()
+        for raw in self.featuredReplies:
+            root = nodes.get(raw.root_id or "")
+            node = nodes[raw.id]
+            if root is None or root is node or raw.id in attached:
+                continue
+
+            replied_to = nodes.get(raw.replyId or "")
+            parent_author = replied_to.author if replied_to is not None else None
+            if parent_author is None and raw.replyUid:
+                parent_author = author_by_uid.get(raw.replyUid)
+            root.add_reply(node, parent_author)
+            attached.add(raw.id)
+
+    def _root_comments(self, nodes: dict[str, Comment]) -> list[Comment]:
+        return list({raw.id: nodes[raw.id] for raw in self.feedComments}.values())
+
+    @property
+    def comment_list(self) -> list[Comment]:
+        raw_comments = list(chain(self.feedComments, self.featuredReplies))
+        nodes, author_by_uid = self._build_nodes(raw_comments)
+        self._attach_replies(nodes, author_by_uid)
+        return self._root_comments(nodes)
+
+
+decoder = Decoder(Result)

--- a/src/nonebot_plugin_parser_lite/parsers/ds/comment.py
+++ b/src/nonebot_plugin_parser_lite/parsers/ds/comment.py
@@ -135,8 +135,8 @@ class Result(Struct):
         attached: set[str] = set()
         for raw in self.featuredReplies:
             root = nodes.get(raw.root_id or "")
-            node = nodes[raw.id]
-            if root is None or root is node or raw.id in attached:
+            node = nodes.get(raw.id)
+            if root is None or node is None or root is node or raw.id in attached:
                 continue
 
             replied_to = nodes.get(raw.replyId or "")

--- a/src/nonebot_plugin_parser_lite/parsers/ds/feed.py
+++ b/src/nonebot_plugin_parser_lite/parsers/ds/feed.py
@@ -1,0 +1,135 @@
+from msgspec import Struct, field
+from msgspec.json import Decoder
+
+from ...creator import ContentItem, Creator
+from ...utils.format import format_num
+from .util import parse_rich_content
+
+
+class DisplayIpInfo(Struct):
+    ipLocationName: str
+
+
+class User(Struct):
+    uid: str
+    nick: str
+    icon: str
+    intro: str
+
+
+class UserInfo(Struct):
+    user: User
+
+
+class Record(Struct):
+    repostCount: int
+    commentCount: int
+    likeCount: int
+    shareCount: int
+    favCount: int
+
+
+class Media(Struct):
+    url: str
+    mimeType: str
+    """video/xxx, image/xxx"""
+    name: str | None = field(default=None)
+    duration: int | None = field(default=None)
+    cover: str | None = field(default=None)
+
+
+class Body(Struct):
+    text: str | None = field(default=None)
+    media: list[Media] = field(default_factory=list)
+    title: str | None = field(default=None)
+    html: str | None = field(name="longText", default=None)
+
+
+class Content(Struct):
+    body: Body
+
+
+contentDecoder = Decoder(Content)
+
+
+class Feed(Struct):
+    id: str
+    uid: str
+    dumps: str = field(name="content")
+    createTime: int
+    record: Record
+    displayIpInfo: DisplayIpInfo | None = field(default=None)
+    _content_obj: Content | None = field(default=None)
+
+    @property
+    def content_obj(self) -> Content:
+        if self._content_obj is None:
+            self._content_obj = contentDecoder.decode(self.dumps)
+        return self._content_obj
+
+    @property
+    def content(self):
+        body = self.content_obj.body
+        if body.html:
+            return parse_rich_content(body.html)
+        content: list[ContentItem] = []
+        if text := body.text:
+            content.append(text)
+        if medias := body.media:
+            for media in medias:
+                if media.mimeType.startswith("video"):
+                    assert media.duration, "duration is required in video media"
+                    content.append(
+                        Creator.video(
+                            url_or_task=media.url,
+                            duration=media.duration // 1000,
+                            cover_url=media.cover,
+                        )
+                    )
+                elif media.mimeType.startswith("image"):
+                    content.append(Creator.image(url=media.url))
+        return content
+
+    @property
+    def title(self):
+        return self.content_obj.body.title
+
+    @property
+    def timestamp(self):
+        return self.createTime // 1000
+
+    @property
+    def stats(self):
+        record = self.record
+        return Creator.stats(
+            like_count=format_num(record.likeCount),
+            comment_count=format_num(record.commentCount),
+            share_count=format_num(record.shareCount),
+            collect_count=format_num(record.favCount),
+        )
+
+
+class Result(Struct):
+    feed: Feed
+    userInfos: list[UserInfo]
+
+    @property
+    def user_info_by_uid(self):
+        return {info.user.uid: info for info in self.userInfos}
+
+    @property
+    def author(self):
+        author = self.user_info_by_uid[self.feed.uid]
+        location = (
+            self.feed.displayIpInfo.ipLocationName if self.feed.displayIpInfo else None
+        )
+        return Creator.author(
+            id=author.user.uid,
+            name=author.user.nick,
+            avatar_url=author.user.icon,
+            location=location,
+        )
+
+
+
+decoder = Decoder(Result)

--- a/src/nonebot_plugin_parser_lite/parsers/ds/util.py
+++ b/src/nonebot_plugin_parser_lite/parsers/ds/util.py
@@ -6,7 +6,7 @@ from ...data import ContentItem
 
 
 def parse_rich_content(html: str) -> list[ContentItem]:
-    soup = BeautifulSoup(html.replace(r"\"", '"'), "html.parser")
+    soup = BeautifulSoup(html, "html.parser")
 
     result: list[ContentItem] = []
     buffer: list[str] = []

--- a/src/nonebot_plugin_parser_lite/parsers/ds/util.py
+++ b/src/nonebot_plugin_parser_lite/parsers/ds/util.py
@@ -1,0 +1,55 @@
+from bs4 import BeautifulSoup
+from bs4.element import NavigableString, Tag
+
+from ...creator import Creator
+from ...data import ContentItem
+
+
+def parse_rich_content(html: str) -> list[ContentItem]:
+    soup = BeautifulSoup(html.replace(r"\"", '"'), "html.parser")
+
+    result: list[ContentItem] = []
+    buffer: list[str] = []
+
+    for item in _iter_media_and_text(soup):
+        if isinstance(item, str):
+            buffer.append(item)
+        else:
+            if buffer:
+                text_block = "".join(buffer)
+                lines = [line.rstrip() for line in text_block.splitlines()]
+                if normalized := "\n".join(lines).strip():
+                    result.append(normalized)
+                buffer.clear()
+            result.append(item)
+
+    if buffer:
+        text_block = "".join(buffer)
+        lines = [line.rstrip() for line in text_block.splitlines()]
+        if normalized := "\n".join(lines).strip():
+            result.append(normalized)
+
+    return result
+
+
+def _iter_media_and_text(soup: BeautifulSoup):
+    for element in soup.descendants:
+        if isinstance(element, Tag):
+            if element.name == "p":
+                yield "\n"
+                continue
+
+            if element.name == "br":
+                yield "\n"
+                continue
+
+            if element.name == "img":
+                if src := element.get("src"):
+                    src = str(src)
+                    yield Creator.graphic(
+                        url=src,
+                    )
+
+        elif isinstance(element, NavigableString):
+            if text := str(element).strip():
+                yield text


### PR DESCRIPTION
- 添加 DsParser 类用于解析网易大神平台内容
- 支持解析文章和动态内容（feed）
- 支持获取精选评论和最新评论
- 实现评论回复层级结构处理
- 添加相关数据模型定义和解析逻辑
- 在 __init__.py 中注册新解析器

## Summary by Sourcery

为网易大神（ds.163.com）平台添加内容解析支持，包括动态及其评论。

New Features:
- 引入用于网易大神平台的 `DsParser`，并将其注册为受支持的解析器。
- 支持将大神动态/文章中的文本、图片和视频解析为统一的内容条目。
- 支持抓取并解析大神动态的精选评论和最新评论，包括回复层级结构。

Enhancements:
- 扩展平台枚举，增加新的 `DS` 条目以表示网易大神平台。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for parsing content from the NetEase Dashen (ds.163.com) platform, including feeds and their comments.

New Features:
- Introduce DsParser for the NetEase Dashen platform and register it as a supported parser.
- Support parsing Dashen feeds/articles including text, images, and videos into unified content items.
- Support fetching and parsing both handpicked and latest comments for Dashen feeds, including reply hierarchies.

Enhancements:
- Extend the platform enumeration with a new DS entry to represent the NetEase Dashen platform.

</details>