### PR TITLE
fix(buff): 修复buff话题解析器中参数键名错误

### DIFF
--- a/src/nonebot_plugin_parser_lite/parsers/buff/__init__.py
+++ b/src/nonebot_plugin_parser_lite/parsers/buff/__init__.py
@@ -197,7 +197,7 @@ class BuffParser(BaseParser):
         params={"social_topic_post_id": {}, "comment_type": {"equals": "239"}},
     )
     async def parse_topic(self, searched: MatchWithParams):
-        post_id = searched["post_id"]
+        post_id = searched["social_topic_post_id"]
         topic = await self._fetch_ok_json(
             url="https://buff.163.com/api/topic/posts/detail",
             params={"social_topic_post_id": post_id},


### PR DESCRIPTION
修改了BuffParser类中parse_topic方法的参数映射， 将post_id改为social_topic_post_id以匹配API接口要求

## Summary by Sourcery

Bug Fixes:
- 在 `BuffParser.parse_topic` 中从搜索结果获取主题标识符时，使用 `social_topic_post_id` 而不是 `post_id`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Use social_topic_post_id instead of post_id when retrieving the topic identifier from search results in BuffParser.parse_topic.

</details>