### PR TITLE
feat(audio-format): 添加音频内容自动修正格式的功能

### DIFF
--- a/src/nonebot_plugin_parser_lite/creator.py
+++ b/src/nonebot_plugin_parser_lite/creator.py
@@ -253,6 +253,7 @@ class Creator:
                 audio_name=audio_name,
                 ext_headers=ext_headers,
                 use_curl_cffi=use_curl_cffi,
+                convert_to_mp3=True,
             )
         elif isinstance(url_or_task, DownloadTaskWrapper):
             # 2) 传入 DownloadTaskWrapper: 保持原样

--- a/src/nonebot_plugin_parser_lite/download/__init__.py
+++ b/src/nonebot_plugin_parser_lite/download/__init__.py
@@ -23,7 +23,14 @@ from ..config import pconfig
 from ..constants import COMMON_HEADER, DOWNLOAD_TIMEOUT
 from ..exception import DownloadException, SizeLimitException, ZeroSizeException
 from ..utils.cache import CacheManager
-from ..utils.common import generate_file_name, make_filename, safe_unlink
+from ..utils.common import (
+    STANDARD_AUDIO_SUFFIXES,
+    STANDARD_IMAGE_SUFFIXES,
+    STANDARD_VIDEO_SUFFIXES,
+    generate_file_name,
+    make_filename,
+    safe_unlink,
+)
 from ..utils.ffmpeg import FFmpeg
 from .client import RetryableDownloadError, UniHttpClient, UniResponse
 from .task import auto_task
@@ -342,7 +349,9 @@ class StreamDownloader:
         :raise DownloadException: 重试多次仍失败时抛出
         """
         if video_name is None:
-            video_name = generate_file_name(url, ".mp4")
+            video_name = generate_file_name(
+                url, ".mp4", allowed_suffixes=STANDARD_VIDEO_SUFFIXES
+            )
 
         return await self.streamd(
             url=url,
@@ -683,6 +692,7 @@ class StreamDownloader:
         ext_headers: dict[str, str] | None = None,
         cache_type: str = CacheManager.MEDIA,
         use_curl_cffi: bool = False,
+        convert_to_mp3: bool = False,
     ) -> Path:
         """
         下载音频
@@ -692,19 +702,25 @@ class StreamDownloader:
         :param ext_headers: 额外的请求头，会与默认请求头合并
         :param cache_type: 缓存类型
         :param use_curl_cffi: 是否使用 curl_cffi 下载
+        :param convert_to_mp3: 下载完成后是否使用 ffmpeg 转换为 mp3
 
         :return: 下载完成后的音频文件路径
         :raise DownloadException: 下载过程中发生错误时抛出
         """
         if audio_name is None:
-            audio_name = generate_file_name(url, ".mp3")
-        return await self.streamd(
+            audio_name = generate_file_name(
+                url, ".mp3", allowed_suffixes=STANDARD_AUDIO_SUFFIXES
+            )
+        audio_path = await self.streamd(
             url=url,
             file_name=audio_name,
             ext_headers=ext_headers,
             cache_type=cache_type,
             use_curl_cffi=use_curl_cffi,
         )
+        if convert_to_mp3:
+            return await FFmpeg.convert_audio_to_mp3(audio_path)
+        return audio_path
 
     @auto_task
     async def download_img(
@@ -729,7 +745,9 @@ class StreamDownloader:
         :raise DownloadException: 下载过程中发生错误时抛出
         """
         if img_name is None:
-            img_name = generate_file_name(url, ".jpg")
+            img_name = generate_file_name(
+                url, ".jpg", allowed_suffixes=STANDARD_IMAGE_SUFFIXES
+            )
         return await self.streamd(
             url=url,
             file_name=img_name,

--- a/src/nonebot_plugin_parser_lite/matchers/__init__.py
+++ b/src/nonebot_plugin_parser_lite/matchers/__init__.py
@@ -26,7 +26,6 @@ from ..parsers.base import BaseParser, ParseResult
 from ..parsers.weibo.auth import AuthHelper as WeiboAuthHelper
 from ..render import RENDERER
 from ..utils.common import LimitedSizeDict
-from ..utils.ffmpeg import FFmpeg
 from .rule import Searched, SearchResult, _extract_text, on_keyword_regex
 
 # 关键词 / 类型 -> Parser 映射
@@ -191,14 +190,12 @@ async def register_bili_matcher():
                 url=audio_url,
                 audio_name=f"{bvid}-{page_idx + 1}_audio.m4s",
                 ext_headers=bilip.headers,
-            )
-            converted_path = await FFmpeg.convert_audio_to_mp3(
-                audio_path=audio_path, file_name=f"{bvid}-{page_idx + 1}.mp3"
+                convert_to_mp3=True,
             )
             if pconfig.need_upload_audio:
-                await UniMessage(await UniHelper.file_seg(converted_path)).send()
+                await UniMessage(await UniHelper.file_seg(audio_path)).send()
             else:
-                await UniMessage(await UniHelper.record_seg(converted_path)).send()
+                await UniMessage(await UniHelper.record_seg(audio_path)).send()
 
         @on_alconna(
             Alconna("blogin"), block=True, permission=SUPERUSER, rule=to_me()

--- a/src/nonebot_plugin_parser_lite/utils/common.py
+++ b/src/nonebot_plugin_parser_lite/utils/common.py
@@ -1,4 +1,5 @@
 from collections import OrderedDict
+from collections.abc import Collection
 import hashlib
 import re
 from typing import TypeVar
@@ -22,6 +23,38 @@ STANDARD_IMAGE_SUFFIXES = {
     ".heic",
     ".heif",
     ".jfif",
+}
+STANDARD_VIDEO_SUFFIXES = {
+    ".3gp",
+    ".avi",
+    ".flv",
+    ".m2ts",
+    ".m4v",
+    ".mkv",
+    ".mov",
+    ".mp4",
+    ".mpeg",
+    ".mpg",
+    ".ts",
+    ".webm",
+    ".wmv",
+}
+STANDARD_AUDIO_SUFFIXES = {
+    ".aac",
+    ".ac3",
+    ".aiff",
+    ".alac",
+    ".amr",
+    ".ape",
+    ".flac",
+    ".m4a",
+    ".m4s",
+    ".mp3",
+    ".ogg",
+    ".opus",
+    ".wav",
+    ".weba",
+    ".wma",
 }
 
 
@@ -70,11 +103,16 @@ async def fmt_size(file_path: Path) -> str:
     return f"大小: {stat.st_size / 1024 / 1024:.2f} MB"
 
 
-def generate_file_name(url: str, default_suffix: str = "") -> str:
+def generate_file_name(
+    url: str,
+    default_suffix: str = ".bin",
+    allowed_suffixes: Collection[str] | None = None,
+) -> str:
     """根据 URL 生成文件名，保留可能参与资源定位的 query。
 
     :param url: 原始资源 URL
-    :param default_suffix: 默认后缀名（当 path 中不含后缀时使用）
+    :param default_suffix: URL 后缀缺失或不受支持时使用的后缀名，默认 .bin
+    :param allowed_suffixes: 允许从 URL 保留的后缀集合；为空时允许任意后缀
 
     :return: 适合作为文件名的短 md5（含后缀）
     """
@@ -83,7 +121,9 @@ def generate_file_name(url: str, default_suffix: str = "") -> str:
     path = Path(parsed.path)
     path_suffix = path.suffix.lower()
 
-    if path_suffix in STANDARD_IMAGE_SUFFIXES:
+    if path_suffix and (
+        allowed_suffixes is None or path_suffix in allowed_suffixes
+    ):
         suffix = path_suffix
     else:
         suffix = default_suffix

--- a/src/nonebot_plugin_parser_lite/utils/ffmpeg.py
+++ b/src/nonebot_plugin_parser_lite/utils/ffmpeg.py
@@ -4,6 +4,7 @@ import hashlib
 import json
 import math
 from typing import Any
+from uuid import uuid4
 
 from anyio import Path
 from nonebot import logger
@@ -16,7 +17,7 @@ class FFmpeg:
     _available: bool | None = None
 
     @classmethod
-    def generate_file_name(cls, *args: Path) -> str:
+    def __generate_file_name(cls, *args: Path) -> str:
         """
         根据若干路径（或字符串）生成一个稳定的 MD5 文件名（不带扩展名）
         """
@@ -66,6 +67,28 @@ class FFmpeg:
             error_msg = stderr.decode(errors="ignore").strip()
             raise RuntimeError(f"ffprobe 执行失败: {error_msg}")
         return stdout
+
+    @classmethod
+    async def _is_mp3_audio(cls, audio_path: Path) -> bool:
+        """检查首个音频流是否已经使用 MP3 编码。"""
+        try:
+            stdout = await cls.exec_probe(
+                [
+                    "-v",
+                    "error",
+                    "-select_streams",
+                    "a:0",
+                    "-show_entries",
+                    "stream=codec_name",
+                    "-of",
+                    "default=noprint_wrappers=1:nokey=1",
+                    str(audio_path),
+                ]
+            )
+        except RuntimeError as e:
+            logger.debug(f"检测音频编码失败，将继续转码: {audio_path}: {e}")
+            return False
+        return stdout.decode(errors="ignore").strip().casefold() == "mp3"
 
     @classmethod
     async def _probe_media(cls, media_path: Path) -> dict[str, Any]:
@@ -371,7 +394,7 @@ class FFmpeg:
         :param a_path: 音频文件路径
         :param file_name: 输出文件名
         """
-        file_name = file_name or cls.generate_file_name(v_path, a_path)
+        file_name = file_name or cls.__generate_file_name(v_path, a_path)
         cache_dir = await CacheManager.ensure_dir(CacheManager.MEDIA)
         output_path = cache_dir / f"{file_name}.mp4"
         if await output_path.exists():
@@ -456,12 +479,21 @@ class FFmpeg:
         :param file_name: 输出文件名（不含扩展名），为空时根据输入路径生成稳定名称
         :return: 转码后的 mp3 文件路径
         """
-        file_name = file_name or cls.generate_file_name(audio_path)
+        file_name = file_name or cls.__generate_file_name(audio_path)
         cache_dir = await CacheManager.ensure_dir(CacheManager.MEDIA)
         output_path = cache_dir / f"{file_name}.mp3"
+        replaces_input = output_path == audio_path
 
-        if await output_path.exists():
+        if not replaces_input and await output_path.exists():
             return output_path
+        if replaces_input and await cls._is_mp3_audio(audio_path):
+            return audio_path
+
+        ffmpeg_output_path = output_path
+        if replaces_input:
+            ffmpeg_output_path = output_path.with_name(
+                f".{output_path.stem}.{uuid4().hex}.tmp.mp3"
+            )
 
         logger.info(
             f"Converting audio '{audio_path.name}' to mp3 as '{output_path.name}'"
@@ -477,10 +509,16 @@ class FFmpeg:
             "-vn",  # 明确丢弃视频流（若有）
             "-acodec",
             "libmp3lame",  # 使用 mp3 编码器
-            str(output_path),
+            str(ffmpeg_output_path),
         ]
 
-        await cls.exec_ffmpeg(cmd)
+        try:
+            await cls.exec_ffmpeg(cmd)
+            if replaces_input:
+                await ffmpeg_output_path.replace(output_path)
+        finally:
+            if ffmpeg_output_path != output_path:
+                await ffmpeg_output_path.unlink(missing_ok=True)
         logger.success(
             f"Converted to mp3: {output_path.name}, size={await fmt_size(output_path)}"
         )

--- a/src/nonebot_plugin_parser_lite/utils/ffmpeg.py
+++ b/src/nonebot_plugin_parser_lite/utils/ffmpeg.py
@@ -17,7 +17,7 @@ class FFmpeg:
     _available: bool | None = None
 
     @classmethod
-    def __generate_file_name(cls, *args: Path) -> str:
+    def hash_filename(cls, *args: Path) -> str:
         """
         根据若干路径（或字符串）生成一个稳定的 MD5 文件名（不带扩展名）
         """
@@ -394,7 +394,7 @@ class FFmpeg:
         :param a_path: 音频文件路径
         :param file_name: 输出文件名
         """
-        file_name = file_name or cls.__generate_file_name(v_path, a_path)
+        file_name = file_name or cls.hash_filename(v_path, a_path)
         cache_dir = await CacheManager.ensure_dir(CacheManager.MEDIA)
         output_path = cache_dir / f"{file_name}.mp4"
         if await output_path.exists():
@@ -479,7 +479,7 @@ class FFmpeg:
         :param file_name: 输出文件名（不含扩展名），为空时根据输入路径生成稳定名称
         :return: 转码后的 mp3 文件路径
         """
-        file_name = file_name or cls.__generate_file_name(audio_path)
+        file_name = file_name or cls.hash_filename(audio_path)
         cache_dir = await CacheManager.ensure_dir(CacheManager.MEDIA)
         output_path = cache_dir / f"{file_name}.mp3"
         replaces_input = output_path == audio_path


### PR DESCRIPTION
- 在StreamDownloader中添加convert_to_mp3参数，支持下载后自动转换音频格式
- 重构generate_file_name函数，增加allowed_suffixes参数用于限制允许的文件后缀
- 定义标准音视频图片后缀集合(STANDARD_AUDIO/VIDEO/IMAGE_SUFFIXES)
- 优化FFmpeg.convert_audio_to_mp3方法，避免重复转换已为MP3格式的音频
- 修复B站音频下载matcher，直接使用转换后的音频路径发送消息

## Summary by Sourcery

在下载完成后新增可选的音频格式标准化为 MP3，并在各下载器之间统一媒体文件名的生成方式。

新功能：
- 在音频下载 API 中引入 `convert_to_mp3` 选项，可在下载完成后自动将音频转码为 MP3。
- 在基于 URL 的文件名生成中，通过可配置的媒体后缀白名单来限制可保留的后缀。

错误修复：
- 修复 Bilibili 音频下载匹配器，使其发送的是最终转换后音频文件的路径，而不是转换前文件的路径。
- 当源音频已经是 MP3 编码时，避免重复进行 MP3 转换。

优化与增强：
- 定义通用的标准音频、视频和图片后缀集合，并应用于视频、音频和图片下载，以获得更一致的文件扩展名。
- 优化 FFmpeg 音频转换逻辑，通过使用临时文件安全地处理就地替换，防止当输出路径与输入路径相同时产生冲突。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add optional post-download audio format normalization to MP3 and standardize media filename generation across downloaders.

New Features:
- Introduce a convert_to_mp3 option in audio download APIs to automatically transcode downloaded audio to MP3.
- Allow URL-based filename generation to restrict preserved suffixes via configurable media suffix whitelists.

Bug Fixes:
- Fix Bilibili audio download matcher to send the path of the final converted audio file instead of the pre-conversion file.
- Avoid redundant MP3 conversion when the source audio is already encoded as MP3.

Enhancements:
- Define shared standard audio, video, and image suffix sets and apply them to video, audio, and image downloads for more consistent file extensions.
- Refine FFmpeg audio conversion to safely handle in-place replacement using temporary files, preventing conflicts when output and input paths are identical.

</details>