### PR TITLE
refactor(html-parser): 移除HTML转义处理

### DIFF
--- a/src/nonebot_plugin_parser_lite/parsers/douban/util.py
+++ b/src/nonebot_plugin_parser_lite/parsers/douban/util.py
@@ -8,7 +8,7 @@ from ...data import ContentItem
 
 
 def parse_rich_content(html: str) -> list[ContentItem]:
-    soup = BeautifulSoup(html.replace(r"\"", '"'), "html.parser")
+    soup = BeautifulSoup(html, "html.parser")
 
     result: list[ContentItem] = []
     buffer: list[str] = []

--- a/src/nonebot_plugin_parser_lite/parsers/heybox/model.py
+++ b/src/nonebot_plugin_parser_lite/parsers/heybox/model.py
@@ -143,7 +143,7 @@ def extract_from_html(html: str) -> list[ContentItem]:
     :return: 由纯文本字符串和 ContentItem 对象组成的列表
     """
 
-    soup = BeautifulSoup(html.replace(r"\"", '"'), "html.parser")
+    soup = BeautifulSoup(html, "html.parser")
 
     # 忽略 <noscript> 中的内容，避免重复或无效的占位文本干扰顺序
     for noscript in soup.find_all("noscript"):

--- a/src/nonebot_plugin_parser_lite/parsers/hupu/util.py
+++ b/src/nonebot_plugin_parser_lite/parsers/hupu/util.py
@@ -6,7 +6,7 @@ from ...data import ContentItem
 
 
 def parse_rich_content(html: str) -> list[ContentItem]:
-    soup = BeautifulSoup(html.replace(r"\"", '"'), "html.parser")
+    soup = BeautifulSoup(html, "html.parser")
 
     result: list[ContentItem] = []
     buffer: list[str] = []

--- a/src/nonebot_plugin_parser_lite/parsers/linuxdo/util.py
+++ b/src/nonebot_plugin_parser_lite/parsers/linuxdo/util.py
@@ -8,7 +8,7 @@ from ...data import ContentItem
 
 
 def parse_rich_content(html: str) -> list[ContentItem]:
-    soup = BeautifulSoup(html.replace(r"\"", '"'), "html.parser")
+    soup = BeautifulSoup(html, "html.parser")
 
     result: list[ContentItem] = []
     buffer: list[str] = []

--- a/src/nonebot_plugin_parser_lite/parsers/wmpvp/util.py
+++ b/src/nonebot_plugin_parser_lite/parsers/wmpvp/util.py
@@ -6,7 +6,7 @@ from ...data import ContentItem
 
 
 def parse_rich_content(html: str) -> list[ContentItem]:
-    soup = BeautifulSoup(html.replace(r"\"", '"'), "html.parser")
+    soup = BeautifulSoup(html, "html.parser")
 
     result: list[ContentItem] = []
     buffer: list[str] = []

--- a/src/nonebot_plugin_parser_lite/parsers/zhihu/util.py
+++ b/src/nonebot_plugin_parser_lite/parsers/zhihu/util.py
@@ -53,7 +53,7 @@ async def parse_rich_content(html: str, content_type: str) -> list[ContentItem]:
     """
     将知乎内容 HTML 解析为有顺序的文本 + 媒体列表
     """
-    soup = BeautifulSoup(html.replace(r"\"", '"'), "html.parser")
+    soup = BeautifulSoup(html, "html.parser")
     _clean_soup(soup)
 
     result: list[ContentItem] = []

--- a/src/nonebot_plugin_parser_lite/parsers/zlb/util.py
+++ b/src/nonebot_plugin_parser_lite/parsers/zlb/util.py
@@ -8,7 +8,7 @@ from ...data import ContentItem
 
 
 def parse_rich_content(html: str) -> list[ContentItem]:
-    soup = BeautifulSoup(html.replace(r"\"", '"'), "html.parser")
+    soup = BeautifulSoup(html, "html.parser")
 
     result: list[ContentItem] = []
     buffer: list[str] = []


### PR DESCRIPTION
移除所有解析器中对HTML字符串的转义处理逻辑，不再替换\"为"， 直接使用原始HTML进行解析，简化BeautifulSoup的初始化过程

- 修复douban解析器的HTML转义问题
- 修复heybox解析器的HTML转义问题
- 修复hupu解析器的HTML转义问题
- 修复linuxdo解析器的HTML转义问题
- 修复wmpvp解析器的HTML转义问题
- 修复zhihu解析器的HTML转义问题
- 修复zlb解析器的HTML转义问题

## Summary by Sourcery

在所有站点专用的 HTML 解析器中，停止在解析前对 HTML 转义序列进行预处理。

Bug 修复：
- 在 douban、heybox、hupu、linuxdo、wmpvp、zhihu 和 zlb 解析器中，为 BeautifulSoup 初始化使用原始 HTML 字符串，以避免在解析过程中错误替换引号。

改进：
- 通过从所有富内容解析器中移除多余的 HTML 转义处理，简化 HTML 解析流程。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Stop pre-processing HTML escape sequences before parsing in all site-specific HTML parsers.

Bug Fixes:
- Use raw HTML strings for BeautifulSoup initialization in douban, heybox, hupu, linuxdo, wmpvp, zhihu, and zlb parsers to avoid incorrect quote replacement during parsing.

Enhancements:
- Simplify HTML parsing pipeline by removing redundant HTML escape handling from all rich content parsers.

</details>