### PR TITLE
feat(creator): 统一下载函数协议为通用的 DownloadFunc

### DIFF
--- a/src/nonebot_plugin_parser_lite/creator.py
+++ b/src/nonebot_plugin_parser_lite/creator.py
@@ -26,10 +26,10 @@ T = TypeVar("T", bound=MediaContent)
 
 
 @runtime_checkable
-class VideoDownloadFunc(Protocol):
-    """自定义视频下载函数协议：必须暴露真实视频 URL。"""
+class DownloadFunc(Protocol):
+    """自定义下载函数协议：必须暴露 URL。"""
 
-    video_url: str
+    url: str
     ext_headers: dict[str, str] | None = None
 
     def __call__(self) -> Coroutine[Any, Any, Path]:
@@ -85,7 +85,7 @@ class Creator:
 
     @staticmethod
     def video(
-        url_or_task: str | DownloadTaskWrapper[Path] | VideoDownloadFunc,
+        url_or_task: str | DownloadTaskWrapper[Path] | DownloadFunc,
         cover_url: str | None = None,
         duration: float = 0.0,
         video_name: str | None = None,
@@ -95,11 +95,10 @@ class Creator:
     ):
         """
         创建视频内容,
-        传入 `VideoDownloadFunc` 时,
-        会使用 `VideoDownloadFunc` 的 `ext_headers` 而不是传入的.
-        这个问题会在后续版本进行修复
+        传入 `DownloadFunc` 时,
+        会使用 `DownloadFunc` 的 `ext_headers` 而不是传入的.
 
-        :param url: 视频 URL
+        :param url_or_task: 视频 URL 或下载任务
         :param cover_url: 封面 URL
         :param duration: 视频时长
         :param video_name: 视频名称
@@ -125,7 +124,7 @@ class Creator:
         elif isinstance(url_or_task, DownloadTaskWrapper):
             # 2) 传入 DownloadTaskWrapper: 保持原样
             video_task = url_or_task
-        elif isinstance(url_or_task, VideoDownloadFunc):
+        elif isinstance(url_or_task, DownloadFunc):
             # 3) 传入下载函数: 自定义下载逻辑（不走 auto_task）
             download_func = url_or_task
 
@@ -137,7 +136,7 @@ class Creator:
                 func=_runner,
                 args=(),
                 kwargs={},
-                url=download_func.video_url,
+                url=download_func.url,
                 ext_headers=download_func.ext_headers,
                 use_curl_cffi=use_curl_cffi,
             )
@@ -145,7 +144,7 @@ class Creator:
             # 4) 传入了不受支持的类型：立即报错，避免 AttributeError
             raise TypeError(
                 f"Creator.video 收到了不受支持的 url_or_task 类型: {type(url_or_task)},"
-                "期望 str / DownloadTaskWrapper / VideoDownloadFunc 协议对象"
+                "期望 str / DownloadTaskWrapper / DownloadFunc 协议对象"
             )
         return _with_need_send(
             VideoContent(path_task=video_task, cover=cover_task, duration=duration),
@@ -227,7 +226,7 @@ class Creator:
 
     @staticmethod
     def audio(
-        url: str,
+        url_or_task: str | DownloadTaskWrapper[Path] | DownloadFunc,
         duration: float = 0.0,
         audio_name: str | None = None,
         need_send: bool = True,
@@ -235,9 +234,11 @@ class Creator:
         use_curl_cffi: bool = False,
     ):
         """
-        创建音频内容
+        创建音频内容,
+        传入 `DownloadFunc` 时,
+        会使用 `DownloadFunc` 的 `ext_headers` 而不是传入的.
 
-        :param url: 音频 URL
+        :param url_or_task: 音频 URL 或下载任务
         :param duration: 音频时长
         :param audio_name: 音频名称
         :param need_send: 是否发送
@@ -245,15 +246,42 @@ class Creator:
         :param use_curl_cffi: 是否使用 curl_cffi 下载
         """
 
-        task = DOWNLOADER.download_audio(
-            url=url,
-            audio_name=audio_name,
-            ext_headers=ext_headers,
-            use_curl_cffi=use_curl_cffi,
-        )
+        if isinstance(url_or_task, str):
+            # 1) 传入 URL: 使用默认下载逻辑
+            audio_task = DOWNLOADER.download_audio(
+                url=url_or_task,
+                audio_name=audio_name,
+                ext_headers=ext_headers,
+                use_curl_cffi=use_curl_cffi,
+            )
+        elif isinstance(url_or_task, DownloadTaskWrapper):
+            # 2) 传入 DownloadTaskWrapper: 保持原样
+            audio_task = url_or_task
+        elif isinstance(url_or_task, DownloadFunc):
+            # 3) 传入下载函数: 自定义下载逻辑（不走 auto_task）
+            download_func = url_or_task
+
+            async def _runner() -> Path:
+                return await download_func()
+
+            # 这里手动构造一个 DownloadTaskWrapper，url 塞个占位描述字符串
+            audio_task = DownloadTaskWrapper(
+                func=_runner,
+                args=(),
+                kwargs={},
+                url=download_func.url,
+                ext_headers=download_func.ext_headers,
+                use_curl_cffi=use_curl_cffi,
+            )
+        else:
+            # 4) 传入了不受支持的类型：立即报错，避免 AttributeError
+            raise TypeError(
+                f"Creator.audio 收到了不受支持的 url_or_task 类型: {type(url_or_task)},"
+                "期望 str / DownloadTaskWrapper / DownloadFunc 协议对象"
+            )
 
         return _with_need_send(
-            AudioContent(path_task=task, duration=duration), need_send
+            AudioContent(path_task=audio_task, duration=duration), need_send
         )
 
     @staticmethod

--- a/src/nonebot_plugin_parser_lite/parsers/base.py
+++ b/src/nonebot_plugin_parser_lite/parsers/base.py
@@ -28,7 +28,7 @@ from ..constants import (
     ParamRules,
 )
 from ..constants import PlatformEnum as PlatformEnum
-from ..creator import Creator, VideoDownloadFunc
+from ..creator import Creator, DownloadFunc
 from ..data import (
     Author,
     Comment,
@@ -363,7 +363,7 @@ class BaseParser:
 
     def create_video(
         self,
-        url_or_task: str | DownloadTaskWrapper[Path] | VideoDownloadFunc,
+        url_or_task: str | DownloadTaskWrapper[Path] | DownloadFunc,
         cover_url: str | None = None,
         duration: float = 0.0,
         video_name: str | None = None,
@@ -480,7 +480,7 @@ class BaseParser:
         """
 
         return Creator.audio(
-            url=url,
+            url_or_task=url,
             duration=duration,
             audio_name=audio_name,
             need_send=need_send,

--- a/src/nonebot_plugin_parser_lite/parsers/base.py
+++ b/src/nonebot_plugin_parser_lite/parsers/base.py
@@ -372,9 +372,11 @@ class BaseParser:
         use_curl_cffi: bool = False,
     ):
         """
-        创建视频内容
+        创建视频内容,
+        传入 `DownloadFunc` 时,
+        会使用 `DownloadFunc` 的 `ext_headers` 而不是传入的.
 
-        :param url: 视频 URL
+        :param url_or_task: 视频 URL 或下载任务
         :param cover_url: 封面 URL
         :param duration: 视频时长
         :param video_name: 视频名称
@@ -469,9 +471,11 @@ class BaseParser:
         use_curl_cffi: bool = False,
     ):
         """
-        创建音频内容
+        创建音频内容,
+        传入 `DownloadFunc` 时,
+        会使用 `DownloadFunc` 的 `ext_headers` 而不是传入的.
 
-        :param url: 音频 URL
+        :param url_or_task: 音频 URL 或下载任务
         :param duration: 音频时长
         :param audio_name: 音频名称
         :param need_send: 是否发送

--- a/src/nonebot_plugin_parser_lite/parsers/bilibili/__init__.py
+++ b/src/nonebot_plugin_parser_lite/parsers/bilibili/__init__.py
@@ -296,21 +296,21 @@ class BilibiliParser(BaseParser):
         class BiliVideoDownloader:
             def __init__(
                 self,
-                video_url: str,
+                url: str,
                 audio_url: str | None,
                 ext_headers: dict[str, str] | None,
             ):
-                self.video_url = video_url
-                self._audio_url = audio_url
+                self.url = url
+                self.audio_url = audio_url
                 self.ext_headers = ext_headers
 
             async def __call__(self) -> Path:
                 file_base = f"{video_info.bvid}-{page_num}"
                 # 有单独音频流时，走 av 合并
-                if self._audio_url:
+                if self.audio_url:
                     return await DOWNLOADER.download_av_and_merge(
-                        video_url=self.video_url,
-                        audio_url=self._audio_url,
+                        video_url=self.url,
+                        audio_url=self.audio_url,
                         merge_name=file_base,
                         video_name=f"{file_base}_video.m4s",
                         audio_name=f"{file_base}_audio.m4s",
@@ -318,7 +318,7 @@ class BilibiliParser(BaseParser):
                     )
                 # 否则直接用流式下载
                 return await DOWNLOADER.streamd(
-                    url=self.video_url,
+                    url=self.url,
                     file_name=f"{file_base}.mp4",
                     ext_headers=self.ext_headers,
                 )

--- a/src/nonebot_plugin_parser_lite/parsers/douyin/aweme.py
+++ b/src/nonebot_plugin_parser_lite/parsers/douyin/aweme.py
@@ -98,7 +98,7 @@ class Aweme(Struct):
             if music_url:
                 content.append(
                     Creator.audio(
-                        url=music_url,
+                        url_or_task=music_url,
                         duration=music.duration,
                         ext_headers={"Referer": "https://www.douyin.com/"},
                     )


### PR DESCRIPTION
- 将 VideoDownloadFunc 重命名为更通用的 DownloadFunc，适用于所有媒体类型
- 修改协议中的 video_url 为更通用的 url 字段
- 更新 Creator.video 和 Creator.audio 方法以支持新的协议类型
- 在音频处理中添加与视频处理相同的自定义下载函数逻辑
- 相应更新文档字符串中的参数说明

BREAKING CHANGE: VideoDownloadFunc 已重命名为 DownloadFunc

## Summary by Sourcery

将自定义媒体下载协议统一为通用的 `DownloadFunc`，并在视频和音频创建流程中统一使用。

新特性：
- 允许 `Creator.audio` 接受 URL、预构建的 `DownloadTaskWrapper`，或用于音频下载的自定义 `DownloadFunc`。
- 支持适用于所有媒体类型的统一 `DownloadFunc` 协议，取代仅用于视频的 `VideoDownloadFunc`。

改进：
- 将 `VideoDownloadFunc` 重命名为更通用的 `DownloadFunc`，并将其字段从 `video_url` 泛化为 `url`。
- 使 Bilibili 和 Douyin 解析器实现与新的 `DownloadFunc` 协议保持一致，以实现统一的媒体下载行为。
- 改进 `Creator.video` 和 `Creator.audio` 的文档字符串，以反映新的 `url_or_task` 参数和统一的下载函数行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify the custom media download protocol into a generic DownloadFunc and apply it across video and audio creation.

New Features:
- Allow Creator.audio to accept either a URL, a prebuilt DownloadTaskWrapper, or a custom DownloadFunc for audio downloads.
- Support a unified DownloadFunc protocol for all media types instead of the video-specific VideoDownloadFunc.

Enhancements:
- Rename VideoDownloadFunc to the more generic DownloadFunc and generalize its field from video_url to url.
- Align Bilibili and Douyin parser implementations with the new DownloadFunc protocol for consistent media downloading behavior.
- Improve Creator.video and Creator.audio docstrings to reflect the new url_or_task parameter and unified download function behavior.

</details>