### PR TITLE
chore(workflow): 添加插件启动测试工作流

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -15,6 +15,7 @@ autolabeler:
     title:
       - "/:sparkles:.+/"
       - "/✨.+/"
+      - "/feat/"
   - label: "ci"
     files:
       - .github/**/*

--- a/.github/workflows/plugin-startup-comment.yml
+++ b/.github/workflows/plugin-startup-comment.yml
@@ -107,7 +107,9 @@ jobs:
           PY
 
       - name: Create or update comment
-        if: github.event.workflow_run.conclusion != 'cancelled'
+        if: >-
+          github.event.workflow_run.conclusion != 'cancelled' &&
+          steps.download.outputs.pr_number != ''
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           script: |
@@ -152,6 +154,10 @@ jobs:
             const success = workflowRun.conclusion === "success" &&
               report.status === "success" && report.step_outcome === "success";
             const pullRequestNumber = Number("${{ steps.download.outputs.pr_number }}");
+            if (!Number.isSafeInteger(pullRequestNumber) || pullRequestNumber <= 0) {
+              core.setFailed("PR 编号无效");
+              return;
+            }
             const currentPullRequest = await github.rest.pulls.get({
               ...context.repo,
               pull_number: pullRequestNumber,

--- a/.github/workflows/plugin-startup-comment.yml
+++ b/.github/workflows/plugin-startup-comment.yml
@@ -1,0 +1,254 @@
+name: Comment plugin startup result
+
+# workflow_run uses this file from the default branch, so privileged code never comes
+# from the pull request under test. This workflow becomes active after it is merged.
+on:
+  workflow_run:
+    workflows: ["Plugin startup test"]
+    types: [completed]
+
+permissions:
+  actions: write
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: >-
+    plugin-startup-comment-${{ github.event.workflow_run.pull_requests[0].number || github.event.workflow_run.head_branch }}
+  cancel-in-progress: true
+
+jobs:
+  comment:
+    name: Update pull request comment
+    if: github.event.workflow_run.event == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Download startup report archive
+        id: download
+        continue-on-error: true
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            const fs = require("fs");
+            const run_id = context.payload.workflow_run.id;
+            const workflowRun = context.payload.workflow_run;
+            let pullRequest = workflowRun.pull_requests?.[0];
+            if (!pullRequest) {
+              const associated = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+                ...context.repo,
+                commit_sha: workflowRun.head_sha,
+              });
+              pullRequest = associated.data.find(
+                (item) => item.head.sha === workflowRun.head_sha,
+              );
+            }
+            if (!pullRequest) {
+              core.setFailed("无法从 workflow_run 事件确定对应的 PR");
+              return;
+            }
+            core.setOutput("pr_number", pullRequest.number);
+            const artifactName = `plugin-startup-report-${pullRequest.number}`;
+            const artifacts = await github.paginate(
+              github.rest.actions.listWorkflowRunArtifacts,
+              {...context.repo, run_id, per_page: 100},
+            );
+            const matches = artifacts
+              .filter((item) => item.name === artifactName && !item.expired)
+              .sort((left, right) => right.id - left.id);
+            if (matches.length === 0) {
+              core.setFailed("启动测试没有生成报告 artifact");
+              return;
+            }
+            const artifact = matches[0];
+            core.setOutput("artifact_id", artifact.id);
+            if (artifact.size_in_bytes <= 0 || artifact.size_in_bytes > 512 * 1024) {
+              core.setFailed(`报告 artifact 大小异常：${artifact.size_in_bytes} bytes`);
+              return;
+            }
+            const download = await github.rest.actions.downloadArtifact({
+              ...context.repo,
+              artifact_id: artifact.id,
+              archive_format: "zip",
+            });
+            fs.writeFileSync("startup-report.zip", Buffer.from(download.data));
+
+      - name: Validate startup report archive
+        id: validate
+        if: steps.download.outcome == 'success'
+        continue-on-error: true
+        run: |
+          python - <<'PY'
+          import json
+          from pathlib import Path
+          from zipfile import ZipFile
+
+          with ZipFile("startup-report.zip") as archive:
+              matches = [
+                  item for item in archive.infolist()
+                  if item.filename == "startup-report.json" and not item.is_dir()
+              ]
+              if len(matches) != 1:
+                  raise ValueError("artifact 必须包含唯一的 startup-report.json")
+              info = matches[0]
+              if info.file_size > 256 * 1024:
+                  raise ValueError("startup-report.json 超过 256 KiB")
+              content = archive.read(info)
+
+          report = json.loads(content.decode("utf-8"))
+          if not isinstance(report, dict):
+              raise TypeError("启动报告不是 JSON 对象")
+          output = Path("report/startup-report.json")
+          output.parent.mkdir(parents=True, exist_ok=True)
+          output.write_text(
+              json.dumps(report, ensure_ascii=False), encoding="utf-8"
+          )
+          PY
+
+      - name: Create or update comment
+        if: github.event.workflow_run.conclusion != 'cancelled'
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            const fs = require("fs");
+            const marker = "<!-- plugin-startup-test -->";
+            const reportPath = "report/startup-report.json";
+            let report = {
+              status: "failure",
+              stage: "workflow",
+              total_ms: null,
+              timings: {},
+              step_outcome: "failure",
+              error_type: "WorkflowError",
+              error: "启动测试报告不存在，请查看工作流日志。",
+              traceback: "",
+            };
+            if (fs.existsSync(reportPath)) {
+              if (fs.statSync(reportPath).size > 256 * 1024) {
+                report.error = "启动报告超过 256 KiB，请查看工作流日志。";
+              } else {
+                try {
+                  const parsed = JSON.parse(fs.readFileSync(reportPath, "utf8"));
+                  if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+                    report = parsed;
+                  } else {
+                    report.error = "启动报告不是 JSON 对象，请查看工作流日志。";
+                  }
+                } catch (error) {
+                  report.error = `启动报告解析失败：${error.message}`;
+                }
+              }
+            }
+            const escapeHtml = (value) => String(value ?? "")
+              .replaceAll("&", "&amp;")
+              .replaceAll("<", "&lt;")
+              .replaceAll(">", "&gt;");
+            const formatMs = (value) =>
+              typeof value === "number" && Number.isFinite(value) && value >= 0
+                ? `${value.toFixed(2)} ms`
+                : "-";
+            const workflowRun = context.payload.workflow_run;
+            const success = workflowRun.conclusion === "success" &&
+              report.status === "success" && report.step_outcome === "success";
+            const pullRequestNumber = Number("${{ steps.download.outputs.pr_number }}");
+            const currentPullRequest = await github.rest.pulls.get({
+              ...context.repo,
+              pull_number: pullRequestNumber,
+            });
+            if (currentPullRequest.data.head.sha !== workflowRun.head_sha) {
+              core.notice(
+                `忽略旧提交 ${workflowRun.head_sha}，PR 当前提交为 ${currentPullRequest.data.head.sha}`,
+              );
+              return;
+            }
+            const lines = [
+              marker,
+              "## 插件启动测试",
+              "",
+              `**结果：${success ? "通过" : "失败"}**`,
+              "",
+              "| 阶段 | CI 耗时 |",
+              "| --- | ---: |",
+              `| NoneBot 初始化 | ${formatMs(report.timings?.nonebot_init_ms)} |`,
+              `| 插件加载 | ${formatMs(report.timings?.plugin_load_ms)} |`,
+              `| 启动回调 | ${formatMs(report.timings?.startup_callbacks_ms)} |`,
+              `| 关闭回调 | ${formatMs(report.timings?.shutdown_callbacks_ms)} |`,
+              `| **总计** | **${formatMs(report.total_ms)}** |`,
+              "",
+              `- 提交：\`${workflowRun.head_sha.slice(0, 12)}\``,
+            ];
+            if (!success) {
+              const details = [
+                `stage: ${report.stage ?? "unknown"}`,
+                `${report.error_type ?? "Error"}: ${report.error ?? "未知错误"}`,
+                report.traceback ?? "",
+              ].filter(Boolean).join("\n").slice(0, 12000);
+              lines.push(
+                "",
+                "<details><summary>错误信息</summary>",
+                "",
+                `<pre>${escapeHtml(details)}</pre>`,
+                "</details>",
+              );
+            }
+            const body = lines.join("\n");
+            const issue_number = pullRequestNumber;
+            const comments = await github.paginate(
+              github.rest.issues.listComments,
+              {...context.repo, issue_number, per_page: 100},
+            );
+            const previous = comments.filter(
+              (comment) => comment.user?.login === "github-actions[bot]" &&
+                comment.body?.includes(marker),
+            );
+            if (previous.length > 0) {
+              const [primary, ...duplicates] = previous.sort(
+                (left, right) => left.id - right.id,
+              );
+              await github.rest.issues.updateComment({
+                ...context.repo,
+                comment_id: primary.id,
+                body,
+              });
+              for (const duplicate of duplicates) {
+                await github.rest.issues.deleteComment({
+                  ...context.repo,
+                  comment_id: duplicate.id,
+                });
+              }
+            } else {
+              await github.rest.issues.createComment({
+                ...context.repo,
+                issue_number,
+                body,
+              });
+            }
+
+      - name: Delete consumed startup report
+        if: always() && steps.download.outputs.artifact_id != '' && steps.download.outputs.pr_number != ''
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        env:
+          ARTIFACT_ID: ${{ steps.download.outputs.artifact_id }}
+          PR_NUMBER: ${{ steps.download.outputs.pr_number }}
+        with:
+          script: |
+            const currentArtifactId = Number(process.env.ARTIFACT_ID);
+            const artifactName = `plugin-startup-report-${process.env.PR_NUMBER}`;
+            const artifacts = await github.paginate(
+              github.rest.actions.listArtifactsForRepo,
+              {...context.repo, name: artifactName, per_page: 100},
+            );
+            const obsolete = artifacts.filter(
+              (artifact) => artifact.id <= currentArtifactId,
+            );
+            for (const artifact of obsolete) {
+              try {
+                await github.rest.actions.deleteArtifact({
+                  ...context.repo,
+                  artifact_id: artifact.id,
+                });
+              } catch (error) {
+                if (error.status !== 404) throw error;
+              }
+            }

--- a/.github/workflows/plugin-startup.yml
+++ b/.github/workflows/plugin-startup.yml
@@ -48,6 +48,7 @@ jobs:
           python -m venv .venv
           .venv/bin/python -m pip install -r requirements.txt
           .venv/bin/python -m pip install "nonebot_plugin_htmlrender[playwright]>=0.5.0,<1.0.0"
+          .venv/bin/python -m pip install "nonebot2[fastapi]>=2.4.3,<3.0.0"
 
       - name: Activate dependency environment
         shell: bash

--- a/.github/workflows/plugin-startup.yml
+++ b/.github/workflows/plugin-startup.yml
@@ -1,0 +1,132 @@
+name: Plugin startup test
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+    paths:
+      - "src/nonebot_plugin_parser_lite/**"
+      - "requirements.txt"
+      - "scripts/verify_plugin_startup.py"
+      - ".github/workflows/plugin-startup.yml"
+      - ".github/workflows/plugin-startup-comment.yml"
+
+concurrency:
+  group: plugin-startup-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  startup:
+    name: Load plugin and run startup callbacks
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Check out pull request merge commit
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Set up Python
+        id: python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: requirements.txt
+
+      - name: Restore dependency environment
+        id: dependencies
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+        with:
+          path: .venv
+          key: dependencies-${{ runner.os }}-${{ runner.arch }}-python-${{ steps.python.outputs.python-version }}-${{ hashFiles('requirements.txt') }}
+
+      - name: Create dependency environment
+        if: steps.dependencies.outputs.cache-hit != 'true'
+        run: |
+          python -m venv .venv
+          .venv/bin/python -m pip install -r requirements.txt
+
+      - name: Activate dependency environment
+        shell: bash
+        run: |
+          echo "$GITHUB_WORKSPACE/.venv/bin" >> "$GITHUB_PATH"
+          echo "VIRTUAL_ENV=$GITHUB_WORKSPACE/.venv" >> "$GITHUB_ENV"
+
+      - name: Read Playwright version
+        id: playwright
+        shell: bash
+        run: |
+          echo "version=$(python -m playwright --version | cut -d ' ' -f 2)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ runner.arch }}-${{ steps.playwright.outputs.version }}-chromium
+
+      - name: Install Chromium system dependencies
+        run: python -m playwright install-deps chromium
+
+      - name: Install Chromium for HTMLRender startup
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: python -m playwright install chromium
+
+      - name: Run plugin startup test
+        id: startup
+        continue-on-error: true
+        env:
+          PYTHONPATH: ${{ github.workspace }}/src
+          STARTUP_REPORT_PATH: ${{ runner.temp }}/plugin-startup-report/startup-report.json
+        run: python scripts/verify_plugin_startup.py
+
+      - name: Create fallback report
+        if: always()
+        env:
+          STARTUP_REPORT_PATH: ${{ runner.temp }}/plugin-startup-report/startup-report.json
+          STEP_OUTCOME: ${{ steps.startup.outcome }}
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          path = Path(os.environ["STARTUP_REPORT_PATH"])
+          try:
+              if path.stat().st_size > 256 * 1024:
+                  raise ValueError("启动报告超过 256 KiB")
+              report = json.loads(path.read_text(encoding="utf-8"))
+              if not isinstance(report, dict):
+                  raise TypeError("启动报告不是 JSON 对象")
+          except Exception as exc:
+              report = {
+                  "status": "failure",
+                  "plugin": "nonebot_plugin_parser_lite",
+                  "stage": "workflow",
+                  "total_ms": None,
+                  "timings": {},
+                  "error_type": "WorkflowError",
+                  "error": f"启动测试未生成有效报告：{exc}",
+                  "traceback": "",
+              }
+          report["step_outcome"] = os.environ["STEP_OUTCOME"]
+          path.parent.mkdir(parents=True, exist_ok=True)
+          path.write_text(
+              json.dumps(report, ensure_ascii=False, indent=2), encoding="utf-8"
+          )
+          PY
+
+      - name: Upload startup report
+        if: always()
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
+        with:
+          name: plugin-startup-report-${{ github.event.pull_request.number }}
+          path: ${{ runner.temp }}/plugin-startup-report/startup-report.json
+          retention-days: 1
+          overwrite: true
+
+      - name: Fail when startup test failed
+        if: steps.startup.outcome != 'success'
+        run: exit 1

--- a/.github/workflows/plugin-startup.yml
+++ b/.github/workflows/plugin-startup.yml
@@ -40,13 +40,14 @@ jobs:
         uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: .venv
-          key: dependencies-${{ runner.os }}-${{ runner.arch }}-python-${{ steps.python.outputs.python-version }}-${{ hashFiles('requirements.txt') }}
+          key: dependencies-${{ runner.os }}-${{ runner.arch }}-python-${{ steps.python.outputs.python-version }}-${{ hashFiles('requirements.txt') }}-htmlrender-playwright-v1
 
       - name: Create dependency environment
         if: steps.dependencies.outputs.cache-hit != 'true'
         run: |
           python -m venv .venv
           .venv/bin/python -m pip install -r requirements.txt
+          .venv/bin/python -m pip install "nonebot_plugin_htmlrender[playwright]>=0.5.0,<1.0.0"
 
       - name: Activate dependency environment
         shell: bash

--- a/.github/workflows/plugin-startup.yml
+++ b/.github/workflows/plugin-startup.yml
@@ -129,6 +129,3 @@ jobs:
           retention-days: 1
           overwrite: true
 
-      - name: Fail when startup test failed
-        if: steps.startup.outcome != 'success'
-        run: exit 1

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ aiofiles>=23.2.1
 msgspec>=0.20.0,<1.0.0
 beautifulsoup4>=4.12.0,<5.0.0
 curl_cffi>=0.15.0,<1.0.0
+httpx>=0.20.0,<1.0.0
 nonebot-plugin-alconna>=0.59.4,<1.0.0
 nonebot-plugin-apscheduler>=0.5.0,<1.0.0
 nonebot-plugin-localstore>=0.7.4,<1.0.0

--- a/scripts/generate_standalone.py
+++ b/scripts/generate_standalone.py
@@ -1,7 +1,4 @@
-#!/usr/bin/env python3
-"""Generate the standalone branch from an unmodified main working tree."""
-
-from __future__ import annotations
+"""生成独立分支"""
 
 import argparse
 import ast

--- a/scripts/verify_plugin_startup.py
+++ b/scripts/verify_plugin_startup.py
@@ -37,7 +37,7 @@ async def verify() -> dict[str, Any]:
         stage_started_at = perf_counter()
         plugin = nonebot.load_plugin(PLUGIN_NAME)
         if plugin is None:
-            raise RuntimeError(f"NoneBot returned no plugin for {PLUGIN_NAME}")
+            raise RuntimeError(f"NoneBot returned no plugin for {PLUGIN_NAME}.")
         timings["plugin_load_ms"] = elapsed_ms(stage_started_at)
 
         stage = "startup_callbacks"

--- a/scripts/verify_plugin_startup.py
+++ b/scripts/verify_plugin_startup.py
@@ -1,0 +1,93 @@
+"""加载插件测试"""
+
+import asyncio
+import contextlib
+import json
+import os
+from pathlib import Path
+import sys
+from time import perf_counter
+import traceback
+
+import nonebot
+
+REPORT_PATH = Path(os.getenv("STARTUP_REPORT_PATH", "startup-report.json"))
+PLUGIN_NAME = "nonebot_plugin_parser_lite"
+
+
+def elapsed_ms(started_at: float) -> float:
+    return round((perf_counter() - started_at) * 1000, 2)
+
+
+async def verify() -> dict[str, object]:
+    driver = None
+    startup_attempted = False
+    stage = "nonebot_init"
+    timings: dict[str, float] = {}
+    total_started_at = perf_counter()
+
+    try:
+        stage_started_at = perf_counter()
+        nonebot.init()
+        driver = nonebot.get_driver()
+        timings["nonebot_init_ms"] = elapsed_ms(stage_started_at)
+
+        stage = "plugin_load"
+        stage_started_at = perf_counter()
+        plugin = nonebot.load_plugin(PLUGIN_NAME)
+        if plugin is None:
+            raise RuntimeError(f"NoneBot returned no plugin for {PLUGIN_NAME}")
+        timings["plugin_load_ms"] = elapsed_ms(stage_started_at)
+
+        stage = "startup_callbacks"
+        stage_started_at = perf_counter()
+        startup_attempted = True
+        await driver._lifespan.startup()
+        startup_attempted = False
+        timings["startup_callbacks_ms"] = elapsed_ms(stage_started_at)
+
+        stage = "shutdown_callbacks"
+        stage_started_at = perf_counter()
+        await driver._lifespan.shutdown()
+        timings["shutdown_callbacks_ms"] = elapsed_ms(stage_started_at)
+
+        return {
+            "status": "success",
+            "plugin": PLUGIN_NAME,
+            "stage": "completed",
+            "total_ms": elapsed_ms(total_started_at),
+            "timings": timings,
+        }
+    except BaseException as exc:
+        if driver is not None and startup_attempted:
+            with contextlib.suppress(BaseException):
+                await driver._lifespan.shutdown(
+                    exc_type=type(exc), exc_val=exc, exc_tb=exc.__traceback__
+                )
+        return {
+            "status": "failure",
+            "plugin": PLUGIN_NAME,
+            "stage": stage,
+            "total_ms": elapsed_ms(total_started_at),
+            "timings": timings,
+            "error_type": type(exc).__name__,
+            "error": str(exc),
+            "traceback": "".join(
+                traceback.format_exception(type(exc), exc, exc.__traceback__)
+            ),
+        }
+
+
+def main() -> None:
+    report = asyncio.run(verify())
+    REPORT_PATH.parent.mkdir(parents=True, exist_ok=True)
+    REPORT_PATH.write_text(
+        json.dumps(report, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
+    sys.stdout.write(REPORT_PATH.read_text(encoding="utf-8") + "\n")
+    if report["status"] != "success":
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/verify_plugin_startup.py
+++ b/scripts/verify_plugin_startup.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import sys
 from time import perf_counter
 import traceback
+from typing import Any
 
 import nonebot
 
@@ -19,7 +20,7 @@ def elapsed_ms(started_at: float) -> float:
     return round((perf_counter() - started_at) * 1000, 2)
 
 
-async def verify() -> dict[str, object]:
+async def verify() -> dict[str, Any]:
     driver = None
     startup_attempted = False
     stage = "nonebot_init"

--- a/scripts/verify_standalone.py
+++ b/scripts/verify_standalone.py
@@ -1,7 +1,4 @@
-#!/usr/bin/env python3
-"""Verify a generated standalone tree without changing the Python environment."""
-
-from __future__ import annotations
+"""验证独立分支是否可以工作"""
 
 import argparse
 import ast
@@ -49,7 +46,7 @@ def static_checks(root: Path) -> None:
             elif isinstance(node, ast.ImportFrom) and node.module:
                 modules = [node.module]
             errors.extend(
-                f"{path.relative_to(root)}:{node.lineno} imports {module}" # pyright: ignore[reportAttributeAccessIssue]
+                f"{path.relative_to(root)}:{node.lineno} imports {module}"  # pyright: ignore[reportAttributeAccessIssue]
                 for module in modules
                 if is_nonebot_module(module)
             )
@@ -109,14 +106,10 @@ def import_checks(root: Path, *, render: bool = False) -> None:
     if ParseStep.MATCH.value != "match":
         fail(["ParseStep export is invalid"])
     parser = Parser([BilibiliParser])
-    matched = parser.match(
-        "分享 https://www.bilibili.com/video/BV1xx411c7mD 给你"
-    )
+    matched = parser.match("分享 https://www.bilibili.com/video/BV1xx411c7mD 给你")
     if matched.parser_type is not BilibiliParser or "bilibili.com" not in matched.url:
         fail(["text matching returned an unexpected result"])
-    discovered = Parser().match(
-        "分享 https://www.bilibili.com/video/BV1xx411c7mD 给你"
-    )
+    discovered = Parser().match("分享 https://www.bilibili.com/video/BV1xx411c7mD 给你")
     if discovered.parser_type is not BilibiliParser:
         fail(["lazy all-platform discovery returned an unexpected parser"])
     try:
@@ -208,9 +201,7 @@ def import_checks(root: Path, *, render: bool = False) -> None:
                 fail(["BrowserManager.screenshot reused stale HTML"])
 
             async with Parser([OfflineParser]) as rendering_parser:
-                rendered = await rendering_parser.parse(
-                    text, until=ParseStep.RENDER
-                )
+                rendered = await rendering_parser.parse(text, until=ParseStep.RENDER)
             if not rendered.startswith(b"\xff\xd8\xff"):
                 fail(["ParseStep.RENDER did not return a JPEG image"])
 


### PR DESCRIPTION
新增两个 GitHub 工作流文件用于自动化测试插件启动性能：
- plugin-startup.yml：执行插件加载和启动回调测试
- plugin-startup-comment.yml：在 PR 中评论测试结果

添加了 verify_plugin_startup.py 脚本来验证插件启动过程，
包括 NoneBot 初始化、插件加载和生命周期回调的时间测量。

更新了脚本文件的注释说明，并优化了静态检查中的代码格式。

## Summary by Sourcery

为 `nonebot_plugin_parser_lite` 添加 CI 工作流和脚本，用于在拉取请求上自动测量并报告插件启动性能。

New Features:
- 引入插件启动测试工作流，在相关的拉取请求上运行，测量 NoneBot 初始化、插件加载以及生命周期回调的性能。
- 添加一个工作流，将插件启动结果的摘要作为评论发布到对应的拉取请求中。

Enhancements:
- 添加 `verify_plugin_startup.py` 脚本，用于生成结构化的启动性能报告，并在运行失败时强制标记为失败。
- 整理现有的独立验证脚本，更新文档字符串并进行轻微的格式调整。

CI:
- 配置 GitHub Actions 工作流，以运行插件启动测试、缓存 Python 和 Playwright 依赖、上传 JSON 启动报告作为构建产物，并管理带有测试结果的 PR 评论。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add CI workflows and scripts to automatically measure and report plugin startup performance for nonebot_plugin_parser_lite on pull requests.

New Features:
- Introduce a plugin startup test workflow that runs on relevant pull requests and measures NoneBot initialization, plugin loading, and lifecycle callbacks.
- Add a workflow that posts summarized plugin startup results as a comment on the associated pull request.

Enhancements:
- Add a verify_plugin_startup.py script to generate structured startup performance reports and enforce failure on unsuccessful runs.
- Tidy existing standalone verification scripts with updated docstrings and minor formatting adjustments.

CI:
- Configure GitHub Actions workflows to run plugin startup tests, cache Python and Playwright dependencies, upload JSON startup reports as artifacts, and manage PR comments with test results.

</details>