### PR TITLE
feat(download): 调整断点续传时文件大小验证机制

### DIFF
--- a/src/nonebot_plugin_parser_lite/download/__init__.py
+++ b/src/nonebot_plugin_parser_lite/download/__init__.py
@@ -35,7 +35,7 @@ class StreamDownloader:
     """Downloader class for downloading files with stream"""
 
     MAX_RETRIES = pconfig.max_retries
-    _SIZE_MISMATCH_TOLERANCE_BYTES = 10 * 1024
+    _SIZE_MISMATCH_TOLERANCE_BYTES = 1024
 
     def __init__(self):
         self.headers: dict[str, str] = COMMON_HEADER.copy()
@@ -307,8 +307,15 @@ class StreamDownloader:
             if final_size == 0:
                 raise ZeroSizeException
 
+            # 允许一定范围内的大小不匹配（最多 1KB），避免因为服务器端的轻微差异导致失败
             if total_size is not None and final_size != total_size:
-                raise DownloadException(f"文件大小不匹配: {final_size}/{total_size}")
+                size_diff = abs(final_size - total_size)
+                if size_diff > self._SIZE_MISMATCH_TOLERANCE_BYTES:
+                    raise DownloadException(
+                        f"文件大小不匹配: {final_size}/{total_size} "
+                        f"(差值: {size_diff} bytes, 超过允许的 "
+                        f"{self._SIZE_MISMATCH_TOLERANCE_BYTES} bytes)"
+                    )
 
     @auto_task
     async def download_video(


### PR DESCRIPTION
- 将文件大小不匹配容差从 10KB 减少到 1KB
- 增加对大小不匹配的详细检查逻辑
- 添加中文注释说明容差机制的作用
- 当大小差异超过容差时提供更详细的错误信息

## Summary by Sourcery

收紧可续传下载的文件大小不匹配容差，并在下载大小超出允许范围时提供更清晰的错误报告。

Enhancements:
- 将流式下载的允许文件大小不匹配容差从 10KB 降低到 1KB。
- 在最终下载大小超过配置的容差时，添加详细的大小不匹配计算过程和错误信息。
- 在校验逻辑附近通过内联中文注释记录文件大小不匹配容差的行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Tighten the file size mismatch tolerance for resumable downloads and provide clearer error reporting when the downloaded size deviates beyond the allowed range.

Enhancements:
- Reduce the allowed file size mismatch tolerance for stream downloads from 10KB to 1KB.
- Add detailed size mismatch calculation and error messages when the final downloaded size exceeds the configured tolerance.
- Document the size mismatch tolerance behavior with inline Chinese comments near the validation logic.

</details>