### PR TITLE
feat(bilibili/video): 替换资源CDN以防分配到垃圾cdn

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,15 @@ plite_bili_video_codes=["avc", "av01", "hev", "unknown"]
 # 360p(16), 480p(32), 720p(64), 1080p(80), 1080p+(112), 1080p_60(116), 4k(120)
 plite_bili_video_quality=80
 
+# [可选] B 站下载 CDN 地区；地区列表会在启动时及每 24 小时在线更新
+# 可选地区见 https://kanda-akihito-kun.github.io/ccb/api/region.json
+# zh、en、ja 是无需在线列表也能使用的内置基础线路
+plite_bili_cdn_region="zh"
+
+# [可选] 自定义 B 站下载 CDN 域名，设置后优先于地区配置
+# 留空则使用地区配置；只接受 bilivideo.com 域名，不要包含协议、端口或路径
+plite_bili_cdn_domain=""
+
 # [可选] 音频解析，是否需要上传群文件
 plite_need_upload_audio=False
 

--- a/src/nonebot_plugin_parser_lite/__init__.py
+++ b/src/nonebot_plugin_parser_lite/__init__.py
@@ -1,4 +1,4 @@
-from nonebot import logger, require
+from nonebot import get_driver, logger, require
 from nonebot.plugin import PluginMetadata, inherit_supported_adapters
 
 require("nonebot_plugin_alconna")
@@ -11,6 +11,7 @@ from nonebot_plugin_apscheduler import scheduler
 
 from .config import Config
 from .matchers import clear_result_cache
+from .utils.bilibili.cdn import load_cdn_domains, update_cdn_domains
 from .utils.cache import CacheManager
 
 __plugin_meta__ = PluginMetadata(
@@ -42,3 +43,23 @@ async def clean_plugin_cache() -> None:
         logger.exception(f"清理缓存文件时发生异常: {e!r}")
 
     clear_result_cache()
+
+
+@scheduler.scheduled_job(
+    "interval",
+    hours=24,
+    id="parser-update-bilibili-cdn",
+)
+async def update_bilibili_cdn() -> None:
+    """刷新 B 站 CDN 地区列表"""
+    try:
+        await update_cdn_domains()
+    except Exception as e:
+        logger.warning(f"更新 B 站 CDN 列表失败，继续使用本地数据: {e}")
+
+
+@get_driver().on_startup
+async def initialize_bilibili_cdn() -> None:
+    """启动时先加载快照，再尝试在线更新"""
+    await load_cdn_domains()
+    await update_bilibili_cdn()

--- a/src/nonebot_plugin_parser_lite/config.py
+++ b/src/nonebot_plugin_parser_lite/config.py
@@ -81,6 +81,10 @@ class Config(BaseModel):
     """最大下载重试次数"""
     plite_day_range: list[str] = ["6:00", "19:00"]
     """白天时间范围 [开始, 结束]，格式 h:m；范围内为浅色主题，范围外为夜间模式"""
+    plite_bili_cdn_region: str = "zh"
+    """哔哩哔哩 CDN 地区；zh、en、ja 为内置基础线路"""
+    plite_bili_cdn_domain: str | None = None
+    """自定义哔哩哔哩 CDN 域名，优先于地区配置"""
 
     @property
     def nickname(self) -> str:
@@ -229,6 +233,16 @@ class Config(BaseModel):
             parse_hm_to_minutes(self.plite_day_range[0]),
             parse_hm_to_minutes(self.plite_day_range[1]),
         )
+
+    @property
+    def bili_cdn_region(self) -> str:
+        """哔哩哔哩 CDN 地区"""
+        return self.plite_bili_cdn_region
+
+    @property
+    def bili_cdn_domain(self) -> str | None:
+        """自定义哔哩哔哩 CDN 域名"""
+        return self.plite_bili_cdn_domain
 
 
 # 初始化配置实例

--- a/src/nonebot_plugin_parser_lite/parsers/bilibili/__init__.py
+++ b/src/nonebot_plugin_parser_lite/parsers/bilibili/__init__.py
@@ -950,6 +950,8 @@ class BilibiliParser(BaseParser):
             codecs=pconfig.bili_video_codes,
             no_dolby_video=True,
             no_hdr=True,
+            cdn_region=pconfig.bili_cdn_region,
+            cdn_domain=pconfig.bili_cdn_domain,
         )
         video_stream = streams[0]
         if video_stream is None:

--- a/src/nonebot_plugin_parser_lite/utils/bilibili/cdn.py
+++ b/src/nonebot_plugin_parser_lite/utils/bilibili/cdn.py
@@ -1,0 +1,120 @@
+import json
+from random import choice
+import re
+from typing import Final
+
+from anyio import Path
+from nonebot import logger
+import nonebot_plugin_localstore as store
+
+from .client import CLIENT
+
+CDN_DATA_URL: Final[str] = "https://kanda-akihito-kun.github.io/ccb/api/cdn.json"
+CDN_DATA_PATH: Final[Path] = Path(store.get_plugin_data_dir()) / "bilibili_cdn.json"
+
+# 在线列表不可用时仍可使用的稳定官方镜像。
+DEFAULT_CDN_DOMAINS: Final[dict[str, tuple[str, ...]]] = {
+    "zh": ("upos-sz-mirrorcos.bilivideo.com",),
+    "en": ("upos-sz-mirroraliov.bilivideo.com",),
+    "ja": ("upos-sz-mirroralib.bilivideo.com",),
+}
+_HOST_PATTERN = re.compile(
+    r"^(?=.{1,253}$)(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z]{2,63}$",
+    re.IGNORECASE,
+)
+_cdn_domains: dict[str, tuple[str, ...]] = dict(DEFAULT_CDN_DOMAINS)
+
+
+def _is_bilivideo_domain(domain: str) -> bool:
+    domain = domain.lower()
+    return domain == "bilivideo.com" or domain.endswith(".bilivideo.com")
+
+
+def _validate_cdn_data(data: object) -> dict[str, tuple[str, ...]]:
+    if not isinstance(data, dict):
+        raise ValueError("CDN 数据必须是对象")
+
+    result: dict[str, tuple[str, ...]] = {}
+    for region, domains in data.items():
+        if not isinstance(region, str) or not region.strip():
+            raise ValueError("CDN 地区名称无效")
+        if not isinstance(domains, list) or not domains:
+            raise ValueError(f"CDN 地区 {region!r} 没有可用域名")
+
+        normalized_domains: list[str] = []
+        seen_domains: set[str] = set()
+        for domain in domains:
+            if not isinstance(domain, str):
+                continue
+            try:
+                normalized_domain = normalize_cdn_domain(domain)
+            except ValueError:
+                continue
+            if normalized_domain not in seen_domains:
+                normalized_domains.append(normalized_domain)
+                seen_domains.add(normalized_domain)
+        if normalized_domains:
+            result[region.strip()] = tuple(normalized_domains)
+
+    if not result:
+        raise ValueError("CDN 数据为空")
+    return result
+
+
+def normalize_cdn_domain(domain: str) -> str:
+    """校验并规范化不含协议、端口或路径的 CDN 域名"""
+    normalized_domain = domain.strip().lower()
+    if not _HOST_PATTERN.fullmatch(normalized_domain) or not _is_bilivideo_domain(
+        normalized_domain
+    ):
+        raise ValueError(f"无效的 B 站 CDN 域名: {domain!r}")
+    return normalized_domain
+
+
+def _set_cdn_domains(data: object) -> None:
+    global _cdn_domains
+    _cdn_domains = {**DEFAULT_CDN_DOMAINS, **_validate_cdn_data(data)}
+
+
+async def load_cdn_domains(path: Path = CDN_DATA_PATH) -> bool:
+    """从 data 目录加载 CDN 快照，失败时保留当前列表"""
+    if not await path.is_file():
+        return False
+    try:
+        _set_cdn_domains(json.loads(await path.read_text(encoding="utf-8")))
+    except (OSError, ValueError, json.JSONDecodeError) as e:
+        logger.warning(f"加载 B 站 CDN 列表失败: {e}")
+        return False
+    return True
+
+
+def choose_cdn_domain(region: str) -> str:
+    """从指定地区随机选择 CDN；在线地区与基础线路使用同一入口"""
+    try:
+        return choice(_cdn_domains[region])
+    except KeyError:
+        available_regions = ", ".join(_cdn_domains)
+        raise ValueError(
+            f"未知的 B 站 CDN 地区 {region!r}，可选：{available_regions}"
+        ) from None
+
+
+async def update_cdn_domains(path: Path = CDN_DATA_PATH) -> None:
+    """下载 CDN 列表并原子更新 data 目录中的快照"""
+    response = await CLIENT.get(CDN_DATA_URL)
+    response.raise_for_status()
+    data = response.json()
+    validated_data = _validate_cdn_data(data)
+
+    await path.parent.mkdir(parents=True, exist_ok=True)
+    temporary_path = path.with_suffix(f"{path.suffix}.tmp")
+    await temporary_path.write_text(
+        json.dumps(validated_data, ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+    await temporary_path.replace(path)
+    _set_cdn_domains(data)
+    logger.info(
+        f"已更新 B 站 CDN 列表: {len(validated_data)} 个地区，"
+        f"{sum(map(len, validated_data.values()))} 个域名"
+    )

--- a/src/nonebot_plugin_parser_lite/utils/bilibili/video.py
+++ b/src/nonebot_plugin_parser_lite/utils/bilibili/video.py
@@ -1,7 +1,8 @@
 from dataclasses import dataclass
 from enum import Enum, IntEnum
 import re
-from typing import Any
+from typing import Any, Final
+from urllib.parse import urlsplit
 
 from yarl import URL
 
@@ -10,6 +11,13 @@ from .client import CLIENT
 from .credential import Credential
 from .exceptions import BiliHelperException
 from .sign import encWbi, getWbiKeys
+
+OFFICIAL_CDN_DOMAIN: Final[dict[str, str]] = {
+    "zh": "upos-sz-mirrorcos.bilivideo.com",
+    "en": "upos-sz-mirroraliov.bilivideo.com",
+    "ja": "upos-sz-mirroralib.bilivideo.com",
+}
+REPLACE_CDN_DOMAIN = OFFICIAL_CDN_DOMAIN["zh"]
 
 
 class BiliVideoQuality(IntEnum):
@@ -378,66 +386,30 @@ def sanitize_stream_urls(
 
     1. 若 base_url 为 PCDN，则优先使用 backup_url 中第一个非 PCDN 链接；
     2. 若 backup_url 里也没有非 PCDN，则保留原 base_url (真倒霉)
+    3. PCDN 清洗完成后，统一替换主链接与备用链接的 CDN
 
     :param video: 视频流 URL 信息
     :param audio: 音频流 URL 信息
     :return: (清洗后的 video, audio)
     """
 
-    def _sanitize_video(
-        v: VideoStreamDownloadURL | FLVStreamDownloadURL | MP4StreamDownloadURL | None,
-    ):
-        if v is None:
-            return None
+    def _replace_host(url: str) -> str:
+        return urlsplit(url)._replace(netloc=REPLACE_CDN_DOMAIN).geturl()
 
-        base_url = v.url
-        backups = v.backup_url
+    for stream in (video, audio):
+        if stream is None:
+            continue
 
-        # 如果主 URL 不是 PCDN，则优先使用它
-        if not is_pcdn_url(base_url):
-            return v
+        if is_pcdn_url(stream.url):
+            clean_backups = [url for url in stream.backup_url if not is_pcdn_url(url)]
+            if clean_backups:
+                stream.url = clean_backups[0]
+                stream.backup_url = clean_backups[1:]
 
-        # 主 URL 是 PCDN，尝试从 backup_url 里找干净的替换
-        clean_backups = [u for u in backups if not is_pcdn_url(u)]
-        if clean_backups:
-            new_base = clean_backups[0]
-            rest_backups = clean_backups[1:]
-            if isinstance(v, VideoStreamDownloadURL):
-                return VideoStreamDownloadURL(
-                    url=new_base,
-                    video_quality=v.video_quality,
-                    video_codecs=v.video_codecs,
-                    backup_url=rest_backups,
-                )
-            if isinstance(v, FLVStreamDownloadURL):
-                return FLVStreamDownloadURL(url=new_base, backup_url=rest_backups)
-            return MP4StreamDownloadURL(url=new_base, backup_url=rest_backups)
+        stream.url = _replace_host(stream.url)
+        stream.backup_url = [_replace_host(url) for url in stream.backup_url]
 
-        return v
-
-    def _sanitize_audio(a: AudioStreamDownloadURL | None):
-        if a is None:
-            return None
-
-        base_url = a.url
-        backups = a.backup_url
-
-        if not is_pcdn_url(base_url):
-            return a
-
-        clean_backups = [u for u in backups if not is_pcdn_url(u)]
-        if clean_backups:
-            new_base = clean_backups[0]
-            rest_backups = clean_backups[1:]
-            return AudioStreamDownloadURL(
-                url=new_base,
-                audio_quality=a.audio_quality,
-                backup_url=rest_backups,
-            )
-
-        return a
-
-    return _sanitize_video(video), _sanitize_audio(audio)
+    return video, audio
 
 
 class VideoDownloadURLDataDetecter:
@@ -519,8 +491,7 @@ class VideoDownloadURLDataDetecter:
                     backup_url=backup_url,
                 )
 
-            video_stream, _ = sanitize_stream_urls(video_stream, None)
-            return video_stream, None
+            return sanitize_stream_urls(video_stream, None)
 
         # DASH 正常情况
         videos_data = self.__data["dash"]["video"]
@@ -645,6 +616,4 @@ class VideoDownloadURLDataDetecter:
         best_video = max(video_streams, key=video_score) if video_streams else None
         best_audio = max(audio_streams, key=audio_score) if audio_streams else None
 
-        # 清洗 PCDN URL，尽量替换为正规 CDN
-        best_video, best_audio = sanitize_stream_urls(best_video, best_audio)
-        return best_video, best_audio
+        return sanitize_stream_urls(best_video, best_audio)

--- a/src/nonebot_plugin_parser_lite/utils/bilibili/video.py
+++ b/src/nonebot_plugin_parser_lite/utils/bilibili/video.py
@@ -1,23 +1,17 @@
 from dataclasses import dataclass
 from enum import Enum, IntEnum
 import re
-from typing import Any, Final
+from typing import Any
 from urllib.parse import urlsplit
 
 from yarl import URL
 
 from .a2v import av2bv, bv2av
+from .cdn import choose_cdn_domain, normalize_cdn_domain
 from .client import CLIENT
 from .credential import Credential
 from .exceptions import BiliHelperException
 from .sign import encWbi, getWbiKeys
-
-OFFICIAL_CDN_DOMAIN: Final[dict[str, str]] = {
-    "zh": "upos-sz-mirrorcos.bilivideo.com",
-    "en": "upos-sz-mirroraliov.bilivideo.com",
-    "ja": "upos-sz-mirroralib.bilivideo.com",
-}
-REPLACE_CDN_DOMAIN = OFFICIAL_CDN_DOMAIN["zh"]
 
 
 class BiliVideoQuality(IntEnum):
@@ -375,6 +369,9 @@ class MP4StreamDownloadURL:
 def sanitize_stream_urls(
     video: VideoStreamDownloadURL | FLVStreamDownloadURL | MP4StreamDownloadURL | None,
     audio: AudioStreamDownloadURL | None,
+    *,
+    cdn_region: str = "zh",
+    cdn_domain: str | None = None,
 ) -> tuple[
     VideoStreamDownloadURL | FLVStreamDownloadURL | MP4StreamDownloadURL | None,
     AudioStreamDownloadURL | None,
@@ -390,12 +387,10 @@ def sanitize_stream_urls(
 
     :param video: 视频流 URL 信息
     :param audio: 音频流 URL 信息
+    :param cdn_region: CDN 地区；在线列表不可用时仍可使用 zh、en、ja
+    :param cdn_domain: 自定义 CDN 域名，设置后优先于地区配置
     :return: (清洗后的 video, audio)
     """
-
-    def _replace_host(url: str) -> str:
-        return urlsplit(url)._replace(netloc=REPLACE_CDN_DOMAIN).geturl()
-
     for stream in (video, audio):
         if stream is None:
             continue
@@ -406,6 +401,16 @@ def sanitize_stream_urls(
                 stream.url = clean_backups[0]
                 stream.backup_url = clean_backups[1:]
 
+    replacement_domain = (
+        normalize_cdn_domain(cdn_domain) if cdn_domain and cdn_domain.strip() else None
+    ) or choose_cdn_domain(cdn_region)
+
+    def _replace_host(url: str) -> str:
+        return urlsplit(url)._replace(netloc=replacement_domain).geturl()
+
+    for stream in (video, audio):
+        if stream is None:
+            continue
         stream.url = _replace_host(stream.url)
         stream.backup_url = [_replace_host(url) for url in stream.backup_url]
 
@@ -442,6 +447,8 @@ class VideoDownloadURLDataDetecter:
         no_dolby_audio: bool = False,
         no_hdr: bool = False,
         no_hires: bool = False,
+        cdn_region: str = "zh",
+        cdn_domain: str | None = None,
     ) -> tuple[
         VideoStreamDownloadURL | FLVStreamDownloadURL | MP4StreamDownloadURL | None,
         AudioStreamDownloadURL | None,
@@ -463,6 +470,9 @@ class VideoDownloadURLDataDetecter:
         :param no_dolby_audio: 是否禁用杜比音频流
         :param no_hdr: 是否禁用 HDR 视频流
         :param no_hires: 是否禁用 Hi-Res 音频流
+        :param cdn_region: CDN 地区
+        :param cdn_domain: 自定义 CDN 域名，设置后优先于地区配置
+
         :return: (最佳视频流, 最佳音频流)，若不存在则对应位置为 `None`
         """  # noqa: E501
         if video_accepted_qualities is None:
@@ -491,7 +501,12 @@ class VideoDownloadURLDataDetecter:
                     backup_url=backup_url,
                 )
 
-            return sanitize_stream_urls(video_stream, None)
+            return sanitize_stream_urls(
+                video_stream,
+                None,
+                cdn_region=cdn_region,
+                cdn_domain=cdn_domain,
+            )
 
         # DASH 正常情况
         videos_data = self.__data["dash"]["video"]
@@ -616,4 +631,9 @@ class VideoDownloadURLDataDetecter:
         best_video = max(video_streams, key=video_score) if video_streams else None
         best_audio = max(audio_streams, key=audio_score) if audio_streams else None
 
-        return sanitize_stream_urls(best_video, best_audio)
+        return sanitize_stream_urls(
+            best_video,
+            best_audio,
+            cdn_region=cdn_region,
+            cdn_domain=cdn_domain,
+        )


### PR DESCRIPTION
- 添加官方CDN域名配置字典用于URL标准化
- 重构sanitize_stream_urls函数，简化PCDN清洗逻辑
- 统一替换主链接与备用链接的CDN域名为指定域名
- 移除冗余的音频流处理逻辑，直接复用视频流处理
- 在多个位置统一调用URL清洗函数以确保一致性
- resolve #263

## Summary by Sourcery

通过清理 PCDN 链接并强制使用已配置的官方 CDN 域名，规范化 Bilibili 视频/音频流的 URL。

New Features:
- 引入可配置的官方 Bilibili CDN 域名映射，以及用于流媒体 URL 的默认替换域名。

Enhancements:
- 将视频和音频流的净化逻辑统一到单一路径中，复用相同的 URL 清理和 CDN 替换行为。
- 确保所有选定的最佳流在返回给调用方之前都经过 URL 净化步骤。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Normalize Bilibili video/audio stream URLs by cleaning PCDN links and forcing use of configured official CDN domains.

New Features:
- Introduce a configurable mapping of official Bilibili CDN domains and a default replacement domain for stream URLs.

Enhancements:
- Unify video and audio stream sanitization logic into a single path that reuses the same URL cleaning and CDN replacement behavior.
- Ensure all selected best streams are passed through the URL sanitization step before being returned to callers.

</details>