### PR TITLE
feat(cache): 支持动态媒体链接的稳定缓存与格式识别

### DIFF
--- a/src/nonebot_plugin_parser_lite/creator.py
+++ b/src/nonebot_plugin_parser_lite/creator.py
@@ -53,6 +53,7 @@ class Creator:
         location: str | None = None,
         ext_headers: dict[str, str] | None = None,
         use_curl_cffi: bool = False,
+        avatar_cache_key: str | None = None,
     ):
         """
         创建作者对象
@@ -64,11 +65,14 @@ class Creator:
         :param location: 位置信息
         :param ext_headers: 额外请求头
         :param use_curl_cffi: 是否使用 curl_cffi 下载头像
+        :param avatar_cache_key: 头像的稳定缓存标识，为空时根据 URL 生成
         """
 
         avatar_task = (
             DOWNLOADER.download_img(
                 url=avatar_url,
+                cache_key=avatar_cache_key,
+                cache_variant="avatar" if avatar_cache_key is not None else None,
                 ext_headers=ext_headers,
                 use_curl_cffi=use_curl_cffi,
             )
@@ -88,10 +92,10 @@ class Creator:
         url_or_task: str | DownloadTaskWrapper[Path] | DownloadFunc,
         cover_url: str | None = None,
         duration: float = 0.0,
-        video_name: str | None = None,
         need_send: bool = True,
         ext_headers: dict[str, str] | None = None,
         use_curl_cffi: bool = False,
+        cache_key: str | None = None,
     ):
         """
         创建视频内容,
@@ -101,7 +105,7 @@ class Creator:
         :param url_or_task: 视频 URL 或下载任务
         :param cover_url: 封面 URL
         :param duration: 视频时长
-        :param video_name: 视频名称
+        :param cache_key: 稳定缓存标识，为空时根据各自 URL 生成
         :param need_send: 是否发送
         :param ext_headers: 额外请求头
         :param use_curl_cffi: 是否使用 curl_cffi 下载视频/封面
@@ -110,6 +114,8 @@ class Creator:
         if cover_url:
             cover_task = DOWNLOADER.download_img(
                 url=cover_url,
+                cache_key=cache_key,
+                cache_variant="cover" if cache_key is not None else None,
                 ext_headers=ext_headers,
                 use_curl_cffi=use_curl_cffi,
             )
@@ -117,7 +123,7 @@ class Creator:
             # 1) 传入 URL: 使用默认下载逻辑
             video_task = DOWNLOADER.download_video(
                 url=url_or_task,
-                video_name=video_name,
+                cache_key=cache_key,
                 ext_headers=ext_headers,
                 use_curl_cffi=use_curl_cffi,
             )
@@ -156,37 +162,44 @@ class Creator:
         video_urls: list[str],
         ext_headers: dict[str, str] | None = None,
         use_curl_cffi: bool = False,
+        cache_keys: list[str | None] | None = None,
     ):
         """
         创建视频内容列表
 
         :param video_urls: 视频 URL 列表
+        :param cache_keys: 与视频 URL 一一对应的稳定缓存标识
         :param ext_headers: 额外请求头
         :param use_curl_cffi: 是否使用 curl_cffi 下载
         """
 
+        if cache_keys is None:
+            cache_keys = [None] * len(video_urls)
+        if len(cache_keys) != len(video_urls):
+            raise ValueError("cache_keys 与 video_urls 长度必须一致")
         return [
             Creator.video(
                 url_or_task=url,
                 ext_headers=ext_headers,
                 use_curl_cffi=use_curl_cffi,
+                cache_key=cache_key,
             )
-            for url in video_urls
+            for url, cache_key in zip(video_urls, cache_keys, strict=True)
         ]
 
     @staticmethod
     def image(
         url: str,
-        img_name: str | None = None,
         need_send: bool = True,
         ext_headers: dict[str, str] | None = None,
         use_curl_cffi: bool = False,
+        cache_key: str | None = None,
     ):
         """
         创建图片内容
 
         :param url: 图片 URL
-        :param img_name: 图片名称
+        :param cache_key: 稳定缓存标识，为空时根据 URL 生成
         :param need_send: 是否发送
         :param ext_headers: 额外请求头
         :param use_curl_cffi: 是否使用 curl_cffi 下载
@@ -194,7 +207,7 @@ class Creator:
 
         task = DOWNLOADER.download_img(
             url=url,
-            img_name=img_name,
+            cache_key=cache_key,
             ext_headers=ext_headers,
             use_curl_cffi=use_curl_cffi,
         )
@@ -206,32 +219,39 @@ class Creator:
         image_urls: list[str],
         ext_headers: dict[str, str] | None = None,
         use_curl_cffi: bool = False,
+        cache_keys: list[str | None] | None = None,
     ):
         """
         创建图片内容列表
 
         :param image_urls: 图片 URL 列表
+        :param cache_keys: 与图片 URL 一一对应的稳定缓存标识
         :param ext_headers: 额外请求头
         :param use_curl_cffi: 是否使用 curl_cffi 下载
         """
 
+        if cache_keys is None:
+            cache_keys = [None] * len(image_urls)
+        if len(cache_keys) != len(image_urls):
+            raise ValueError("cache_keys 与 image_urls 长度必须一致")
         return [
             Creator.image(
                 url=url,
                 ext_headers=ext_headers,
                 use_curl_cffi=use_curl_cffi,
+                cache_key=cache_key,
             )
-            for url in image_urls
+            for url, cache_key in zip(image_urls, cache_keys, strict=True)
         ]
 
     @staticmethod
     def audio(
         url_or_task: str | DownloadTaskWrapper[Path] | DownloadFunc,
         duration: float = 0.0,
-        audio_name: str | None = None,
         need_send: bool = True,
         ext_headers: dict[str, str] | None = None,
         use_curl_cffi: bool = False,
+        cache_key: str | None = None,
     ):
         """
         创建音频内容,
@@ -240,7 +260,7 @@ class Creator:
 
         :param url_or_task: 音频 URL 或下载任务
         :param duration: 音频时长
-        :param audio_name: 音频名称
+        :param cache_key: 稳定缓存标识，为空时根据 URL 生成
         :param need_send: 是否发送
         :param ext_headers: 额外请求头
         :param use_curl_cffi: 是否使用 curl_cffi 下载
@@ -250,7 +270,7 @@ class Creator:
             # 1) 传入 URL: 使用默认下载逻辑
             audio_task = DOWNLOADER.download_audio(
                 url=url_or_task,
-                audio_name=audio_name,
+                cache_key=cache_key,
                 ext_headers=ext_headers,
                 use_curl_cffi=use_curl_cffi,
                 convert_to_mp3=True,
@@ -288,17 +308,17 @@ class Creator:
     @staticmethod
     def graphic(
         url: str,
-        img_name: str | None = None,
         alt: str | None = None,
         need_send: bool = True,
         ext_headers: dict[str, str] | None = None,
         use_curl_cffi: bool = False,
+        cache_key: str | None = None,
     ):
         """
         图片,此图片不参与九宫格且无高度限制
 
         :param url: 图片 URL
-        :param img_name: 图片名称
+        :param cache_key: 稳定缓存标识，为空时根据 URL 生成
         :param alt: 图片描述
         :param need_send: 是否发送
         :param ext_headers: 额外请求头
@@ -307,7 +327,7 @@ class Creator:
 
         image_task = DOWNLOADER.download_img(
             url=url,
-            img_name=img_name,
+            cache_key=cache_key,
             ext_headers=ext_headers,
             use_curl_cffi=use_curl_cffi,
         )
@@ -320,11 +340,13 @@ class Creator:
         desc: str | None = None,
         ext_headers: dict[str, str] | None = None,
         use_curl_cffi: bool = False,
+        cache_key: str | None = None,
     ):
         """
         创建贴纸内容
 
         :param url: 贴纸图片链接
+        :param cache_key: 稳定缓存标识，为空时根据 URL 生成
         :param size: 贴纸大小
             - small: 比文字大一点
             - medium: 文字大小的两倍大一点
@@ -335,6 +357,7 @@ class Creator:
 
         image_task = DOWNLOADER.download_img(
             url=url,
+            cache_key=cache_key,
             ext_headers=ext_headers,
             cache_type=CacheManager.STICKER,
             use_curl_cffi=use_curl_cffi,
@@ -350,12 +373,14 @@ class Creator:
         need_send: bool = True,
         ext_headers: dict[str, str] | None = None,
         use_curl_cffi: bool = False,
+        cache_key: str | None = None,
     ):
         """
         创建  iPhone Live Photo 内容
 
         :param video_url: iPhone Live Photo 变化过程视频
         :param image_url: iPhone Live Photo 底图
+        :param cache_key: 稳定缓存标识，为空时根据各自 URL 生成
         :param bgm_url: iPhone Live Photo 背景音乐
         :param loop: iPhone Live Photo 循环次数
         :param need_send: 是否发送
@@ -365,17 +390,23 @@ class Creator:
 
         video_task = DOWNLOADER.download_video(
             url=video_url,
+            cache_key=cache_key,
+            cache_variant="motion" if cache_key is not None else None,
             ext_headers=ext_headers,
             use_curl_cffi=use_curl_cffi,
         )
         image_task = DOWNLOADER.download_img(
             url=image_url,
+            cache_key=cache_key,
+            cache_variant="base" if cache_key is not None else None,
             ext_headers=ext_headers,
             use_curl_cffi=use_curl_cffi,
         )
         if bgm_url:
             bgm_task = DOWNLOADER.download_audio(
                 url=bgm_url,
+                cache_key=cache_key,
+                cache_variant="bgm" if cache_key is not None else None,
                 ext_headers=ext_headers,
                 use_curl_cffi=use_curl_cffi,
             )

--- a/src/nonebot_plugin_parser_lite/data.py
+++ b/src/nonebot_plugin_parser_lite/data.py
@@ -196,7 +196,8 @@ class Platform:
     async def get_logo_path(self) -> Path:
         return await DOWNLOADER.download_img(
             url=STICKER_CDN.format(platform="logo", name=self.name),
-            img_name=f"{self.name}.webp",
+            cache_key=f"platform:{self.name}",
+            cache_variant="logo",
             cache_type=CacheManager.LOGO,
         )
 

--- a/src/nonebot_plugin_parser_lite/download/__init__.py
+++ b/src/nonebot_plugin_parser_lite/download/__init__.py
@@ -713,7 +713,7 @@ class StreamDownloader:
             use_curl_cffi=use_curl_cffi,
         )
         if convert_to_mp3:
-            return await FFmpeg.convert_audio_to_mp3(audio_path)
+            return await FFmpeg.convert_to_mp3(audio_path)
         return audio_path
 
     @auto_task

--- a/src/nonebot_plugin_parser_lite/download/__init__.py
+++ b/src/nonebot_plugin_parser_lite/download/__init__.py
@@ -2,10 +2,9 @@ import asyncio
 from collections.abc import Callable, Generator
 import contextlib
 from functools import partial
-import hashlib
-import os
+import mimetypes
 import re
-from urllib.parse import urljoin
+from urllib.parse import urljoin, urlparse
 
 import aiofiles
 from anyio import Path
@@ -24,11 +23,8 @@ from ..constants import COMMON_HEADER, DOWNLOAD_TIMEOUT
 from ..exception import DownloadException, SizeLimitException, ZeroSizeException
 from ..utils.cache import CacheManager
 from ..utils.common import (
-    STANDARD_AUDIO_SUFFIXES,
-    STANDARD_IMAGE_SUFFIXES,
-    STANDARD_VIDEO_SUFFIXES,
+    compose_cache_key,
     generate_file_name,
-    make_filename,
     safe_unlink,
 )
 from ..utils.ffmpeg import FFmpeg
@@ -36,6 +32,34 @@ from .client import RetryableDownloadError, UniHttpClient, UniResponse
 from .task import auto_task
 
 _RE_RANGE_PATTERN = re.compile(r"bytes\s+(\d+)-\d+/(\d+|\*)")
+_CONTENT_TYPE_SUFFIX_OVERRIDES = {
+    "audio/m4a": ".m4a",
+    "audio/mp4": ".m4a",
+    "audio/ogg": ".ogg",
+    "audio/webm": ".weba",
+    "audio/x-m4a": ".m4a",
+    "video/x-matroska": ".mkv",
+}
+
+
+def _resolve_suffix(
+    url: str,
+    content_type: str | None,
+    default_suffix: str,
+) -> str:
+    if content_type:
+        media_type = content_type.partition(";")[0].strip().lower()
+        suffix = _CONTENT_TYPE_SUFFIX_OVERRIDES.get(
+            media_type
+        ) or mimetypes.guess_extension(media_type, strict=False)
+        if suffix:
+            suffix = suffix.lower()
+        if suffix:
+            return suffix
+
+    if url_suffix := Path(urlparse(url).path).suffix.lower():
+        return url_suffix
+    return default_suffix if default_suffix.startswith(".") else f".{default_suffix}"
 
 
 class StreamDownloader:
@@ -48,8 +72,7 @@ class StreamDownloader:
         self.headers: dict[str, str] = COMMON_HEADER.copy()
         self.cache_dir: Path = pconfig.cache_dir
         self.client = UniHttpClient(timeout=DOWNLOAD_TIMEOUT)
-        self._active_downloads: dict[str, asyncio.Task[None]] = {}
-        self._ffmpeg_available: bool | None = None
+        self._active_downloads: dict[str, asyncio.Task[Path]] = {}
 
     async def aclose(self) -> None:
         await self.client.aclose()
@@ -113,14 +136,16 @@ class StreamDownloader:
         self,
         *,
         url: str,
-        file_name: str | None = None,
+        cache_key: str | None = None,
+        default_suffix: str = ".bin",
         ext_headers: dict[str, str] | None = None,
         cache_type: str = CacheManager.MEDIA,
         use_curl_cffi: bool = False,
     ) -> Path:
         """
         :param url: 下载文件的链接地址
-        :param file_name: 保存到本地的文件名，为空时根据 url 自动生成
+        :param cache_key: 稳定缓存标识，为空时根据 URL 生成
+        :param default_suffix: 响应和 URL 均无法确定后缀时使用的后缀名
         :param ext_headers: 额外的请求头，会与默认请求头合并
         :param cache_type: 缓存类型
         :param use_curl_cffi: 是否使用 curl_cffi 下载
@@ -130,70 +155,73 @@ class StreamDownloader:
         :raise SizeLimitException: 资源大小超过配置的最大限制时抛出
         :raise DownloadException: 重试多次仍失败时抛出
         """
-        file_name = make_filename(file_name) if file_name else generate_file_name(url)
+        cache_name = generate_file_name(url, cache_key)
+        fallback_suffix = _resolve_suffix(url, None, default_suffix)
         cache_dir = await CacheManager.ensure_dir(cache_type)
-        file_path = cache_dir / file_name
-        partial_path = file_path.parent / f"{file_path.name}.part"
-
-        if await file_path.exists():
-            return file_path
+        base_path = cache_dir / cache_name
+        partial_path = cache_dir / f"{cache_name}.part"
 
         headers = {**self.headers, **(ext_headers or {})}
-        download_key = str(file_path)
+        download_key = str(base_path)
         active_download = self._active_downloads.get(download_key)
         if active_download is not None:
-            await active_download
-            return file_path
+            return await active_download
 
-        async def __download_task() -> None:
-            if await file_path.exists():
-                return
-            await self.__download_with_retry(
+        async def __download_task() -> Path:
+            if cached_path := await CacheManager.get_cached_file(base_path):
+                return cached_path
+            result = await self.__download_with_retry(
                 url=url,
-                file_path=file_path,
+                base_path=base_path,
                 partial_path=partial_path,
+                fallback_suffix=fallback_suffix,
                 headers=headers,
-                desc=file_name,
+                desc=f"{cache_name}{fallback_suffix}",
                 use_curl_cffi=use_curl_cffi,
             )
+            await CacheManager.set_cached_file(base_path, result)
+            return result
 
         download_task = asyncio.create_task(__download_task())
         self._active_downloads[download_key] = download_task
 
         try:
-            await download_task
+            return await download_task
         except (SizeLimitException, ZeroSizeException):
-            await safe_unlink(file_path)
             await safe_unlink(partial_path)
             raise
         finally:
             if self._active_downloads.get(download_key) is download_task:
                 self._active_downloads.pop(download_key, None)
 
-        return file_path
-
     async def __download_with_retry(
         self,
         url: str,
-        file_path: Path,
+        base_path: Path,
         partial_path: Path,
+        fallback_suffix: str,
         headers: dict[str, str],
         desc: str,
         use_curl_cffi: bool = False,
-    ) -> None:
+    ) -> Path:
         last_error: Exception | None = None
 
         for retry in range(self.MAX_RETRIES + 1):
             try:
-                await self.__download_once(
+                content_type = await self.__download_once(
                     url=url,
                     file_path=partial_path,
                     headers=headers,
                     desc=desc,
                     use_curl_cffi=use_curl_cffi,
                 )
+                suffix = _resolve_suffix(url, content_type, fallback_suffix)
+                file_path = base_path.with_suffix(suffix)
+                if await file_path.exists():
+                    await safe_unlink(partial_path)
+                    return file_path
                 await partial_path.rename(file_path)
-                return
+                return file_path
             except (SizeLimitException, ZeroSizeException):
                 await safe_unlink(partial_path)
                 raise
@@ -245,7 +273,7 @@ class StreamDownloader:
         headers: dict[str, str],
         desc: str,
         use_curl_cffi: bool,
-    ):
+    ) -> str | None:
         downloaded = (await file_path.stat()).st_size if await file_path.exists() else 0
         async with self.client.stream(
             "GET",
@@ -255,6 +283,7 @@ class StreamDownloader:
         ) as response:
             self.__validate_response(response, downloaded)
             content_length = response.headers.get("content-length")
+            content_type = response.headers.get("content-type")
 
             total_size = (
                 downloaded + int(content_length)
@@ -323,13 +352,15 @@ class StreamDownloader:
                         f"(差值: {size_diff} bytes, 超过允许的 "
                         f"{self._SIZE_MISMATCH_TOLERANCE_BYTES} bytes)"
                     )
+            return content_type
 
     @auto_task
     async def download_video(
         self,
         *,
         url: str,
-        video_name: str | None = None,
+        cache_key: str | None = None,
+        cache_variant: str | None = None,
         ext_headers: dict[str, str] | None = None,
         cache_type: str = CacheManager.MEDIA,
         use_curl_cffi: bool = False,
@@ -338,7 +369,8 @@ class StreamDownloader:
         下载普通视频
 
         :param url: 视频下载地址
-        :param video_name: 保存到本地的视频文件名，为空时根据 url 自动生成 mp4 文件名
+        :param cache_key: 视频的稳定缓存标识，为空时根据 URL 生成
+        :param cache_variant: 同一资源下的视频用途标识
         :param ext_headers: 额外的请求头，会与默认请求头合并
         :param cache_type: 缓存类型
         :param use_curl_cffi: 是否使用 curl_cffi 下载
@@ -348,14 +380,10 @@ class StreamDownloader:
         :raise SizeLimitException: 资源大小超过配置的最大限制时抛出
         :raise DownloadException: 重试多次仍失败时抛出
         """
-        if video_name is None:
-            video_name = generate_file_name(
-                url, ".mp4", allowed_suffixes=STANDARD_VIDEO_SUFFIXES
-            )
-
         return await self.streamd(
             url=url,
-            file_name=video_name,
+            cache_key=compose_cache_key("video", cache_key, cache_variant),
+            default_suffix=".mp4",
             ext_headers=ext_headers,
             cache_type=cache_type,
             use_curl_cffi=use_curl_cffi,
@@ -366,7 +394,8 @@ class StreamDownloader:
         self,
         *,
         url: str,
-        video_name: str | None = None,
+        cache_key: str | None = None,
+        cache_variant: str | None = None,
         ext_headers: dict[str, str] | None = None,
         cache_type: str = CacheManager.MEDIA,
         use_curl_cffi: bool = False,
@@ -375,7 +404,8 @@ class StreamDownloader:
         下载 m3u8 视频并合并到 mp4
 
         :param m3u8_url: m3u8 播放列表链接地址
-        :param video_name: 输出的 mp4 文件名，为空时根据 m3u8 链接生成
+        :param cache_key: 视频的稳定缓存标识，为空时根据 URL 生成
+        :param cache_variant: 同一资源下的视频用途标识
         :param ext_headers: 额外的请求头，会与默认请求头合并
         :param cache_type: 缓存类型
         :param use_curl_cffi: 是否使用 curl_cffi 下载
@@ -384,10 +414,11 @@ class StreamDownloader:
         :raise SizeLimitException: 资源大小超过配置的最大限制时抛出
         :raise DownloadException: m3u8 解析、下载或转封装失败时抛出
         """
-        file_id = hashlib.md5(url.encode()).hexdigest()[:16]
-
-        if video_name is None:
-            video_name = f"{file_id}.mp4"
+        file_id = generate_file_name(
+            url=url,
+            cache_key=compose_cache_key("m3u8", cache_key, cache_variant),
+        )
+        video_name = f"{file_id}.mp4"
 
         cache_dir = await CacheManager.ensure_dir(cache_type)
         final_video_path = cache_dir / video_name
@@ -518,8 +549,8 @@ class StreamDownloader:
             )
 
         # 转封装处理
-        if await self._has_ffmpeg():
-            await self._remux_to_mp4(temp_ts_path, final_video_path)
+        if await FFmpeg.is_available():
+            await FFmpeg.remux_to_mp4(temp_ts_path, final_video_path)
         elif await temp_ts_path.exists():
             await temp_ts_path.rename(final_video_path)
 
@@ -647,48 +678,13 @@ class StreamDownloader:
             raise DownloadException(f"请求失败: {resp.status_code}")
         return resp.content
 
-    async def _has_ffmpeg(self) -> bool:
-        """
-        :return: 本机是否可用 ffmpeg 可执行程序
-        """
-        if self._ffmpeg_available is not None:
-            return self._ffmpeg_available
-
-        try:
-            proc = await asyncio.create_subprocess_shell(
-                "ffmpeg -version",
-                stdout=asyncio.subprocess.DEVNULL,
-                stderr=asyncio.subprocess.DEVNULL,
-            )
-            await proc.communicate()
-            self._ffmpeg_available = proc.returncode == 0
-        except Exception:
-            self._ffmpeg_available = False
-        return self._ffmpeg_available
-
-    async def _remux_to_mp4(self, input_path: Path, output_path: Path):
-        """
-        :param input_path: 输入的 ts 或其他容器格式文件路径
-        :param output_path: 转封装后输出的 mp4 文件路径
-        :return: None
-        """
-        # 增加 -f mp4 强制格式，增加 probesize 防止开头数据分析失败
-        cmd = (
-            f'ffmpeg -y -v error -probesize 50M -analyzeduration 100M -i "{input_path}"'
-            f' -c copy -bsf:a aac_adtstoasc "{output_path}"'
-        )
-        proc = await asyncio.create_subprocess_shell(cmd)
-        await proc.communicate()
-
-        if await output_path.exists() and await input_path.exists():
-            os.remove(input_path)
-
     @auto_task
     async def download_audio(
         self,
         *,
         url: str,
-        audio_name: str | None = None,
+        cache_key: str | None = None,
+        cache_variant: str | None = None,
         ext_headers: dict[str, str] | None = None,
         cache_type: str = CacheManager.MEDIA,
         use_curl_cffi: bool = False,
@@ -698,7 +694,8 @@ class StreamDownloader:
         下载音频
 
         :param url: 音频下载地址
-        :param audio_name: 保存到本地的音频文件名，为空时根据 url 自动生成 mp3 文件名
+        :param cache_key: 音频的稳定缓存标识，为空时根据 URL 生成
+        :param cache_variant: 同一资源下的音频用途标识
         :param ext_headers: 额外的请求头，会与默认请求头合并
         :param cache_type: 缓存类型
         :param use_curl_cffi: 是否使用 curl_cffi 下载
@@ -707,13 +704,10 @@ class StreamDownloader:
         :return: 下载完成后的音频文件路径
         :raise DownloadException: 下载过程中发生错误时抛出
         """
-        if audio_name is None:
-            audio_name = generate_file_name(
-                url, ".mp3", allowed_suffixes=STANDARD_AUDIO_SUFFIXES
-            )
         audio_path = await self.streamd(
             url=url,
-            file_name=audio_name,
+            cache_key=compose_cache_key("audio", cache_key, cache_variant),
+            default_suffix=".mp3",
             ext_headers=ext_headers,
             cache_type=cache_type,
             use_curl_cffi=use_curl_cffi,
@@ -727,7 +721,8 @@ class StreamDownloader:
         self,
         *,
         url: str,
-        img_name: str | None = None,
+        cache_key: str | None = None,
+        cache_variant: str | None = None,
         ext_headers: dict[str, str] | None = None,
         cache_type: str = CacheManager.MEDIA,
         use_curl_cffi: bool = False,
@@ -736,7 +731,8 @@ class StreamDownloader:
         下载图片
 
         :param url: 图片下载地址
-        :param img_name: 保存到本地的图片文件名，为空时根据 url 自动生成 jpg 文件名
+        :param cache_key: 图片的稳定缓存标识，为空时根据 URL 生成
+        :param cache_variant: 同一资源下的图片用途标识
         :param ext_headers: 额外的请求头，会与默认请求头合并
         :param cache_type: 缓存类型
         :param use_curl_cffi: 是否使用 curl_cffi 下载
@@ -744,13 +740,10 @@ class StreamDownloader:
         :return: 下载完成后的图片文件路径
         :raise DownloadException: 下载过程中发生错误时抛出
         """
-        if img_name is None:
-            img_name = generate_file_name(
-                url, ".jpg", allowed_suffixes=STANDARD_IMAGE_SUFFIXES
-            )
         return await self.streamd(
             url=url,
-            file_name=img_name,
+            cache_key=compose_cache_key("image", cache_key, cache_variant),
+            default_suffix=".jpg",
             ext_headers=ext_headers,
             cache_type=cache_type,
             use_curl_cffi=use_curl_cffi,
@@ -760,9 +753,7 @@ class StreamDownloader:
         self,
         video_url: str,
         audio_url: str,
-        merge_name: str,
-        video_name: str | None = None,
-        audio_name: str | None = None,
+        cache_key: str | None = None,
         ext_headers: dict[str, str] | None = None,
         use_curl_cffi: bool = False,
     ) -> Path:
@@ -771,14 +762,16 @@ class StreamDownloader:
 
         :param video_url: 视频流下载地址
         :param audio_url: 音频流下载地址
-        :param merge_name: 合并后输出文件名(不含扩展名)
-        :param video_name: 保存到本地的视频文件名，为空时根据 url 自动生成 mp4 文件名
-        :param audio_name: 保存到本地的音频文件名，为空时根据 url 自动生成 mp3 文件名
+        :param cache_key: 合并任务的稳定缓存标识，为空时根据两个 URL 生成
         :param ext_headers: 额外的请求头，会与默认请求头合并
         :param use_curl_cffi: 是否使用 curl_cffi 下载
         :return: 合并后的视频文件本地路径(mp4)
         :raise DownloadException: 下载或合并过程中发生错误时抛出
         """
+        merge_cache_key = compose_cache_key("video", cache_key, "merged")
+        if merge_cache_key is None:
+            merge_cache_key = f"video:{video_url}\naudio:{audio_url}\nmerged"
+        merge_name = generate_file_name(url=video_url, cache_key=merge_cache_key)
         cache_dir = await CacheManager.ensure_dir(CacheManager.MEDIA)
         output_path = cache_dir / f"{merge_name}.mp4"
         if await output_path.exists():
@@ -786,13 +779,15 @@ class StreamDownloader:
         v_path, a_path = await asyncio.gather(
             self.download_video(
                 url=video_url,
-                video_name=video_name,
+                cache_key=cache_key,
+                cache_variant="source" if cache_key is not None else None,
                 ext_headers=ext_headers,
                 use_curl_cffi=use_curl_cffi,
             ),
             self.download_audio(
                 url=audio_url,
-                audio_name=audio_name,
+                cache_key=cache_key,
+                cache_variant="source" if cache_key is not None else None,
                 ext_headers=ext_headers,
                 use_curl_cffi=use_curl_cffi,
             ),

--- a/src/nonebot_plugin_parser_lite/matchers/__init__.py
+++ b/src/nonebot_plugin_parser_lite/matchers/__init__.py
@@ -188,7 +188,8 @@ async def register_bili_matcher():
 
             audio_path = await DOWNLOADER.download_audio(
                 url=audio_url,
-                audio_name=f"{bvid}-{page_idx + 1}_audio.m4s",
+                cache_key=f"bilibili:{bvid}:{page_idx + 1}",
+                cache_variant="source",
                 ext_headers=bilip.headers,
                 convert_to_mp3=True,
             )

--- a/src/nonebot_plugin_parser_lite/parsers/acfun/__init__.py
+++ b/src/nonebot_plugin_parser_lite/parsers/acfun/__init__.py
@@ -35,11 +35,11 @@ class AcfunParser(BaseParser):
 
         video_content = self.create_video(
             url_or_task=DOWNLOADER.download_m3u8_video(
-                url=video_info.m3u8_url, video_name=f"acfun_{acid}.mp4"
+                url=video_info.m3u8_url, cache_key=f"acfun:{acid}"
             ),
             cover_url=video_info.coverUrl,
             duration=video_info.duration,
-            video_name=f"acfun_{acid}.mp4",
+            cache_key=f"acfun:{acid}",
         )
 
         return self.result(

--- a/src/nonebot_plugin_parser_lite/parsers/base.py
+++ b/src/nonebot_plugin_parser_lite/parsers/base.py
@@ -338,6 +338,7 @@ class BaseParser:
         location: str | None = None,
         ext_headers: dict[str, str] | None = None,
         use_curl_cffi: bool = False,
+        avatar_cache_key: str | None = None,
     ):
         """
         创建作者对象
@@ -349,6 +350,7 @@ class BaseParser:
         :param location: 位置信息
         :param ext_headers: 额外请求头
         :param use_curl_cffi: 是否使用 curl_cffi 下载头像
+        :param avatar_cache_key: 头像的稳定缓存标识，为空时根据 URL 生成
         """
 
         return Creator.author(
@@ -359,6 +361,7 @@ class BaseParser:
             location=location,
             ext_headers=ext_headers,
             use_curl_cffi=use_curl_cffi,
+            avatar_cache_key=avatar_cache_key,
         )
 
     def create_video(
@@ -366,10 +369,10 @@ class BaseParser:
         url_or_task: str | DownloadTaskWrapper[Path] | DownloadFunc,
         cover_url: str | None = None,
         duration: float = 0.0,
-        video_name: str | None = None,
         need_send: bool = True,
         ext_headers: dict[str, str] | None = None,
         use_curl_cffi: bool = False,
+        cache_key: str | None = None,
     ):
         """
         创建视频内容,
@@ -379,7 +382,7 @@ class BaseParser:
         :param url_or_task: 视频 URL 或下载任务
         :param cover_url: 封面 URL
         :param duration: 视频时长
-        :param video_name: 视频名称
+        :param cache_key: 稳定缓存标识，为空时根据各自 URL 生成
         :param need_send: 是否发送
         :param ext_headers: 额外请求头
         :param use_curl_cffi: 是否使用 curl_cffi 下载视频/封面
@@ -389,10 +392,10 @@ class BaseParser:
             url_or_task=url_or_task,
             cover_url=cover_url,
             duration=duration,
-            video_name=video_name,
             need_send=need_send,
             ext_headers=ext_headers,
             use_curl_cffi=use_curl_cffi,
+            cache_key=cache_key,
         )
 
     def create_videos(
@@ -400,11 +403,13 @@ class BaseParser:
         video_urls: list[str],
         ext_headers: dict[str, str] | None = None,
         use_curl_cffi: bool = False,
+        cache_keys: list[str | None] | None = None,
     ):
         """
         创建视频内容列表
 
         :param video_urls: 视频 URL 列表
+        :param cache_keys: 与视频 URL 一一对应的稳定缓存标识
         :param ext_headers: 额外请求头
         :param use_curl_cffi: 是否使用 curl_cffi 下载
         """
@@ -413,6 +418,7 @@ class BaseParser:
             video_urls=video_urls,
             ext_headers=ext_headers,
             use_curl_cffi=use_curl_cffi,
+            cache_keys=cache_keys,
         )
 
     def create_images(
@@ -420,11 +426,13 @@ class BaseParser:
         image_urls: list[str],
         ext_headers: dict[str, str] | None = None,
         use_curl_cffi: bool = False,
+        cache_keys: list[str | None] | None = None,
     ):
         """
         创建图片内容列表
 
         :param image_urls: 图片 URL 列表
+        :param cache_keys: 与图片 URL 一一对应的稳定缓存标识
         :param ext_headers: 额外请求头
         :param use_curl_cffi: 是否使用 curl_cffi 下载
         """
@@ -433,21 +441,22 @@ class BaseParser:
             image_urls=image_urls,
             ext_headers=ext_headers,
             use_curl_cffi=use_curl_cffi,
+            cache_keys=cache_keys,
         )
 
     def create_image(
         self,
         url: str,
-        img_name: str | None = None,
         need_send: bool = True,
         ext_headers: dict[str, str] | None = None,
         use_curl_cffi: bool = False,
+        cache_key: str | None = None,
     ):
         """
         创建图片内容
 
         :param url: 图片 URL
-        :param img_name: 图片名称
+        :param cache_key: 稳定缓存标识，为空时根据 URL 生成
         :param need_send: 是否发送
         :param ext_headers: 额外请求头
         :param use_curl_cffi: 是否使用 curl_cffi 下载
@@ -455,20 +464,20 @@ class BaseParser:
 
         return Creator.image(
             url=url,
-            img_name=img_name,
             need_send=need_send,
             ext_headers=ext_headers,
             use_curl_cffi=use_curl_cffi,
+            cache_key=cache_key,
         )
 
     def create_audio(
         self,
         url: str,
         duration: float = 0.0,
-        audio_name: str | None = None,
         need_send: bool = True,
         ext_headers: dict[str, str] | None = None,
         use_curl_cffi: bool = False,
+        cache_key: str | None = None,
     ):
         """
         创建音频内容,
@@ -477,7 +486,7 @@ class BaseParser:
 
         :param url_or_task: 音频 URL 或下载任务
         :param duration: 音频时长
-        :param audio_name: 音频名称
+        :param cache_key: 稳定缓存标识，为空时根据 URL 生成
         :param need_send: 是否发送
         :param ext_headers: 额外请求头
         :param use_curl_cffi: 是否使用 curl_cffi 下载
@@ -486,26 +495,26 @@ class BaseParser:
         return Creator.audio(
             url_or_task=url,
             duration=duration,
-            audio_name=audio_name,
             need_send=need_send,
             ext_headers=ext_headers,
             use_curl_cffi=use_curl_cffi,
+            cache_key=cache_key,
         )
 
     def create_graphic(
         self,
         url: str,
-        img_name: str | None = None,
         alt: str | None = None,
         need_send: bool = True,
         ext_headers: dict[str, str] | None = None,
         use_curl_cffi: bool = False,
+        cache_key: str | None = None,
     ):
         """
         图片,此图片不参与九宫格且无高度限制
 
         :param url: 图片 URL
-        :param img_name: 图片名称
+        :param cache_key: 稳定缓存标识，为空时根据 URL 生成
         :param alt: 图片描述
         :param need_send: 是否发送
         :param ext_headers: 额外请求头
@@ -514,11 +523,11 @@ class BaseParser:
 
         return Creator.graphic(
             url=url,
-            img_name=img_name,
             alt=alt,
             need_send=need_send,
             ext_headers=ext_headers,
             use_curl_cffi=use_curl_cffi,
+            cache_key=cache_key,
         )
 
     def create_sticker(
@@ -528,11 +537,13 @@ class BaseParser:
         desc: str | None = None,
         ext_headers: dict[str, str] | None = None,
         use_curl_cffi: bool = False,
+        cache_key: str | None = None,
     ):
         """
         创建贴纸内容
 
         :param url: 贴纸图片链接
+        :param cache_key: 稳定缓存标识，为空时根据 URL 生成
         :param size: 贴纸大小
             - small: 比文字大一点
             - medium: 文字大小的两倍大一点
@@ -547,6 +558,7 @@ class BaseParser:
             desc=desc,
             ext_headers=ext_headers,
             use_curl_cffi=use_curl_cffi,
+            cache_key=cache_key,
         )
 
     def create_live_photo(
@@ -558,12 +570,14 @@ class BaseParser:
         need_send: bool = True,
         ext_headers: dict[str, str] | None = None,
         use_curl_cffi: bool = False,
+        cache_key: str | None = None,
     ):
         """
         创建  iPhone Live Photo 内容
 
         :param video_url: iPhone Live Photo 变化过程视频
         :param image_url: iPhone Live Photo 底图
+        :param cache_key: 稳定缓存标识，为空时根据各自 URL 生成
         :param bgm_url: iPhone Live Photo 背景音乐
         :param loop: iPhone Live Photo 循环次数
         :param need_send: 是否发送
@@ -578,6 +592,7 @@ class BaseParser:
             need_send=need_send,
             ext_headers=ext_headers,
             use_curl_cffi=use_curl_cffi,
+            cache_key=cache_key,
         )
 
     def create_stats(

--- a/src/nonebot_plugin_parser_lite/parsers/bilibili/__init__.py
+++ b/src/nonebot_plugin_parser_lite/parsers/bilibili/__init__.py
@@ -292,6 +292,7 @@ class BilibiliParser(BaseParser):
         v_url, a_url = await self.extract_download_urls(
             video=video, page_index=page_info.index
         )
+        cache_key = f"bilibili:{video_info.bvid}:{page_info.index + 1}"
 
         class BiliVideoDownloader:
             def __init__(
@@ -305,21 +306,19 @@ class BilibiliParser(BaseParser):
                 self.ext_headers = ext_headers
 
             async def __call__(self) -> Path:
-                file_base = f"{video_info.bvid}-{page_num}"
                 # 有单独音频流时，走 av 合并
                 if self.audio_url:
                     return await DOWNLOADER.download_av_and_merge(
                         video_url=self.url,
                         audio_url=self.audio_url,
-                        merge_name=file_base,
-                        video_name=f"{file_base}_video.m4s",
-                        audio_name=f"{file_base}_audio.m4s",
+                        cache_key=cache_key,
                         ext_headers=self.ext_headers,
                     )
                 # 否则直接用流式下载
-                return await DOWNLOADER.streamd(
+                return await DOWNLOADER.download_video(
                     url=self.url,
-                    file_name=f"{file_base}.mp4",
+                    cache_key=cache_key,
+                    cache_variant="source",
                     ext_headers=self.ext_headers,
                 )
 
@@ -330,6 +329,7 @@ class BilibiliParser(BaseParser):
             cover_url=page_info.cover,
             duration=page_info.duration,
             ext_headers=self.headers,
+            cache_key=cache_key,
         )
 
         # 提取统计数据

--- a/src/nonebot_plugin_parser_lite/parsers/doubao/__init__.py
+++ b/src/nonebot_plugin_parser_lite/parsers/doubao/__init__.py
@@ -47,6 +47,7 @@ class DouBaoParser(BaseParser):
                 self.create_video(
                     url_or_task=result.play_info.main,
                     cover_url=result.play_info.poster_url,
+                    cache_key=f"doubao:{video_id}",
                 ),
             ],
         )

--- a/src/nonebot_plugin_parser_lite/parsers/douyin/__init__.py
+++ b/src/nonebot_plugin_parser_lite/parsers/douyin/__init__.py
@@ -125,6 +125,7 @@ class DouyinParser(BaseParser):
                 avatar_url=aweme.author.avatar_thumb.url_list[0],
                 description=aweme.author.signature,
                 id=aweme.author.uid,
+                avatar_cache_key=f"douyin:{aweme.author.uid}",
                 location=aweme.region,
                 ext_headers={"Referer": "https://www.douyin.com/"},
             ),

--- a/src/nonebot_plugin_parser_lite/parsers/douyin/aweme.py
+++ b/src/nonebot_plugin_parser_lite/parsers/douyin/aweme.py
@@ -48,6 +48,7 @@ class Video(Struct):
 
 class Image(Struct):
     url_list: list[str]
+    uri: str = field(default="")
     clip_type: int | None = field(default=None)
     """=2 or None 是普通图片"""
     video: Video | None = field(default=None)
@@ -60,6 +61,7 @@ class MusicPlayUrl(Struct):
 
 class Music(Struct):
     duration: int
+    mid: str
     play_url: MusicPlayUrl
     extra: str
 
@@ -74,6 +76,7 @@ class ShareInfo(Struct):
 
 
 class Aweme(Struct):
+    aweme_id: str
     author: Author
     share_info: ShareInfo
     statistics: Statistics
@@ -88,6 +91,7 @@ class Aweme(Struct):
     @property
     def content(self) -> list[ContentItem]:
         content: list[ContentItem] = [self.share_info.text]
+        aweme_cache_key = f"douyin:{self.aweme_id}"
         music_url: str | None = None
         if music := self.music:
             if music.play_url.uri == "":
@@ -100,15 +104,20 @@ class Aweme(Struct):
                     Creator.audio(
                         url_or_task=music_url,
                         duration=music.duration,
+                        cache_key=f"douyin:{music.mid}",
                         ext_headers={"Referer": "https://www.douyin.com/"},
                     )
                 )
         if self.images:
             for image in self.images:
+                image_cache_key = (
+                    f"{aweme_cache_key}:{image.uri}" if image.uri else None
+                )
                 if image.clip_type == 2 or image.clip_type is None:
                     content.append(
                         Creator.image(
                             url=image.url_list[-1],
+                            cache_key=image_cache_key,
                             ext_headers={"Referer": "https://www.douyin.com/"},
                         )
                     )
@@ -118,6 +127,7 @@ class Aweme(Struct):
                             video_url=image_video.play_addr.url,
                             image_url=image_video.cover.url_list[-1],
                             bgm_url=music_url,
+                            cache_key=image_cache_key,
                             ext_headers={"Referer": "https://www.douyin.com/"},
                             loop=3,
                         )
@@ -128,6 +138,7 @@ class Aweme(Struct):
                     url_or_task=video.play_addr.url,
                     cover_url=video.cover.url_list[-1],
                     duration=video.duration // 1000,
+                    cache_key=aweme_cache_key,
                     ext_headers={"Referer": "https://www.douyin.com/"},
                 )
             )

--- a/src/nonebot_plugin_parser_lite/parsers/douyin/comment.py
+++ b/src/nonebot_plugin_parser_lite/parsers/douyin/comment.py
@@ -41,6 +41,11 @@ class DComment(Struct):
             content.extend(
                 Creator.image(
                     url=image.origin_url.url_list[-1],
+                    cache_key=(
+                        f"douyin:{image.origin_url.uri}"
+                        if image.origin_url.uri
+                        else None
+                    ),
                     ext_headers={"Referer": "https://www.douyin.com/"},
                 )
                 for image in image_list
@@ -49,6 +54,11 @@ class DComment(Struct):
             content.append(
                 Creator.image(
                     url=sticker.static_url.url_list[-1],
+                    cache_key=(
+                        f"douyin:{sticker.static_url.uri}"
+                        if sticker.static_url.uri
+                        else None
+                    ),
                     ext_headers={"Referer": "https://www.douyin.com/"},
                 )
             )
@@ -65,6 +75,7 @@ class Response(Struct):
                 author=Creator.author(
                     name=comment.user.nickname,
                     avatar_url=comment.user.avatar_thumb.url_list[-1],
+                    avatar_cache_key=f"douyin:{comment.user.uid}",
                     location=comment.ip_label,
                 ),
                 content=comment.content,

--- a/src/nonebot_plugin_parser_lite/parsers/heybox/__init__.py
+++ b/src/nonebot_plugin_parser_lite/parsers/heybox/__init__.py
@@ -70,12 +70,13 @@ class HeyBoxParser(BaseParser):
 
         return self.result(
             title=data.link.title,
-            content=data.link.content,
+            content=data.link.build_content(cache_key=f"heybox:{link_id}"),
             timestamp=data.link.create_at,
             url=f"https://www.xiaoheihe.cn/app/bbs/link/{link_id}",
             author=self.create_author(
                 name=data.link.user.username,
                 avatar_url=data.link.user.avatar_url,
+                avatar_cache_key=f"heybox:{data.link.user.userid}",
             ),
             comments=comments,
             stats=self.create_stats(
@@ -107,6 +108,7 @@ class HeyBoxParser(BaseParser):
                 author=self.create_author(
                     name=root.user.username,
                     avatar_url=root.user.avatar_url,
+                    avatar_cache_key=f"heybox:{root.user.userid}",
                     location=root.ip_location,
                 ),
                 content=root.content,
@@ -123,6 +125,7 @@ class HeyBoxParser(BaseParser):
                         author=self.create_author(
                             name=child.user.username,
                             avatar_url=child.user.avatar_url,
+                            avatar_cache_key=f"heybox:{child.user.userid}",
                             location=child.ip_location,
                         ),
                         content=child.content,

--- a/src/nonebot_plugin_parser_lite/parsers/heybox/model.py
+++ b/src/nonebot_plugin_parser_lite/parsers/heybox/model.py
@@ -104,8 +104,7 @@ class Link(Struct):
     video_url: str | None = None
     video_thumb: str | None = None
 
-    @property
-    def content(self) -> list[ContentItem]:
+    def build_content(self, cache_key: str | None = None) -> list[ContentItem]:
         """格式化的富文本内容"""
         content: list[ContentItem] = []
         try:
@@ -134,7 +133,11 @@ class Link(Struct):
             content.append(self.text)
         if self.has_video and self.video_url and self.video_thumb:
             content.append(
-                Creator.video(url_or_task=self.video_url, cover_url=self.video_thumb)
+                Creator.video(
+                    url_or_task=self.video_url,
+                    cover_url=self.video_thumb,
+                    cache_key=cache_key,
+                )
             )
         return content
 

--- a/src/nonebot_plugin_parser_lite/parsers/hupu/bbs.py
+++ b/src/nonebot_plugin_parser_lite/parsers/hupu/bbs.py
@@ -65,6 +65,7 @@ class BBS(Struct):
                     url_or_task=video.src,
                     cover_url=video.img,
                     duration=int(video.duration),
+                    cache_key=f"hupu:{self.tid}",
                 )
             )
         return c
@@ -75,6 +76,7 @@ class BBS(Struct):
             name=self.author.name,
             avatar_url=self.author.header,
             id=str(self.author.puid),
+            avatar_cache_key=f"hupu:{self.author.puid}",
         )
 
     @property

--- a/src/nonebot_plugin_parser_lite/parsers/hupu/comment.py
+++ b/src/nonebot_plugin_parser_lite/parsers/hupu/comment.py
@@ -59,6 +59,7 @@ class Response(Struct):
                     name=c.userName,
                     avatar_url=c.userImg,
                     id=c.puid,
+                    avatar_cache_key=f"hupu:{c.puid}",
                     location=c.location,
                 ),
                 content=c.content,

--- a/src/nonebot_plugin_parser_lite/parsers/hupu/util.py
+++ b/src/nonebot_plugin_parser_lite/parsers/hupu/util.py
@@ -1,3 +1,5 @@
+from urllib.parse import urlparse
+
 from bs4 import BeautifulSoup
 from bs4.element import NavigableString, Tag
 
@@ -44,9 +46,14 @@ def _iter_media_and_text(soup: BeautifulSoup):
                 continue
 
             if element.name == "video":
+                video_url = str(element.get("src"))
+                stable_url = (
+                    urlparse(video_url)._replace(query="", fragment="").geturl()
+                )
                 yield Creator.video(
-                    url_or_task=str(element.get("src")),
+                    url_or_task=video_url,
                     cover_url=str(element.get("poster")),
+                    cache_key=f"hupu:{stable_url}",
                 )
                 element.decompose()
                 continue

--- a/src/nonebot_plugin_parser_lite/parsers/kuaishou/comment.py
+++ b/src/nonebot_plugin_parser_lite/parsers/kuaishou/comment.py
@@ -17,6 +17,7 @@ class KsComment(Struct):
     comment_id: int
     headurl: str
     author_name: str
+    user_id: int
     subCommentCount: int = 0
     authorArea: str | None = None
 
@@ -31,6 +32,7 @@ def _build_comment(comment: KsComment, *, include_reply_count: bool = False) -> 
         author=Creator.author(
             name=comment.author_name,
             avatar_url=comment.headurl,
+            avatar_cache_key=f"kuaishou:{comment.user_id}",
             location=comment.authorArea,
         ),
         content=replace_placeholder_to_sticker(

--- a/src/nonebot_plugin_parser_lite/parsers/kuaishou/state.py
+++ b/src/nonebot_plugin_parser_lite/parsers/kuaishou/state.py
@@ -45,6 +45,7 @@ class Photo(Struct):
     coverUrls: list[MvorCoverCdnUrl]
     ext_params: ExtParams
     photoId: str
+    userId: int
     photoType: str
     mainMvUrls: list[MvorCoverCdnUrl] | None = None
     duration: int = 0
@@ -55,6 +56,7 @@ class Photo(Struct):
         return Creator.author(
             name=self.userName.replace("\u3164", "").strip(),
             avatar_url=self.headUrl,
+            avatar_cache_key=f"kuaishou:{self.userId}",
         )
 
     @property
@@ -75,10 +77,19 @@ class Photo(Struct):
                     url_or_task=video[0].url,
                     duration=self.duration // 1000,
                     cover_url=self.coverUrls[0].url,
+                    cache_key=f"kuaishou:{self.photoId}",
                 )
             )
         elif atlas := self.ext_params.atlas:
-            content.extend(Creator.images(atlas.img_urls))
+            content.extend(
+                Creator.images(
+                    atlas.img_urls,
+                    cache_keys=[
+                        f"kuaishou:{self.photoId}:{route}"
+                        for route in atlas.img_list
+                    ],
+                )
+            )
         return content
 
 

--- a/src/nonebot_plugin_parser_lite/parsers/kugou.py
+++ b/src/nonebot_plugin_parser_lite/parsers/kugou.py
@@ -154,12 +154,10 @@ class KuGouParser(BaseParser):
         if not audio_url:
             raise ParseException("未找到音频资源")
 
-        audio_name = f"{playinfo.fileName}.{playinfo.extName}"
-
         audio_content = self.create_audio(
             url=audio_url,
             duration=playinfo.timeLength,
-            audio_name=audio_name,
+            cache_key=f"kugou:{playinfo.hash}",
         )
         author = self.create_author(
             name=playinfo.singerName  # , playinfo.imgUrl.format(size=480)

--- a/src/nonebot_plugin_parser_lite/parsers/kuwo.py
+++ b/src/nonebot_plugin_parser_lite/parsers/kuwo.py
@@ -35,11 +35,10 @@ class KuWoParser(BaseParser):
         if not audio_url.startswith("http"):
             raise ParseException("无效音乐URL")
         duration = music_data["duration_seconds"]
-        audio_name = f"{music_data['title']}-{music_data['artist']}.mp3"
         audio_content = self.create_audio(
             url=audio_url,
             duration=duration,
-            audio_name=audio_name,
+            cache_key=f"kuwo:{rid}",
         )
         dis_dura = audio_content.display_duration
 

--- a/src/nonebot_plugin_parser_lite/parsers/miyoushe/__init__.py
+++ b/src/nonebot_plugin_parser_lite/parsers/miyoushe/__init__.py
@@ -51,6 +51,7 @@ class MiyousheParser(BaseParser):
                 name=post.user.nickname,
                 avatar_url=post.user.avatar_url,
                 id=post.user.uid,
+                avatar_cache_key=f"miyoushe:{post.user.uid}",
             ),
             url=post.url,
             content=post.post.content,

--- a/src/nonebot_plugin_parser_lite/parsers/miyoushe/comment.py
+++ b/src/nonebot_plugin_parser_lite/parsers/miyoushe/comment.py
@@ -60,6 +60,7 @@ class Response(Struct):
                 name=user.nickname,
                 avatar_url=user.avatar_url,
                 id=user.uid,
+                avatar_cache_key=f"miyoushe:{user.uid}",
                 location=user.ip_region,
             )
 

--- a/src/nonebot_plugin_parser_lite/parsers/miyoushe/structed_content.py
+++ b/src/nonebot_plugin_parser_lite/parsers/miyoushe/structed_content.py
@@ -19,6 +19,7 @@ class Resolution(Struct):
 
 
 class Video(Struct):
+    id: str
     duration: int
     cover: str
     resolutions: list[Resolution]
@@ -69,6 +70,7 @@ def build_body(s: str):
                     url_or_task=v.resolutions[0].url,
                     cover_url=v.cover,
                     duration=v.duration,
+                    cache_key=f"miyoushe:{v.id}",
                 )
             )
         elif link := ins.link_card:

--- a/src/nonebot_plugin_parser_lite/parsers/netease.py
+++ b/src/nonebot_plugin_parser_lite/parsers/netease.py
@@ -100,11 +100,10 @@ class NCMParser(BaseParser):
         audio_type = ext if ext in {"flac", "wav", "m4a", "aac", "mp3"} else "mp3"
         contents: list[ContentItem] = []
 
-        audio_name = f"{title}-{artist}.{audio_type}"
         audio = self.create_audio(
             audio_url,
             duration=duration,
-            audio_name=audio_name,
+            cache_key=f"netease:{ncm_id}",
         )
         contents.append(audio)
 

--- a/src/nonebot_plugin_parser_lite/parsers/qsmusic/__init__.py
+++ b/src/nonebot_plugin_parser_lite/parsers/qsmusic/__init__.py
@@ -35,14 +35,15 @@ class QSMusicParser(BaseParser):
             raw = matched[1]
         else:
             raise ParseException("未找到结构化数据")
-        music_data = shareDecoder.decode(
+        track = shareDecoder.decode(
             raw
-        ).loaderData.track_page.audioWithLyricsOption
+        ).loaderData.track_page
+        music_data = track.audioWithLyricsOption
         contents: list[ContentItem] = [
             self.create_audio(
                 music_data.url,
                 duration=music_data.duration,
-                audio_name=f"{music_data.trackName}.mp3",
+                cache_key=f"qsmusic:{track.track_id}",
             )
         ]
         extra = {

--- a/src/nonebot_plugin_parser_lite/parsers/qsmusic/share.py
+++ b/src/nonebot_plugin_parser_lite/parsers/qsmusic/share.py
@@ -117,6 +117,7 @@ class AudioWithLyricsOption(Struct):
 
 class TrackPage(Struct):
     audioWithLyricsOption: AudioWithLyricsOption
+    track_id: str
 
 
 class LoaderData(Struct):

--- a/src/nonebot_plugin_parser_lite/parsers/rednote/__init__.py
+++ b/src/nonebot_plugin_parser_lite/parsers/rednote/__init__.py
@@ -72,13 +72,17 @@ class RedNoteParser(BaseParser):
         author = self.create_author(
             name=note_detail.nickname,
             avatar_url=note_detail.avatar_url,
+            avatar_cache_key=f"rednote:{note_detail.user.userId}",
         )
         comment_list: list[Comment] = []
 
         for c in comment_data.comments:
             comment = self.create_comment(
                 author=self.create_author(
-                    name=c.user.nickname, avatar_url=c.user.image, location=c.ipLocation
+                    name=c.user.nickname,
+                    avatar_url=c.user.image,
+                    location=c.ipLocation,
+                    avatar_cache_key=f"rednote:{c.user.userId}",
                 ),
                 content=c.content,
                 timestamp=c.time // 1000,
@@ -94,6 +98,7 @@ class RedNoteParser(BaseParser):
                         author=self.create_author(
                             name=sub.user.nickname,
                             avatar_url=sub.user.image,
+                            avatar_cache_key=f"rednote:{sub.user.userId}",
                         ),
                         content=sub.content,
                         timestamp=sub.time // 1000,

--- a/src/nonebot_plugin_parser_lite/parsers/rednote/discovery.py
+++ b/src/nonebot_plugin_parser_lite/parsers/rednote/discovery.py
@@ -156,6 +156,7 @@ class NoteDetail(Struct):
                     url_or_task=self.video.url,
                     cover_url=f"https://ci.xiaohongshu.com/{self.cover.fileId}?imageView2/2/w/1080/format/jpg",
                     duration=self.video.capa.duration,
+                    cache_key=f"rednote:{self.video.consumer.originVideoKey}",
                 )
             )
         else:
@@ -165,12 +166,14 @@ class NoteDetail(Struct):
                         Creator.live_photo(
                             video_url=img.stream.url,
                             image_url=img.url,
+                            cache_key=f"rednote:{img.fileId}" if img.fileId else None,
                         )
                     )
                 else:
                     items.append(
                         Creator.image(
                             url=img.url,
+                            cache_key=f"rednote:{img.fileId}" if img.fileId else None,
                         )
                     )
 

--- a/src/nonebot_plugin_parser_lite/parsers/taptap/comment.py
+++ b/src/nonebot_plugin_parser_lite/parsers/taptap/comment.py
@@ -53,6 +53,7 @@ class Response(Struct):
                 id=str(tc.author.id),
                 name=tc.author.name,
                 avatar_url=tc.author.avatar,
+                avatar_cache_key=f"taptap:{tc.author.id}",
             )
 
         def to_comment(tc: TComment):

--- a/src/nonebot_plugin_parser_lite/parsers/taptap/moment.py
+++ b/src/nonebot_plugin_parser_lite/parsers/taptap/moment.py
@@ -92,6 +92,7 @@ class Data(Struct):
             name=self.moment.author.user.name,
             avatar_url=self.moment.author.user.avatar,
             id=str(self.moment.author.user.id),
+            avatar_cache_key=f"taptap:{self.moment.author.user.id}",
         )
 
     @property

--- a/src/nonebot_plugin_parser_lite/parsers/taptap/video.py
+++ b/src/nonebot_plugin_parser_lite/parsers/taptap/video.py
@@ -31,9 +31,13 @@ class Data(Struct):
     def content(self) -> list[ContentItem]:
         return [
             Creator.video(
-                url_or_task=DOWNLOADER.download_m3u8_video(url=video.play_url.url),
+                url_or_task=DOWNLOADER.download_m3u8_video(
+                    url=video.play_url.url,
+                    cache_key=f"taptap:{video.video_id}",
+                ),
                 cover_url=video.raw_cover.url,
                 duration=video.info.duration,
+                cache_key=f"taptap:{video.video_id}",
             )
             for video in self.videos
         ]

--- a/src/nonebot_plugin_parser_lite/parsers/weibo/__init__.py
+++ b/src/nonebot_plugin_parser_lite/parsers/weibo/__init__.py
@@ -117,6 +117,7 @@ class WeiBoParser(BaseParser):
                     author=self.create_author(
                         name=sc.user_info.screen_name,
                         avatar_url=sc.user_info.profile_image_url,
+                        avatar_cache_key=f"weibo:{sc.user_info.id}",
                         ext_headers={"Referer": "https://weibo.com/"},
                     ),
                     content=sc.content,
@@ -133,6 +134,7 @@ class WeiBoParser(BaseParser):
             author=self.create_author(
                 name=data.userinfo.screen_name,
                 avatar_url=data.userinfo.profile_image_url,
+                avatar_cache_key=f"weibo:{data.userinfo.id}",
                 location=data.region_info.region_name,
                 ext_headers={"Referer": "https://weibo.com/"},
             ),
@@ -160,6 +162,7 @@ class WeiBoParser(BaseParser):
             url_or_task=play_info.video_url,
             cover_url=play_info.cover_url,
             duration=play_info.duration_time,
+            cache_key=f"weibo:{fid}",
             ext_headers={"Referer": "https://weibo.com/"},
         )
 
@@ -180,6 +183,7 @@ class WeiBoParser(BaseParser):
                     author=self.create_author(
                         name=sc.user.screen_name,
                         avatar_url=sc.user.profile_image_url,
+                        avatar_cache_key=f"weibo:{sc.user.id}",
                         location=sc.source,
                         ext_headers={"Referer": "https://weibo.com/"},
                     ),
@@ -194,6 +198,7 @@ class WeiBoParser(BaseParser):
                             author=self.create_author(
                                 name=c.user.screen_name,
                                 avatar_url=c.user.profile_image_url,
+                                avatar_cache_key=f"weibo:{c.user.id}",
                                 location=c.source,
                                 ext_headers={"Referer": "https://weibo.com/"},
                             ),
@@ -213,6 +218,7 @@ class WeiBoParser(BaseParser):
             author=self.create_author(
                 name=play_info.author,
                 avatar_url=play_info.avatar_url,
+                avatar_cache_key=f"weibo:{play_info.author_id}",
                 location=play_info.ip_info_str,
                 ext_headers={"Referer": "https://weibo.com/"},
             ),
@@ -253,6 +259,7 @@ class WeiBoParser(BaseParser):
                         author=self.create_author(
                             name=sc.user.screen_name,
                             avatar_url=sc.user.profile_image_url,
+                            avatar_cache_key=f"weibo:{sc.user.id}",
                             location=sc.source,
                             ext_headers={"Referer": "https://weibo.com/"},
                         ),
@@ -267,6 +274,7 @@ class WeiBoParser(BaseParser):
                                 author=self.create_author(
                                     name=c.user.screen_name,
                                     avatar_url=c.user.profile_image_url,
+                                    avatar_cache_key=f"weibo:{c.user.id}",
                                     location=c.source,
                                     ext_headers={"Referer": "https://weibo.com/"},
                                 ),
@@ -289,6 +297,7 @@ class WeiBoParser(BaseParser):
                 name=data.user.screen_name,
                 avatar_url=data.user.profile_image_url,
                 id=data.user.idstr,
+                avatar_cache_key=f"weibo:{data.user.idstr}",
                 location=data.region_name,
                 ext_headers={"Referer": "https://weibo.com/"},
             ),

--- a/src/nonebot_plugin_parser_lite/parsers/weibo/article.py
+++ b/src/nonebot_plugin_parser_lite/parsers/weibo/article.py
@@ -1,3 +1,5 @@
+from urllib.parse import urlparse
+
 from bs4 import BeautifulSoup, Tag
 from msgspec import Struct, field
 from msgspec.json import Decoder
@@ -39,9 +41,12 @@ class Data(Struct):
             elif element.name == "img":
                 src = element.get("src")
                 if isinstance(src, str):
+                    stable_url = urlparse(src)._replace(query="", fragment="").geturl()
                     content.append(
                         Creator.image(
-                            url=src, ext_headers={"Referer": "https://weibo.com/"}
+                            url=src,
+                            cache_key=f"weibo:{stable_url}",
+                            ext_headers={"Referer": "https://weibo.com/"},
                         )
                     )
         return content

--- a/src/nonebot_plugin_parser_lite/parsers/weibo/show.py
+++ b/src/nonebot_plugin_parser_lite/parsers/weibo/show.py
@@ -7,6 +7,7 @@ class PlayInfo(Struct):
     title: str
     text: str
     author: str
+    author_id: int
     avatar: str
     cover_image: str
     stream_url: str

--- a/src/nonebot_plugin_parser_lite/parsers/weibo/show_comment.py
+++ b/src/nonebot_plugin_parser_lite/parsers/weibo/show_comment.py
@@ -26,14 +26,18 @@ class Pic(Struct):
 
     @property
     def content(self):
+        cache_key = f"weibo:{self.pic_id}"
         if self.video:
             return Creator.live_photo(
                 video_url=self.video,
                 image_url=self.original.url,
+                cache_key=cache_key,
                 ext_headers={"Referer": "https://weibo.com/"},
             )
         return Creator.image(
-            url=self.original.url, ext_headers={"Referer": "https://weibo.com/"}
+            url=self.original.url,
+            cache_key=cache_key,
+            ext_headers={"Referer": "https://weibo.com/"},
         )
 
 
@@ -47,7 +51,7 @@ class User(Struct):
 class TvComment(Struct):
     created_at: str
     text_raw: str
-    id: str
+    id: int
     source: str
     user: User
     like_counts: int = 0

--- a/src/nonebot_plugin_parser_lite/parsers/weibo/statuses.py
+++ b/src/nonebot_plugin_parser_lite/parsers/weibo/statuses.py
@@ -28,14 +28,18 @@ class Pic(Struct):
 
     @property
     def content(self):
+        cache_key = f"weibo:{self.pic_id}"
         if self.type == "livephoto":
             return Creator.live_photo(
                 video_url=self.video,
                 image_url=self.original.url,
+                cache_key=cache_key,
                 ext_headers={"Referer": "https://weibo.com/"},
             )
         return Creator.image(
-            url=self.original.url, ext_headers={"Referer": "https://weibo.com/"}
+            url=self.original.url,
+            cache_key=cache_key,
+            ext_headers={"Referer": "https://weibo.com/"},
         )
 
 
@@ -49,11 +53,11 @@ class PageInfo(Struct):
     page_title: str
     media_info: MediaInfo
 
-    @property
-    def content(self):
+    def build_content(self, cache_key: str):
         return Creator.video(
             url_or_task=self.media_info.stream_url_hd,
             cover_url=self.page_pic,
+            cache_key=cache_key,
             ext_headers={"Referer": "https://weibo.com/"},
         )
 
@@ -103,7 +107,9 @@ class WeiboData(Struct):
         if self.pic_infos:
             content.extend(pic.content for pic in self.pic_infos.values())
         if self.page_info:
-            content.append(self.page_info.content)
+            content.append(
+                self.page_info.build_content(cache_key=f"weibo:{self.idstr}")
+            )
         return content
 
     @property

--- a/src/nonebot_plugin_parser_lite/parsers/weibo/statuses_comment.py
+++ b/src/nonebot_plugin_parser_lite/parsers/weibo/statuses_comment.py
@@ -27,14 +27,18 @@ class Pic(Struct):
 
     @property
     def content(self):
+        cache_key = f"weibo:{self.pic_id}"
         if self.video:
             return Creator.live_photo(
                 video_url=self.video,
                 image_url=self.original.url,
+                cache_key=cache_key,
                 ext_headers={"Referer": "https://weibo.com/"},
             )
         return Creator.image(
-            url=self.original.url, ext_headers={"Referer": "https://weibo.com/"}
+            url=self.original.url,
+            cache_key=cache_key,
+            ext_headers={"Referer": "https://weibo.com/"},
         )
 
 

--- a/src/nonebot_plugin_parser_lite/utils/cache.py
+++ b/src/nonebot_plugin_parser_lite/utils/cache.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 import time
 from typing import ClassVar
 
+import aiofiles
 from anyio import Path
 from nonebot import logger
 
@@ -33,7 +34,6 @@ class CacheManager:
         LOGO: CachePolicy("logo", 60 * 60 * 24 * 30),
         STICKER: CachePolicy("sticker", 60 * 60 * 24 * 15),
     }
-
     @classmethod
     def cache_dir(cls, cache_type: str = MEDIA) -> Path:
         policy = cls._POLICIES.get(cache_type, cls._POLICIES[cls.MEDIA])
@@ -44,6 +44,36 @@ class CacheManager:
         cache_dir = cls.cache_dir(cache_type)
         await cache_dir.mkdir(parents=True, exist_ok=True)
         return cache_dir
+
+    @classmethod
+    async def set_cached_file(cls, base_path: Path, file_path: Path) -> None:
+        meta_path = base_path.with_suffix(".meta")
+        partial_path = base_path.with_suffix(".meta.part")
+        try:
+            async with aiofiles.open(partial_path, "w") as file:
+                await file.write(file_path.suffix.lower())
+            await partial_path.replace(meta_path)
+        except OSError as e:
+            await safe_unlink(partial_path)
+            logger.warning(f"写入缓存索引 {meta_path} 失败: {e!r}")
+
+    @classmethod
+    async def get_cached_file(
+        cls,
+        base_path: Path,
+    ) -> Path | None:
+        meta_path = base_path.with_suffix(".meta")
+        try:
+            async with aiofiles.open(meta_path) as file:
+                suffix = (await file.read()).strip().lower()
+        except OSError:
+            return None
+
+        cached_path = base_path.with_suffix(suffix)
+        if await cached_path.is_file():
+            return cached_path
+        await safe_unlink(meta_path)
+        return None
 
     @classmethod
     async def iter_files(cls, path: Path) -> AsyncIterator[Path]:

--- a/src/nonebot_plugin_parser_lite/utils/common.py
+++ b/src/nonebot_plugin_parser_lite/utils/common.py
@@ -1,7 +1,5 @@
 from collections import OrderedDict
-from collections.abc import Collection
 import hashlib
-import re
 from typing import TypeVar
 from urllib.parse import urlparse
 
@@ -10,53 +8,6 @@ from nonebot import logger
 
 K = TypeVar("K")
 V = TypeVar("V")
-
-STANDARD_IMAGE_SUFFIXES = {
-    ".jpeg",
-    ".webp",
-    ".jpg",
-    ".gif",
-    ".png",
-    ".bmp",
-    ".svg",
-    ".avif",
-    ".heic",
-    ".heif",
-    ".jfif",
-}
-STANDARD_VIDEO_SUFFIXES = {
-    ".3gp",
-    ".avi",
-    ".flv",
-    ".m2ts",
-    ".m4v",
-    ".mkv",
-    ".mov",
-    ".mp4",
-    ".mpeg",
-    ".mpg",
-    ".ts",
-    ".webm",
-    ".wmv",
-}
-STANDARD_AUDIO_SUFFIXES = {
-    ".aac",
-    ".ac3",
-    ".aiff",
-    ".alac",
-    ".amr",
-    ".ape",
-    ".flac",
-    ".m4a",
-    ".m4s",
-    ".mp3",
-    ".ogg",
-    ".opus",
-    ".wav",
-    ".weba",
-    ".wma",
-}
-
 
 class LimitedSizeDict(OrderedDict[K, V]):
     """
@@ -71,17 +22,6 @@ class LimitedSizeDict(OrderedDict[K, V]):
         super().__setitem__(key, value)
         if len(self) > self.max_size:
             self.popitem(last=False)
-
-
-def make_filename(text: str) -> str:
-    """
-    清理路径非法字符，保留中英文、数字及合法路径字符
-    """
-    illegal_chars_pattern = r'[<>:"/\\|?*\x00-\x1f]'
-    cleaned_text = re.sub(illegal_chars_pattern, "", text)
-    cleaned_text = cleaned_text.replace(" ", "_")
-
-    return cleaned_text
 
 
 async def safe_unlink(path: Path):
@@ -103,36 +43,25 @@ async def fmt_size(file_path: Path) -> str:
     return f"大小: {stat.st_size / 1024 / 1024:.2f} MB"
 
 
-def generate_file_name(
-    url: str,
-    default_suffix: str = ".bin",
-    allowed_suffixes: Collection[str] | None = None,
-) -> str:
-    """根据 URL 生成文件名，保留可能参与资源定位的 query。
+def compose_cache_key(
+    media_type: str,
+    resource_key: str | None,
+    variant: str | None = None,
+) -> str | None:
+    """为显式资源标识补充媒体类型和用途，未传标识时交给 URL 兜底"""
+    if resource_key is None:
+        return None
+    if not media_type.strip() or not resource_key.strip():
+        raise ValueError("缓存标识组成部分不能为空")
+    if variant is not None and not variant.strip():
+        raise ValueError("缓存用途不能为空")
+    return ":".join(part for part in (media_type, resource_key, variant) if part)
 
-    :param url: 原始资源 URL
-    :param default_suffix: URL 后缀缺失或不受支持时使用的后缀名，默认 .bin
-    :param allowed_suffixes: 允许从 URL 保留的后缀集合；为空时允许任意后缀
 
-    :return: 适合作为文件名的短 md5（含后缀）
-    """
-
+def generate_file_name(url: str, cache_key: str | None = None) -> str:
+    """根据稳定标识或完整 URL 生成不带后缀的文件名"""
     parsed = urlparse(url)
-    path = Path(parsed.path)
-    path_suffix = path.suffix.lower()
-
-    if path_suffix and (
-        allowed_suffixes is None or path_suffix in allowed_suffixes
-    ):
-        suffix = path_suffix
-    else:
-        suffix = default_suffix
-
-    # 确保后缀格式正确（以点号开头）
-    if suffix and not suffix.startswith("."):
-        suffix = f".{suffix}"
-
-    # fragment 不会发送给服务器；query 可能决定实际资源，必须参与缓存键。
-    resource_url = parsed._replace(fragment="").geturl()
-    url_hash = hashlib.md5(resource_url.encode("utf-8")).hexdigest()[:16]
-    return f"{url_hash}{suffix}"
+    if cache_key is not None and not cache_key.strip():
+        raise ValueError("cache_key 不能为空字符串")
+    identity = cache_key or parsed._replace(fragment="").geturl()
+    return hashlib.md5(identity.encode("utf-8")).hexdigest()[:16]

--- a/src/nonebot_plugin_parser_lite/utils/ffmpeg.py
+++ b/src/nonebot_plugin_parser_lite/utils/ffmpeg.py
@@ -479,6 +479,11 @@ class FFmpeg:
         :param file_name: 输出文件名（不含扩展名），为空时根据输入路径生成稳定名称
         :return: 转码后的 mp3 文件路径
         """
+        if audio_path.suffix.casefold() == ".mp3" and await cls._is_mp3_audio(
+            audio_path
+        ):
+            return audio_path
+
         file_name = file_name or cls.hash_filename(audio_path)
         cache_dir = await CacheManager.ensure_dir(CacheManager.MEDIA)
         output_path = cache_dir / f"{file_name}.mp3"

--- a/src/nonebot_plugin_parser_lite/utils/ffmpeg.py
+++ b/src/nonebot_plugin_parser_lite/utils/ffmpeg.py
@@ -454,6 +454,14 @@ class FFmpeg:
         if await output_path.exists():
             return output_path
 
+        input_names = f"{image_path.name} and {video_path.name}"
+        if has_bgm and bgm_path:
+            input_names += f" with {bgm_path.name}"
+        logger.info(
+            f"Creating Live Photo video from {input_names} to {output_path.name}, "
+            f"loop={loop}"
+        )
+
         video_probe = await cls._probe_media(video_path)
         duration = cls._get_duration(video_probe, video_path)
         video_fps = cls._get_video_frame_rate(video_probe, video_path)
@@ -466,14 +474,18 @@ class FFmpeg:
         )
         cmd = cls._build_live_command(inputs, filter_parts, *audio_options, output_path)
         await cls.exec_ffmpeg(cmd)
+        logger.success(
+            f"Created Live Photo video {output_path.name}, "
+            f"{await fmt_size(output_path)}"
+        )
         return output_path
 
     @classmethod
-    async def convert_audio_to_mp3(
+    async def convert_to_mp3(
         cls, audio_path: Path, file_name: str | None = None
     ) -> Path:
         """
-        将任意音频文件转码为 mp3。
+        将任意音视频文件转码为 mp3。
 
         :param audio_path: 输入音频文件路径
         :param file_name: 输出文件名（不含扩展名），为空时根据输入路径生成稳定名称


### PR DESCRIPTION
## Summary by Sourcery

为媒体下载引入稳定的缓存键以及按内容类型解析文件后缀，以提升跨平台的缓存复用能力和文件格式处理能力。

New Features:
- 为媒体、图片、音频、视频、贴纸、头像和 logo 下载添加稳定缓存键支持，并可按变体进行区分（可选）。
- 引入缓存索引元数据，将逻辑缓存基准映射到实际文件，实现对动态媒体资源缓存的复用。
- 为流式下载添加基于内容类型的文件后缀解析，并在 URL 和默认后缀之间进行回退处理。

Bug Fixes:
- 通过对稳定标识符而非原始 URL 进行哈希，修复动态 URL 可能导致的缓存冲突和不稳定文件名问题。
- 通过校验缓存文件是否存在并清理无效条目，防止缓存元数据陈旧失效。

Enhancements:
- 以 `cache_key` 参数统一媒体下载接口，并从创建器和解析器中移除手动文件名处理逻辑。
- 重构 m3u8 和 AV 合并流程，改用共享的缓存命名和 FFmpeg 辅助工具，替代各自定制的 ffmpeg 探测逻辑。
- 确保多个调用方等待同一下载时，共享单个任务，并返回最终的缓存文件路径。
- 在各个平台解析器（微博、Bilibili、抖音、快手、小红书、AcFun、酷狗、酷我、网易云音乐、机核、Taptap、虎扑、米游社、豆包、QQ 音乐）中添加平台特定的稳定缓存键，以规范化媒体缓存行为。
- 通过在转换前检测已为 MP3 的输入，避免不必要的音频转码。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce stable cache keys and content-type-aware suffix resolution for media downloads to improve cache reuse and file format handling across platforms.

New Features:
- Add stable cache key support for media, image, audio, video, sticker, avatar, and logo downloads, with optional per-variant differentiation.
- Introduce cache index metadata to map logical cache bases to actual files, enabling reuse of cached dynamic media resources.
- Add content-type-based file suffix resolution with URL and default suffix fallback for streamed downloads.

Bug Fixes:
- Fix potential cache collisions and unstable filenames for dynamic URLs by hashing stable identifiers instead of raw URLs.
- Prevent stale cache metadata by validating cached file existence and cleaning up invalid entries.

Enhancements:
- Unify media download interfaces around cache_key parameters and remove manual filename handling from creators and parsers.
- Refactor m3u8 and AV merge workflows to use shared cache naming and FFmpeg helpers instead of bespoke ffmpeg probing logic.
- Ensure multiple callers awaiting the same download share a single task that returns the final cached file path.
- Add platform-specific stable cache keys across parsers (Weibo, Bilibili, Douyin, Kuaishou, Rednote, AcFun, Kugou, Kuwo, Netease, Heybox, Taptap, Hupu, Miyoushe, Doubao, QSMusic) to normalize media caching.
- Avoid unnecessary audio transcoding by detecting already-MP3 inputs before conversion.

</details>