### PR TITLE
feat(render-embed-url): 添加嵌入式播放链接配置

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,9 @@ plite_blacklist_users=[]
 # [可选] 是否在解析结果中附加原始URL
 plite_append_url=False
 
+# [可选] 是否在解析结果中附加嵌入式播放链接
+plite_embed_url=False
+
 # [可选] 是否在解析结果中添加原始URL二维码
 plite_append_qrcode=False
 

--- a/src/nonebot_plugin_parser_lite/config.py
+++ b/src/nonebot_plugin_parser_lite/config.py
@@ -44,6 +44,8 @@ class Config(BaseModel):
     """视频/音频最大时长"""
     plite_append_url: bool = False
     """是否在解析结果中添加原始URL"""
+    plite_embed_url: bool = False
+    """是否在解析结果中添加嵌入式播放链接"""
     plite_append_qrcode: bool = False
     """是否在解析结果中添加原始URL二维码"""
     plite_disabled_platforms: list[PlatformEnum] = []
@@ -163,6 +165,11 @@ class Config(BaseModel):
     def append_url(self) -> bool:
         """是否在解析结果中添加原始URL"""
         return self.plite_append_url
+
+    @property
+    def embed_url(self) -> bool:
+        """是否在解析结果中添加嵌入式播放链接"""
+        return self.plite_embed_url
 
     @property
     def append_qrcode(self) -> bool:

--- a/src/nonebot_plugin_parser_lite/data.py
+++ b/src/nonebot_plugin_parser_lite/data.py
@@ -300,6 +300,8 @@ class ParseResult:
     """评论列表"""
     ai_summary: str | None = field(default=None)
     """AI摘要"""
+    embed_url: str | None = field(default=None)
+    """嵌入播放链接"""
     extra: dict[str, Any] = field(default_factory=dict)
     """额外信息"""
     repost: ParseResult | None = field(default=None)
@@ -308,7 +310,7 @@ class ParseResult:
     """渲染图片"""
 
     @property
-    def display_url(self) -> str | None:
+    def display_url(self) -> str:
         return f"链接: {self.url}"
 
     @property
@@ -363,6 +365,8 @@ class ParseResultKwargs(TypedDict, total=False):
     """评论列表"""
     ai_summary: str | None
     """AI摘要"""
+    embed_url: str | None
+    """嵌入播放链接"""
 
 
 ContentItem = (

--- a/src/nonebot_plugin_parser_lite/parsers/bilibili/__init__.py
+++ b/src/nonebot_plugin_parser_lite/parsers/bilibili/__init__.py
@@ -386,6 +386,7 @@ class BilibiliParser(BaseParser):
             comments=processed_comments,
             extra=extra_data,
             ai_summary=ai_summary,
+            embed_url=f"https://player.bilibili.com/player.html?aid={video.aid}&autoplay=1&p={page_num}",
         )
 
     async def parse_dynamic_or_opus(self, dynamic_id: int):

--- a/src/nonebot_plugin_parser_lite/parsers/douyin/__init__.py
+++ b/src/nonebot_plugin_parser_lite/parsers/douyin/__init__.py
@@ -85,4 +85,5 @@ class DouyinParser(BaseParser):
             ),
             timestamp=aweme.create_time,
             url=aweme.share_url,
+            embed_url=f"https://open.douyin.com/player/video?vid={aweme_id}&autoplay=1",
         )

--- a/src/nonebot_plugin_parser_lite/render/__init__.py
+++ b/src/nonebot_plugin_parser_lite/render/__init__.py
@@ -167,6 +167,9 @@ class Renderer:
         if pconfig.append_url:
             urls = (result.display_url, result.repost_display_url)
             msg += "\n".join(url for url in urls if url)
+        if pconfig.embed_url:
+            if embed := result.embed_url:
+                msg += "\n在线播放: " + embed
         return msg
 
     async def send_content(


### PR DESCRIPTION
- 新增 plite_embed_url 配置项用于控制是否显示嵌入式播放链接
- 在 README.md 中添加相关配置说明
- 更新配置模型以支持新的配置选项

feat(parser): 支持解析并返回嵌入式播放链接

- 在 ParseResult 数据类中新增 embed_url 字段
- 为 Bilibili 和 Douyin 解析器添加嵌入式播放链接生成逻辑
- 实现不同平台的嵌入式播放器 URL 格式

feat(render): 支持渲染嵌入式播放链接

- 根据配置决定是否显示嵌入式播放链
- 在消息渲染中添加在线播放链接展示功能

## Summary by Sourcery

在解析结果和消息输出中新增对嵌入式播放链接的配置与渲染支持。

新功能：
- 引入 `plite_embed_url` 配置选项，用于控制是否在解析结果中包含嵌入式播放链接。
- 扩展 `ParseResult`，增加 `embed_url` 字段，由针对 Bilibili 和抖音的平台特定解析器进行填充。
- 在配置启用的情况下，在消息中渲染嵌入式播放链接。

文档：
- 在 `README.md` 中记录新的 `plite_embed_url` 配置选项及其用法。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for configuring and rendering embedded playback links in parse results and message output.

New Features:
- Introduce plite_embed_url configuration option to control whether embedded playback links are included in parse results.
- Extend ParseResult to carry an embed_url field populated by platform-specific parsers for Bilibili and Douyin.
- Render embedded playback links in messages when enabled via configuration.

Documentation:
- Document the new plite_embed_url configuration option and its usage in README.md.

</details>