### PR TITLE
feat(parse-more-seg): 支持解析`linuxdo`,`miyoushe`,`tieba`,`zlb`的引用、链接卡片和投票

### DIFF
--- a/src/nonebot_plugin_parser_lite/parsers/linuxdo/topic.py
+++ b/src/nonebot_plugin_parser_lite/parsers/linuxdo/topic.py
@@ -1,3 +1,5 @@
+from urllib.parse import urljoin
+
 from msgspec import Struct
 from msgspec.json import Decoder
 
@@ -27,7 +29,7 @@ class Post(Struct):
 
     @property
     def avatar_url(self) -> str:
-        return f"https://linux.do/{self.avatar_template.format(size=288)}"
+        return urljoin("https://linux.do/", self.avatar_template.format(size=288))
 
     @property
     def content(self):

--- a/src/nonebot_plugin_parser_lite/parsers/linuxdo/util.py
+++ b/src/nonebot_plugin_parser_lite/parsers/linuxdo/util.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from urllib.parse import urljoin
 
 from bs4 import BeautifulSoup
 from bs4.element import NavigableString, Tag
@@ -43,6 +44,18 @@ def _iter_media_and_text(soup: BeautifulSoup):
             else:
                 skip_parent = None
         if isinstance(element, Tag):
+            if element.name == "aside" and "quote" in (element.get("class") or []):
+                if quote := _parse_quote(element):
+                    yield quote
+                skip_parent = element
+                continue
+
+            if element.name == "aside" and "onebox" in (element.get("class") or []):
+                if link := _parse_onebox(element):
+                    yield link
+                skip_parent = element
+                continue
+
             if element.name == "span" and (
                 "filename" in (element.get("class") or [])
                 or "informations" in (element.get("class") or [])
@@ -56,7 +69,7 @@ def _iter_media_and_text(soup: BeautifulSoup):
 
             if element.name == "img":
                 if src := element.get("src"):
-                    src = str(src)
+                    src = urljoin("https://linux.do/", str(src))
                     classes = element.get("class") or []
                     if "emoji" in classes:
                         yield Creator.sticker(
@@ -76,6 +89,77 @@ def _iter_media_and_text(soup: BeautifulSoup):
         elif isinstance(element, NavigableString):
             if text := str(element).strip():
                 yield text
+
+
+def _parse_quote(aside: Tag):
+    """将 Discourse quote 映射为引用内容，并避免重复解析内部节点"""
+    title_link = aside.select_one(".quote-title__text-content a[href]")
+    blockquote = aside.find("blockquote")
+    icon = aside.select_one(".title img.avatar[src]")
+
+    title = title_link.get_text(" ", strip=True) if title_link else None
+    url = (
+        urljoin("https://linux.do/", str(title_link.get("href")))
+        if title_link
+        else None
+    )
+    text = ""
+    if blockquote:
+        text = "\n".join(
+            line.strip()
+            for line in blockquote.get_text("\n", strip=True).splitlines()
+            if line.strip()
+        )
+    if not any((title, url, text)):
+        return None
+
+    icon_url = urljoin("https://linux.do/", str(icon.get("src"))) if icon else None
+    return Creator.quote(
+        text=text,
+        title=title,
+        url=url,
+        icon_url=icon_url,
+        ext_headers={"Referer": "https://linux.do/"},
+        use_curl_cffi=True,
+        cache_key=f"linuxdo:quote:{url}" if url else None,
+    )
+
+
+def _parse_onebox(aside: Tag):
+    """将 Discourse onebox 映射为带摘要和图片的链接卡片"""
+    source_link = aside.select_one("header.source a[href]")
+    title_link = aside.select_one(".onebox-body h3 a[href]")
+    description = aside.select_one(".onebox-body p")
+    icon = aside.select_one("header.source img.site-icon[src]")
+    preview = aside.select_one(".onebox-body img.thumbnail[src]")
+
+    raw_url = aside.get("data-onebox-src")
+    if not raw_url and title_link:
+        raw_url = title_link.get("href")
+    if not raw_url and source_link:
+        raw_url = source_link.get("href")
+    if not raw_url:
+        return None
+
+    url = urljoin("https://linux.do/", str(raw_url))
+    title = title_link.get_text(" ", strip=True) if title_link else None
+    site_name = source_link.get_text(" ", strip=True) if source_link else None
+    description_text = description.get_text(" ", strip=True) if description else None
+    icon_url = urljoin("https://linux.do/", str(icon.get("src"))) if icon else None
+    preview_url = (
+        urljoin("https://linux.do/", str(preview.get("src"))) if preview else None
+    )
+    return Creator.link(
+        url=url,
+        title=title or site_name or url,
+        site_name=site_name,
+        description=description_text,
+        icon_url=icon_url,
+        preview_url=preview_url,
+        ext_headers={"Referer": "https://linux.do/"},
+        use_curl_cffi=True,
+        cache_key=f"linuxdo:onebox:{url}",
+    )
 
 
 def parse_date(s: str) -> int:

--- a/src/nonebot_plugin_parser_lite/parsers/miyoushe/structed_content.py
+++ b/src/nonebot_plugin_parser_lite/parsers/miyoushe/structed_content.py
@@ -28,6 +28,10 @@ class Video(Struct):
 class LinkCard(Struct):
     title: str
     origin_url: str
+    cover: str | None = None
+    card_id: str | None = None
+    origin_user_avatar: str | None = None
+    origin_user_nickname: str | None = None
 
 
 class CustomEmoticon(Struct):
@@ -76,8 +80,12 @@ def build_body(s: str):
         elif link := ins.link_card:
             content.append(
                 Creator.link(
-                    text=link.title,
+                    title=link.title,
                     url=link.origin_url,
+                    site_name=link.origin_user_nickname or "米游社",
+                    icon_url=link.origin_user_avatar or None,
+                    preview_url=link.cover,
+                    cache_key=f"miyoushe:link:{link.card_id or link.origin_url}",
                 )
             )
         elif url := ins.image:
@@ -94,7 +102,9 @@ def build_body(s: str):
             if bvid := qs.get("bvid"):
                 content.append(
                     Creator.link(
-                        url=f"https://www.bilibili.com/video/{bvid[0]}", text=bvid[0]
+                        url=f"https://www.bilibili.com/video/{bvid[0]}",
+                        title=bvid[0],
+                        site_name="哔哩哔哩",
                     )
                 )
 

--- a/src/nonebot_plugin_parser_lite/parsers/tieba/utils.py
+++ b/src/nonebot_plugin_parser_lite/parsers/tieba/utils.py
@@ -6,7 +6,7 @@ from google.protobuf.message_factory import GetMessageClass
 
 from ...constants import STICKER_CDN
 from ...creator import Creator
-from ...data import Comment, ContentItem
+from ...data import Comment, ContentItem, PollOption
 from ...download import DOWNLOADER
 from .models import (
     Contents,
@@ -156,6 +156,20 @@ def build_content(posts: Posts) -> list[ContentItem]:
         # elif isinstance(part, FragVoice):
         #     audio_task = DOWNLOADER.download_audio(part.md5, ext_headers=headers)
         #     contents.append(post.create_audio_content(audio_task, part.duration))
+
+    if vote := posts.thread.vote_info:
+        contents.append(
+            Creator.poll(
+                options=[
+                    PollOption(text=option.text, votes=option.vote_num)
+                    for option in vote.options
+                ],
+                title=vote.title,
+                total_votes=vote.total_vote,
+                total_voters=vote.total_user,
+                multiple=vote.is_multi,
+            )
+        )
 
     return contents
 

--- a/src/nonebot_plugin_parser_lite/parsers/zlb/topic.py
+++ b/src/nonebot_plugin_parser_lite/parsers/zlb/topic.py
@@ -1,10 +1,90 @@
-from msgspec import Struct
+from datetime import datetime
+from urllib.parse import urljoin
+
+from bs4 import BeautifulSoup
+from msgspec import Struct, field
 from msgspec.json import Decoder
 
 from ...creator import Creator
-from ...data import Comment
+from ...data import Comment, PollContent
+from ...data import PollOption as ContentPollOption
 from ...utils.format import format_num
 from .util import parse_date, parse_rich_content
+
+
+class EventTopic(Struct):
+    title: str
+
+
+class EventPost(Struct):
+    url: str
+    topic: EventTopic
+
+
+class Event(Struct):
+    name: str | None
+    starts_at: str
+    ends_at: str | None
+    timezone: str | None
+    post: EventPost
+
+    @property
+    def display_time(self) -> str:
+        start_at = datetime.fromisoformat(self.starts_at)
+        if self.ends_at:
+            end_at = datetime.fromisoformat(self.ends_at)
+            if start_at.date() == end_at.date():
+                value = f"{start_at:%Y-%m-%d %H:%M} - {end_at:%H:%M}"
+            else:
+                value = (
+                    f"{start_at:%Y-%m-%d %H:%M} - "
+                    f"{end_at:%Y-%m-%d %H:%M}"
+                )
+        else:
+            value = start_at.strftime("%Y-%m-%d %H:%M")
+        return f"{value} ({self.timezone})" if self.timezone else value
+
+    def create_link(self):
+        return Creator.link(
+            url=urljoin("https://bb.zlb.ink/", self.post.url),
+            title=self.name or self.post.topic.title,
+            site_name="壁吧专楼吧",
+            description=f"活动时间：{self.display_time}",
+        )
+
+
+class PollOption(Struct):
+    id: str
+    html: str
+    votes: int
+
+    @property
+    def text(self) -> str:
+        return BeautifulSoup(self.html, "html.parser").get_text(" ", strip=True)
+
+
+class Poll(Struct):
+    name: str
+    type: str
+    status: str
+    options: list[PollOption]
+    voters: int
+    title: str | None = None
+    close: str | None = None
+
+    def create_content(self) -> PollContent:
+        return Creator.poll(
+            options=[
+                ContentPollOption(text=item.text, votes=item.votes)
+                for item in self.options
+            ],
+            title=self.title,
+            total_votes=sum(item.votes for item in self.options),
+            total_voters=self.voters,
+            multiple=self.type == "multiple",
+            closed=self.status == "closed",
+            close_at=self.close,
+        )
 
 
 class Post(Struct):
@@ -20,6 +100,8 @@ class Post(Struct):
     """该post的回复数"""
     reaction_users_count: int
     """可以当成该post的点赞数"""
+    event: Event | None = None
+    polls: list[Poll] = field(default_factory=list)
 
     @property
     def timestamp(self) -> int:
@@ -27,11 +109,15 @@ class Post(Struct):
 
     @property
     def avatar_url(self) -> str:
-        return f"https://zlb.ink/{self.avatar_template.format(size=288)}"
+        return urljoin("https://zlb.ink/", self.avatar_template.format(size=288))
 
     @property
     def content(self):
-        return parse_rich_content(self.cooked)
+        return parse_rich_content(
+            self.cooked,
+            event_link=self.event.create_link() if self.event else None,
+            polls={poll.name: poll.create_content() for poll in self.polls},
+        )
 
 
 class PostStream(Struct):

--- a/src/nonebot_plugin_parser_lite/parsers/zlb/util.py
+++ b/src/nonebot_plugin_parser_lite/parsers/zlb/util.py
@@ -1,19 +1,29 @@
 from datetime import datetime
+from urllib.parse import urljoin
 
 from bs4 import BeautifulSoup
 from bs4.element import NavigableString, Tag
 
 from ...creator import Creator
-from ...data import ContentItem
+from ...data import ContentItem, LinkContent, PollContent
 
 
-def parse_rich_content(html: str) -> list[ContentItem]:
+def parse_rich_content(
+    html: str,
+    *,
+    event_link: LinkContent | None = None,
+    polls: dict[str, PollContent] | None = None,
+) -> list[ContentItem]:
     soup = BeautifulSoup(html, "html.parser")
 
     result: list[ContentItem] = []
     buffer: list[str] = []
 
-    for item in _iter_media_and_text(soup):
+    for item in _iter_media_and_text(
+        soup,
+        event_link=event_link,
+        polls=polls or {},
+    ):
         if isinstance(item, str):
             buffer.append(item)
         else:
@@ -34,7 +44,12 @@ def parse_rich_content(html: str) -> list[ContentItem]:
     return result
 
 
-def _iter_media_and_text(soup: BeautifulSoup):
+def _iter_media_and_text(
+    soup: BeautifulSoup,
+    *,
+    event_link: LinkContent | None,
+    polls: dict[str, PollContent],
+):
     skip_parent: Tag | None = None
     for element in soup.descendants:
         if skip_parent:
@@ -43,6 +58,33 @@ def _iter_media_and_text(soup: BeautifulSoup):
             else:
                 skip_parent = None
         if isinstance(element, Tag):
+            if element.name == "aside" and "quote" in (element.get("class") or []):
+                if quote := _parse_quote(element):
+                    yield quote
+                skip_parent = element
+                continue
+
+            if element.name == "aside" and "onebox" in (element.get("class") or []):
+                if link := _parse_onebox(element):
+                    yield link
+                skip_parent = element
+                continue
+
+            if element.name == "div" and "discourse-post-event" in (
+                element.get("class") or []
+            ):
+                if event_link:
+                    yield event_link
+                skip_parent = element
+                continue
+
+            if element.name == "div" and "poll" in (element.get("class") or []):
+                poll_name = str(element.get("data-poll-name") or "poll")
+                if poll := polls.get(poll_name):
+                    yield poll
+                skip_parent = element
+                continue
+
             if element.name == "span" and (
                 "filename" in (element.get("class") or [])
                 or "informations" in (element.get("class") or [])
@@ -56,12 +98,12 @@ def _iter_media_and_text(soup: BeautifulSoup):
 
             if element.name == "img":
                 if src := element.get("src"):
-                    src = str(src)
+                    src = urljoin("https://bb.zlb.ink/", str(src))
                     classes = element.get("class") or []
                     if "emoji" in classes:
                         yield Creator.sticker(
                             url=src,
-                            desc=element.get("alt", None), # pyright: ignore[reportArgumentType]
+                            desc=element.get("alt", None),  # pyright: ignore[reportArgumentType]
                             size="small",
                         )
                     else:
@@ -70,6 +112,73 @@ def _iter_media_and_text(soup: BeautifulSoup):
         elif isinstance(element, NavigableString):
             if text := str(element).strip():
                 yield text
+
+
+def _parse_quote(aside: Tag):
+    """将 Discourse quote 映射为引用内容，并避免重复解析内部节点"""
+    title_link = aside.select_one(".quote-title__text-content a[href]")
+    blockquote = aside.find("blockquote")
+    icon = aside.select_one(".title img.avatar[src]")
+
+    title = title_link.get_text(" ", strip=True) if title_link else None
+    url = (
+        urljoin("https://bb.zlb.ink/", str(title_link.get("href")))
+        if title_link
+        else None
+    )
+    text = ""
+    if blockquote:
+        text = "\n".join(
+            line.strip()
+            for line in blockquote.get_text("\n", strip=True).splitlines()
+            if line.strip()
+        )
+    if not any((title, url, text)):
+        return None
+
+    icon_url = urljoin("https://bb.zlb.ink/", str(icon.get("src"))) if icon else None
+    return Creator.quote(
+        text=text,
+        title=title,
+        url=url,
+        icon_url=icon_url,
+        cache_key=f"zlb:quote:{url}" if url else None,
+    )
+
+
+def _parse_onebox(aside: Tag):
+    """将 Discourse onebox 映射为带摘要和图片的链接卡片"""
+    source_link = aside.select_one("header.source a[href]")
+    title_link = aside.select_one(".onebox-body h3 a[href]")
+    description = aside.select_one(".onebox-body p")
+    icon = aside.select_one("header.source img.site-icon[src]")
+    preview = aside.select_one(".onebox-body img.thumbnail[src]")
+
+    raw_url = aside.get("data-onebox-src")
+    if not raw_url and title_link:
+        raw_url = title_link.get("href")
+    if not raw_url and source_link:
+        raw_url = source_link.get("href")
+    if not raw_url:
+        return None
+
+    url = urljoin("https://bb.zlb.ink/", str(raw_url))
+    title = title_link.get_text(" ", strip=True) if title_link else None
+    site_name = source_link.get_text(" ", strip=True) if source_link else None
+    description_text = description.get_text(" ", strip=True) if description else None
+    icon_url = urljoin("https://bb.zlb.ink/", str(icon.get("src"))) if icon else None
+    preview_url = (
+        urljoin("https://bb.zlb.ink/", str(preview.get("src"))) if preview else None
+    )
+    return Creator.link(
+        url=url,
+        title=title or site_name or url,
+        site_name=site_name,
+        description=description_text,
+        icon_url=icon_url,
+        preview_url=preview_url,
+        cache_key=f"zlb:onebox:{url}",
+    )
 
 
 def parse_date(s: str) -> int:


### PR DESCRIPTION
- 在linuxdo和zlb解析器中添加对Discourse quote和onebox元素的支持
- 实现quote引用内容的解析和展示
- 实现onebox链接卡片的解析，包含标题、描述、图标和预览图
- 添加对Discourse投票功能的支持，包括单选和多选投票
- 支持zlb论坛的活动事件和轮询功能解析
- 更新头像URL和图片资源URL的构建方式，使用urljoin确保正确路径
- 优化米游社链接卡片的数据结构，增加封面、用户头像等字段
- 优化贴吧投票功能的实现

## Summary by Sourcery

扩展针对 linuxdo、zlb、贴吧和米游社的论坛解析器，以支持丰富的 Discourse 风格引用、链接卡片、投票和活动内容，并改进链接卡片的元数据及媒体 URL 处理。

新功能：
- 在 linuxdo 和 zlb 帖子中支持将 Discourse 引用块解析为结构化的引用内容
- 在 linuxdo 和 zlb 帖子中支持解析带有元数据和预览图片的 Discourse onebox 链接卡片
- 在 zlb 主题中新增 Discourse 投票内容的解析和渲染，包括单选和多选投票
- 新增对 zlb 论坛活动帖的解析，并将其暴露为带有格式化时间信息的富链接内容
- 支持将贴吧的贴子投票信息作为投票内容进行渲染
- 增强米游社链接卡片解析能力，包含封面图、用户头像、昵称以及站点元数据

改进：
- 使用 `urljoin` 规范化 linuxdo 和 zlb 的头像及图片资源 URL，以确保正确的绝对路径

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Extend forum parsers for linuxdo, zlb, Tieba, and Miyoushe to handle rich Discourse-style quotes, link cards, polls, and events, and improve link card metadata and media URL handling.

New Features:
- Support parsing Discourse quote blocks as structured quote content in linuxdo and zlb posts
- Support parsing Discourse onebox link cards with metadata and preview images in linuxdo and zlb posts
- Add parsing and rendering of Discourse poll content, including single- and multiple-choice polls, in zlb topics
- Add parsing of zlb forum event posts and expose them as rich link content with formatted time information
- Support rendering Tieba thread voting information as poll content
- Enhance Miyoushe link card parsing to include cover image, user avatar, nickname, and site metadata

Enhancements:
- Normalize avatar and image resource URLs for linuxdo and zlb using urljoin to ensure correct absolute paths

</details>