### PR TITLE
feat(x-link): 支持解析 x 的链接卡片和文章

### DIFF
--- a/api_txt/x/link_card.json
+++ b/api_txt/x/link_card.json
@@ -1,0 +1,15666 @@
+{
+  "code": 100000,
+  "data": {
+    "data": {
+      "threaded_conversation_with_injections_v2": {
+        "instructions": [
+          {
+            "type": "TimelineClearCache"
+          },
+          {
+            "entries": [
+              {
+                "content": {
+                  "__typename": "TimelineTimelineItem",
+                  "clientEventInfo": {
+                    "component": "tweet",
+                    "element": "tweet"
+                  },
+                  "entryType": "TimelineTimelineItem",
+                  "itemContent": {
+                    "__typename": "TimelineTweet",
+                    "itemType": "TimelineTweet",
+                    "tweetDisplayType": "Tweet",
+                    "tweet_results": {
+                      "result": {
+                        "__typename": "Tweet",
+                        "card": {
+                          "legacy": {
+                            "binding_values": [
+                              {
+                                "key": "unified_card",
+                                "value": {
+                                  "string_value": "{\"type\":\"image_website\",\"component_objects\":{\"details_1\":{\"type\":\"details\",\"data\":{\"title\":{\"content\":\"Click the image to start\",\"is_rtl\":false},\"subtitle\":{\"content\":\"belugacpn.jp\",\"is_rtl\":false},\"destination\":\"browser_1\"}},\"media_1\":{\"type\":\"media\",\"data\":{\"id\":\"3_2087446329450774528\",\"destination\":\"browser_1\"}}},\"destination_objects\":{\"browser_1\":{\"type\":\"browser\",\"data\":{\"url_data\":{\"url\":\"https://hoyo.link/dBGbcVp14\",\"vanity\":\"belugacpn.jp\"}}}},\"components\":[\"media_1\",\"details_1\"],\"media_entities\":{\"3_2087446329450774528\":{\"id\":2087446329450774528,\"id_str\":\"2087446329450774528\",\"indices\":[0,0],\"media_url\":\"\",\"media_url_https\":\"https://pbs.twimg.com/media/HPgZYHqbQAA5dhu.jpg\",\"url\":\"\",\"display_url\":\"\",\"expanded_url\":\"\",\"type\":\"photo\",\"original_info\":{\"width\":1080,\"height\":1080,\"focus_rects\":[{\"x\":0,\"y\":475,\"h\":605,\"w\":1080},{\"x\":0,\"y\":0,\"h\":1080,\"w\":1080},{\"x\":133,\"y\":0,\"h\":1080,\"w\":947},{\"x\":540,\"y\":0,\"h\":1080,\"w\":540},{\"x\":0,\"y\":0,\"h\":1080,\"w\":1080}]},\"sizes\":{\"medium\":{\"w\":1080,\"h\":1080,\"resize\":\"fit\"},\"thumb\":{\"w\":150,\"h\":150,\"resize\":\"crop\"},\"small\":{\"w\":680,\"h\":680,\"resize\":\"fit\"},\"large\":{\"w\":1080,\"h\":1080,\"resize\":\"fit\"}},\"source_user_id\":1072404907230060544,\"source_user_id_str\":\"1072404907230060544\",\"media_key\":\"3_2087446329450774528\",\"ext\":{\"mediaColor\":{\"r\":{\"ok\":{\"palette\":[{\"rgb\":{\"red\":216,\"green\":234,\"blue\":248},\"percentage\":52.36},{\"rgb\":{\"red\":126,\"green\":166,\"blue\":225},\"percentage\":15.55},{\"rgb\":{\"red\":56,\"green\":69,\"blue\":144},\"percentage\":8.86},{\"rgb\":{\"red\":225,\"green\":214,\"blue\":198},\"percentage\":4.06},{\"rgb\":{\"red\":216,\"green\":133,\"blue\":214},\"percentage\":3.73}]}},\"ttl\":-1}}}}}",
+                                  "type": "STRING"
+                                }
+                              },
+                              {
+                                "key": "card_url",
+                                "value": {
+                                  "scribe_key": "card_url",
+                                  "string_value": "https://twitter.com",
+                                  "type": "STRING"
+                                }
+                              }
+                            ],
+                            "card_platform": {
+                              "platform": {
+                                "audience": {
+                                  "name": "production"
+                                },
+                                "device": {
+                                  "name": "Android",
+                                  "version": "12"
+                                }
+                              }
+                            },
+                            "name": "unified_card",
+                            "url": "card://2087448100843753472",
+                            "user_refs_results": []
+                          },
+                          "rest_id": "card://2087448100843753472"
+                        },
+                        "core": {
+                          "user_results": {
+                            "result": {
+                              "__typename": "User",
+                              "affiliates_highlighted_label": {},
+                              "avatar": {
+                                "image_url": "https://pbs.twimg.com/profile_images/1980836599026868224/crCidubz_normal.jpg"
+                              },
+                              "core": {
+                                "created_at": "Tue Dec 11 08:17:08 +0000 2018",
+                                "name": "Genshin Impact",
+                                "screen_name": "GenshinImpact"
+                              },
+                              "dm_permissions": {
+                                "can_dm": false
+                              },
+                              "follow_request_sent": false,
+                              "has_graduated_access": true,
+                              "id": "VXNlcjoxMDcyNDA0OTA3MjMwMDYwNTQ0",
+                              "is_blue_verified": true,
+                              "legacy": {
+                                "default_profile": false,
+                                "default_profile_image": false,
+                                "description": "In the world of Teyvat — where all kinds of elemental powers constantly surge — epic adventures await, fearless Travelers! #GenshinImpact",
+                                "entities": {
+                                  "description": {},
+                                  "url": {
+                                    "urls": [
+                                      {
+                                        "display_url": "hoyo.link/0jhgFBAL",
+                                        "expanded_url": "https://hoyo.link/0jhgFBAL",
+                                        "indices": [0, 23],
+                                        "url": "https://t.co/e8FHL9LZrQ"
+                                      }
+                                    ]
+                                  }
+                                },
+                                "fast_followers_count": 0,
+                                "favourites_count": 359,
+                                "follow_request_sent": false,
+                                "followers_count": 5625754,
+                                "friends_count": 18,
+                                "has_custom_timelines": true,
+                                "is_translator": false,
+                                "listed_count": 7339,
+                                "media_count": 4953,
+                                "needs_phone_verification": false,
+                                "normal_followers_count": 5625754,
+                                "notifications": false,
+                                "pinned_tweet_ids_str": ["2087720798354395293"],
+                                "possibly_sensitive": false,
+                                "profile_banner_url": "https://pbs.twimg.com/profile_banners/1072404907230060544/1786503123",
+                                "profile_interstitial_type": "",
+                                "statuses_count": 7400,
+                                "time_zone": "",
+                                "translator_type": "none",
+                                "url": "https://t.co/e8FHL9LZrQ",
+                                "utc_offset": 0,
+                                "want_retweets": false,
+                                "withheld_description": "",
+                                "withheld_scope": ""
+                              },
+                              "location": {
+                                "location": ""
+                              },
+                              "media_permissions": {
+                                "can_media_tag": true
+                              },
+                              "parody_commentary_fan_label": "None",
+                              "privacy": {
+                                "protected": false
+                              },
+                              "professional": {
+                                "category": [
+                                  {
+                                    "icon_name": "",
+                                    "id": 15,
+                                    "name": "Entertainment & Recreation"
+                                  }
+                                ],
+                                "professional_type": "Business",
+                                "rest_id": "1560122792078876672"
+                              },
+                              "profile_bio": {
+                                "description": "In the world of Teyvat — where all kinds of elemental powers constantly surge — epic adventures await, fearless Travelers! #GenshinImpact"
+                              },
+                              "profile_description_language": "en",
+                              "profile_image_shape": "Square",
+                              "relationship_perspectives": {
+                                "blocked_by": false,
+                                "blocking": false,
+                                "followed_by": false,
+                                "following": false,
+                                "muting": false
+                              },
+                              "rest_id": "1072404907230060544",
+                              "super_follow_eligible": false,
+                              "super_followed_by": false,
+                              "super_following": false,
+                              "verification": {
+                                "verified": false,
+                                "verified_type": "Business"
+                              }
+                            }
+                          }
+                        },
+                        "edit_control": {
+                          "edit_tweet_ids": ["2087720798702498234"],
+                          "editable_until_msecs": "1786590001000",
+                          "edits_remaining": "5",
+                          "is_edit_eligible": false
+                        },
+                        "grok_analysis_button": true,
+                        "grok_annotations": {
+                          "is_image_editable_by_grok": true
+                        },
+                        "has_birdwatch_notes": false,
+                        "is_translatable": false,
+                        "legacy": {
+                          "bookmark_count": 3849,
+                          "bookmarked": false,
+                          "conversation_id_str": "2087720798702498234",
+                          "created_at": "Thu Aug 13 02:00:01 +0000 2026",
+                          "display_text_range": [0, 254],
+                          "entities": {},
+                          "favorite_count": 19397,
+                          "favorited": false,
+                          "full_text": "Event Now Available\nDedicate yourself to the great cause of Snezhnaya through valuable work!\nTake part in the SnezhnayaCareerTest, share your results to earn Primogems and get a chance to win Intertwined Fate rewards.\n\n↓ Click the image to start the test",
+                          "id_str": "2087720798702498234",
+                          "is_quote_status": false,
+                          "lang": "en",
+                          "quote_count": 133,
+                          "reply_count": 639,
+                          "retweet_count": 1173,
+                          "retweeted": false,
+                          "scopes": {
+                            "followers": false
+                          },
+                          "user_id_str": "1072404907230060544"
+                        },
+                        "quick_promote_eligibility": {
+                          "eligibility": "IneligibleNotVerified"
+                        },
+                        "rest_id": "2087720798702498234",
+                        "source": "<a href=\"https://help.twitter.com/en/using-twitter/how-to-tweet#source-labels\" rel=\"nofollow\">Ads Manager Next</a>",
+                        "unmention_data": {},
+                        "views": {
+                          "count": "5946068",
+                          "state": "EnabledWithCount"
+                        }
+                      }
+                    }
+                  }
+                },
+                "entryId": "tweet-2087720798702498234",
+                "sortIndex": "2088929116056190976"
+              },
+              {
+                "content": {
+                  "__typename": "TimelineTimelineModule",
+                  "clientEventInfo": {
+                    "component": "tweet",
+                    "details": {
+                      "conversationDetails": {
+                        "conversationSection": "HighQuality"
+                      },
+                      "timelinesDetails": {
+                        "controllerData": "DAACDAAEDAABCgABAAAAAAAAAAEKAAIAAAAAAAAAAAoAAwAAAaAKBN5LAAAAAA=="
+                      }
+                    }
+                  },
+                  "displayType": "VerticalConversation",
+                  "entryType": "TimelineTimelineModule",
+                  "items": [
+                    {
+                      "entryId": "conversationthread-2088927711515578819-tweet-2088927711515578819",
+                      "item": {
+                        "clientEventInfo": {
+                          "component": "tweet",
+                          "details": {
+                            "conversationDetails": {
+                              "conversationSection": "HighQuality"
+                            },
+                            "timelinesDetails": {
+                              "controllerData": "DAACDAAEDAABCgABAAAAAAAAAAEKAAIAAAAAAAAAAAoAAwAAAaAKBN5LAAAAAA=="
+                            }
+                          },
+                          "element": "tweet"
+                        },
+                        "itemContent": {
+                          "__typename": "TimelineTweet",
+                          "itemType": "TimelineTweet",
+                          "tweetDisplayType": "Tweet",
+                          "tweet_results": {
+                            "result": {
+                              "__typename": "Tweet",
+                              "core": {
+                                "user_results": {
+                                  "result": {
+                                    "__typename": "User",
+                                    "affiliates_highlighted_label": {},
+                                    "avatar": {
+                                      "image_url": "https://pbs.twimg.com/profile_images/2008296166338015232/e6Gzqvke_normal.jpg"
+                                    },
+                                    "core": {
+                                      "created_at": "Fri Sep 05 11:25:39 +0000 2025",
+                                      "name": "Breza Gani",
+                                      "screen_name": "RazakanR"
+                                    },
+                                    "dm_permissions": {
+                                      "can_dm": false
+                                    },
+                                    "follow_request_sent": false,
+                                    "has_graduated_access": true,
+                                    "id": "VXNlcjoxOTYzOTI2NDQ3MzYzNjk4Njg4",
+                                    "is_blue_verified": false,
+                                    "legacy": {
+                                      "default_profile": true,
+                                      "default_profile_image": false,
+                                      "description": "i'am a guy 20 yo",
+                                      "entities": {
+                                        "description": {}
+                                      },
+                                      "fast_followers_count": 0,
+                                      "favourites_count": 106,
+                                      "follow_request_sent": false,
+                                      "followers_count": 1,
+                                      "friends_count": 49,
+                                      "has_custom_timelines": false,
+                                      "is_translator": false,
+                                      "listed_count": 0,
+                                      "media_count": 6,
+                                      "needs_phone_verification": false,
+                                      "normal_followers_count": 1,
+                                      "notifications": false,
+                                      "possibly_sensitive": false,
+                                      "profile_banner_url": "",
+                                      "profile_interstitial_type": "",
+                                      "statuses_count": 70,
+                                      "time_zone": "",
+                                      "translator_type": "none",
+                                      "url": "",
+                                      "utc_offset": 0,
+                                      "want_retweets": false,
+                                      "withheld_description": "",
+                                      "withheld_scope": ""
+                                    },
+                                    "location": {
+                                      "location": ""
+                                    },
+                                    "media_permissions": {
+                                      "can_media_tag": true
+                                    },
+                                    "parody_commentary_fan_label": "None",
+                                    "privacy": {
+                                      "protected": false
+                                    },
+                                    "profile_bio": {
+                                      "description": "i'am a guy 20 yo"
+                                    },
+                                    "profile_description_language": "en",
+                                    "profile_image_shape": "Circle",
+                                    "relationship_perspectives": {
+                                      "blocked_by": false,
+                                      "blocking": false,
+                                      "followed_by": false,
+                                      "following": false,
+                                      "muting": false
+                                    },
+                                    "rest_id": "1963926447363698688",
+                                    "super_follow_eligible": false,
+                                    "super_followed_by": false,
+                                    "super_following": false,
+                                    "verification": {
+                                      "verified": false
+                                    }
+                                  }
+                                }
+                              },
+                              "edit_control": {
+                                "edit_tweet_ids": ["2088927711515578819"],
+                                "editable_until_msecs": "1786877751000",
+                                "edits_remaining": "5",
+                                "is_edit_eligible": false
+                              },
+                              "grok_analysis_button": true,
+                              "grok_annotations": {},
+                              "has_birdwatch_notes": false,
+                              "is_translatable": false,
+                              "legacy": {
+                                "bookmark_count": 0,
+                                "bookmarked": false,
+                                "conversation_id_str": "2087720798702498234",
+                                "created_at": "Sun Aug 16 09:55:51 +0000 2026",
+                                "display_text_range": [15, 42],
+                                "entities": {
+                                  "media": [
+                                    {
+                                      "display_url": "pic.x.com/AewjbTQ4DY",
+                                      "expanded_url": "https://x.com/RazakanR/status/2088927711515578819/photo/1",
+                                      "ext_media_availability": {
+                                        "status": "Available"
+                                      },
+                                      "features": {
+                                        "large": {
+                                          "faces": []
+                                        },
+                                        "medium": {
+                                          "faces": []
+                                        },
+                                        "orig": {
+                                          "faces": []
+                                        },
+                                        "small": {
+                                          "faces": []
+                                        }
+                                      },
+                                      "id_str": "2088927703932252160",
+                                      "indices": [43, 66],
+                                      "media_key": "3_2088927703932252160",
+                                      "media_results": {
+                                        "result": {
+                                          "media_key": "3_2088927703932252160"
+                                        }
+                                      },
+                                      "media_url_https": "https://pbs.twimg.com/media/HP1crdpasAAQW7s.jpg",
+                                      "original_info": {
+                                        "focus_rects": [
+                                          {
+                                            "h": 685,
+                                            "w": 1224,
+                                            "x": 0,
+                                            "y": 1139
+                                          },
+                                          {
+                                            "h": 1224,
+                                            "w": 1224,
+                                            "x": 0,
+                                            "y": 869
+                                          },
+                                          {
+                                            "h": 1395,
+                                            "w": 1224,
+                                            "x": 0,
+                                            "y": 784
+                                          },
+                                          {
+                                            "h": 2448,
+                                            "w": 1224,
+                                            "x": 0,
+                                            "y": 134
+                                          },
+                                          {
+                                            "h": 2582,
+                                            "w": 1224,
+                                            "x": 0,
+                                            "y": 0
+                                          }
+                                        ],
+                                        "height": 2582,
+                                        "width": 1224
+                                      },
+                                      "sizes": {
+                                        "large": {
+                                          "h": 2048,
+                                          "resize": "fit",
+                                          "w": 971
+                                        },
+                                        "medium": {
+                                          "h": 1200,
+                                          "resize": "fit",
+                                          "w": 569
+                                        },
+                                        "small": {
+                                          "h": 680,
+                                          "resize": "fit",
+                                          "w": 322
+                                        },
+                                        "thumb": {
+                                          "h": 150,
+                                          "resize": "crop",
+                                          "w": 150
+                                        }
+                                      },
+                                      "type": "photo",
+                                      "url": "https://t.co/AewjbTQ4DY"
+                                    }
+                                  ],
+                                  "user_mentions": [
+                                    {
+                                      "id_str": "1072404907230060544",
+                                      "indices": [0, 14],
+                                      "name": "Genshin Impact",
+                                      "screen_name": "GenshinImpact"
+                                    }
+                                  ]
+                                },
+                                "extended_entities": {
+                                  "media": [
+                                    {
+                                      "display_url": "pic.x.com/AewjbTQ4DY",
+                                      "expanded_url": "https://x.com/RazakanR/status/2088927711515578819/photo/1",
+                                      "ext_media_availability": {
+                                        "status": "Available"
+                                      },
+                                      "features": {
+                                        "large": {
+                                          "faces": []
+                                        },
+                                        "medium": {
+                                          "faces": []
+                                        },
+                                        "orig": {
+                                          "faces": []
+                                        },
+                                        "small": {
+                                          "faces": []
+                                        }
+                                      },
+                                      "id_str": "2088927703932252160",
+                                      "indices": [43, 66],
+                                      "media_key": "3_2088927703932252160",
+                                      "media_results": {
+                                        "result": {
+                                          "media_key": "3_2088927703932252160"
+                                        }
+                                      },
+                                      "media_url_https": "https://pbs.twimg.com/media/HP1crdpasAAQW7s.jpg",
+                                      "original_info": {
+                                        "focus_rects": [
+                                          {
+                                            "h": 685,
+                                            "w": 1224,
+                                            "x": 0,
+                                            "y": 1139
+                                          },
+                                          {
+                                            "h": 1224,
+                                            "w": 1224,
+                                            "x": 0,
+                                            "y": 869
+                                          },
+                                          {
+                                            "h": 1395,
+                                            "w": 1224,
+                                            "x": 0,
+                                            "y": 784
+                                          },
+                                          {
+                                            "h": 2448,
+                                            "w": 1224,
+                                            "x": 0,
+                                            "y": 134
+                                          },
+                                          {
+                                            "h": 2582,
+                                            "w": 1224,
+                                            "x": 0,
+                                            "y": 0
+                                          }
+                                        ],
+                                        "height": 2582,
+                                        "width": 1224
+                                      },
+                                      "sizes": {
+                                        "large": {
+                                          "h": 2048,
+                                          "resize": "fit",
+                                          "w": 971
+                                        },
+                                        "medium": {
+                                          "h": 1200,
+                                          "resize": "fit",
+                                          "w": 569
+                                        },
+                                        "small": {
+                                          "h": 680,
+                                          "resize": "fit",
+                                          "w": 322
+                                        },
+                                        "thumb": {
+                                          "h": 150,
+                                          "resize": "crop",
+                                          "w": 150
+                                        }
+                                      },
+                                      "type": "photo",
+                                      "url": "https://t.co/AewjbTQ4DY"
+                                    }
+                                  ]
+                                },
+                                "favorite_count": 1,
+                                "favorited": false,
+                                "full_text": "@GenshinImpact Server: Asia\nUID: 824107554 https://t.co/AewjbTQ4DY",
+                                "id_str": "2088927711515578819",
+                                "in_reply_to_screen_name": "GenshinImpact",
+                                "in_reply_to_status_id_str": "2087720798702498234",
+                                "in_reply_to_user_id_str": "1072404907230060544",
+                                "is_quote_status": false,
+                                "lang": "in",
+                                "possibly_sensitive": false,
+                                "possibly_sensitive_editable": true,
+                                "quote_count": 0,
+                                "reply_count": 0,
+                                "retweet_count": 0,
+                                "retweeted": false,
+                                "user_id_str": "1963926447363698688"
+                              },
+                              "quick_promote_eligibility": {
+                                "eligibility": "IneligibleNotVerified"
+                              },
+                              "rest_id": "2088927711515578819",
+                              "source": "<a href=\"http://twitter.com/download/android\" rel=\"nofollow\">Twitter for Android</a>",
+                              "unmention_data": {},
+                              "views": {
+                                "count": "9",
+                                "state": "EnabledWithCount"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  ],
+                  "metadata": {
+                    "conversationMetadata": {
+                      "allTweetIds": ["2088927711515578819"],
+                      "enableDeduplication": true
+                    }
+                  }
+                },
+                "entryId": "conversationthread-2088927711515578819",
+                "sortIndex": "2088929116056190966"
+              },
+              {
+                "content": {
+                  "__typename": "TimelineTimelineModule",
+                  "clientEventInfo": {
+                    "component": "tweet",
+                    "details": {
+                      "conversationDetails": {
+                        "conversationSection": "HighQuality"
+                      },
+                      "timelinesDetails": {
+                        "controllerData": "DAACDAAEDAABCgABAAAAAAAAAAEKAAIAAAAAAAAAAAoAAwAAAaAKBN5LAAAAAA=="
+                      }
+                    }
+                  },
+                  "displayType": "VerticalConversation",
+                  "entryType": "TimelineTimelineModule",
+                  "items": [
+                    {
+                      "entryId": "conversationthread-2088777309734031869-tweet-2088777309734031869",
+                      "item": {
+                        "clientEventInfo": {
+                          "component": "tweet",
+                          "details": {
+                            "conversationDetails": {
+                              "conversationSection": "HighQuality"
+                            },
+                            "timelinesDetails": {
+                              "controllerData": "DAACDAAEDAABCgABAAAAAAAAAAEKAAIAAAAAAAAAAAoAAwAAAaAKBN5LAAAAAA=="
+                            }
+                          },
+                          "element": "tweet"
+                        },
+                        "itemContent": {
+                          "__typename": "TimelineTweet",
+                          "itemType": "TimelineTweet",
+                          "tweetDisplayType": "Tweet",
+                          "tweet_results": {
+                            "result": {
+                              "__typename": "Tweet",
+                              "core": {
+                                "user_results": {
+                                  "result": {
+                                    "__typename": "User",
+                                    "affiliates_highlighted_label": {},
+                                    "avatar": {
+                                      "image_url": "https://pbs.twimg.com/profile_images/2058689723929939968/5Wskbf8B_normal.jpg"
+                                    },
+                                    "core": {
+                                      "created_at": "Tue Jul 16 21:55:01 +0000 2024",
+                                      "name": "nene kinnie",
+                                      "screen_name": "Melriver029"
+                                    },
+                                    "dm_permissions": {
+                                      "can_dm": false
+                                    },
+                                    "follow_request_sent": false,
+                                    "has_graduated_access": true,
+                                    "id": "VXNlcjoxODEzMzMxMzk4ODUxMTc4NDk2",
+                                    "is_blue_verified": false,
+                                    "legacy": {
+                                      "default_profile": true,
+                                      "default_profile_image": false,
+                                      "description": "",
+                                      "entities": {
+                                        "description": {}
+                                      },
+                                      "fast_followers_count": 0,
+                                      "favourites_count": 20909,
+                                      "follow_request_sent": false,
+                                      "followers_count": 0,
+                                      "friends_count": 64,
+                                      "has_custom_timelines": false,
+                                      "is_translator": false,
+                                      "listed_count": 0,
+                                      "media_count": 1,
+                                      "needs_phone_verification": false,
+                                      "normal_followers_count": 0,
+                                      "notifications": false,
+                                      "possibly_sensitive": false,
+                                      "profile_banner_url": "https://pbs.twimg.com/profile_banners/1813331398851178496/1779728818",
+                                      "profile_interstitial_type": "",
+                                      "statuses_count": 3,
+                                      "time_zone": "",
+                                      "translator_type": "none",
+                                      "url": "",
+                                      "utc_offset": 0,
+                                      "want_retweets": false,
+                                      "withheld_description": "",
+                                      "withheld_scope": ""
+                                    },
+                                    "location": {
+                                      "location": ""
+                                    },
+                                    "media_permissions": {
+                                      "can_media_tag": true
+                                    },
+                                    "parody_commentary_fan_label": "None",
+                                    "privacy": {
+                                      "protected": false
+                                    },
+                                    "profile_bio": {
+                                      "description": ""
+                                    },
+                                    "profile_image_shape": "Circle",
+                                    "relationship_perspectives": {
+                                      "blocked_by": false,
+                                      "blocking": false,
+                                      "followed_by": false,
+                                      "following": false,
+                                      "muting": false
+                                    },
+                                    "rest_id": "1813331398851178496",
+                                    "super_follow_eligible": false,
+                                    "super_followed_by": false,
+                                    "super_following": false,
+                                    "verification": {
+                                      "verified": false
+                                    }
+                                  }
+                                }
+                              },
+                              "edit_control": {
+                                "edit_tweet_ids": ["2088777309734031869"],
+                                "editable_until_msecs": "1786841892000",
+                                "edits_remaining": "5",
+                                "is_edit_eligible": false
+                              },
+                              "grok_analysis_button": true,
+                              "grok_annotations": {},
+                              "has_birdwatch_notes": false,
+                              "is_translatable": false,
+                              "legacy": {
+                                "bookmark_count": 1,
+                                "bookmarked": false,
+                                "conversation_id_str": "2087720798702498234",
+                                "created_at": "Sat Aug 15 23:58:12 +0000 2026",
+                                "display_text_range": [15, 44],
+                                "entities": {
+                                  "media": [
+                                    {
+                                      "display_url": "pic.x.com/ldlk4gYivq",
+                                      "expanded_url": "https://x.com/Melriver029/status/2088777309734031869/photo/1",
+                                      "ext_media_availability": {
+                                        "status": "Available"
+                                      },
+                                      "features": {
+                                        "large": {
+                                          "faces": [
+                                            {
+                                              "h": 160,
+                                              "w": 160,
+                                              "x": 298,
+                                              "y": 575
+                                            }
+                                          ]
+                                        },
+                                        "medium": {
+                                          "faces": [
+                                            {
+                                              "h": 116,
+                                              "w": 116,
+                                              "x": 217,
+                                              "y": 419
+                                            }
+                                          ]
+                                        },
+                                        "orig": {
+                                          "faces": [
+                                            {
+                                              "h": 160,
+                                              "w": 160,
+                                              "x": 298,
+                                              "y": 575
+                                            }
+                                          ]
+                                        },
+                                        "small": {
+                                          "faces": [
+                                            {
+                                              "h": 66,
+                                              "w": 66,
+                                              "x": 123,
+                                              "y": 237
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "id_str": "2088777305514483713",
+                                      "indices": [45, 68],
+                                      "media_key": "3_2088777305514483713",
+                                      "media_results": {
+                                        "result": {
+                                          "media_key": "3_2088777305514483713"
+                                        }
+                                      },
+                                      "media_url_https": "https://pbs.twimg.com/media/HPzT5H4WoAE6PfW.jpg",
+                                      "original_info": {
+                                        "focus_rects": [
+                                          {
+                                            "h": 655,
+                                            "w": 1170,
+                                            "x": 0,
+                                            "y": 945
+                                          },
+                                          {
+                                            "h": 1170,
+                                            "w": 1170,
+                                            "x": 0,
+                                            "y": 475
+                                          },
+                                          {
+                                            "h": 1334,
+                                            "w": 1170,
+                                            "x": 0,
+                                            "y": 311
+                                          },
+                                          {
+                                            "h": 1645,
+                                            "w": 823,
+                                            "x": 40,
+                                            "y": 0
+                                          },
+                                          {
+                                            "h": 1645,
+                                            "w": 1170,
+                                            "x": 0,
+                                            "y": 0
+                                          }
+                                        ],
+                                        "height": 1645,
+                                        "width": 1170
+                                      },
+                                      "sizes": {
+                                        "large": {
+                                          "h": 1645,
+                                          "resize": "fit",
+                                          "w": 1170
+                                        },
+                                        "medium": {
+                                          "h": 1200,
+                                          "resize": "fit",
+                                          "w": 853
+                                        },
+                                        "small": {
+                                          "h": 680,
+                                          "resize": "fit",
+                                          "w": 484
+                                        },
+                                        "thumb": {
+                                          "h": 150,
+                                          "resize": "crop",
+                                          "w": 150
+                                        }
+                                      },
+                                      "type": "photo",
+                                      "url": "https://t.co/ldlk4gYivq"
+                                    }
+                                  ],
+                                  "user_mentions": [
+                                    {
+                                      "id_str": "1072404907230060544",
+                                      "indices": [0, 14],
+                                      "name": "Genshin Impact",
+                                      "screen_name": "GenshinImpact"
+                                    }
+                                  ]
+                                },
+                                "extended_entities": {
+                                  "media": [
+                                    {
+                                      "display_url": "pic.x.com/ldlk4gYivq",
+                                      "expanded_url": "https://x.com/Melriver029/status/2088777309734031869/photo/1",
+                                      "ext_media_availability": {
+                                        "status": "Available"
+                                      },
+                                      "features": {
+                                        "large": {
+                                          "faces": [
+                                            {
+                                              "h": 160,
+                                              "w": 160,
+                                              "x": 298,
+                                              "y": 575
+                                            }
+                                          ]
+                                        },
+                                        "medium": {
+                                          "faces": [
+                                            {
+                                              "h": 116,
+                                              "w": 116,
+                                              "x": 217,
+                                              "y": 419
+                                            }
+                                          ]
+                                        },
+                                        "orig": {
+                                          "faces": [
+                                            {
+                                              "h": 160,
+                                              "w": 160,
+                                              "x": 298,
+                                              "y": 575
+                                            }
+                                          ]
+                                        },
+                                        "small": {
+                                          "faces": [
+                                            {
+                                              "h": 66,
+                                              "w": 66,
+                                              "x": 123,
+                                              "y": 237
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "id_str": "2088777305514483713",
+                                      "indices": [45, 68],
+                                      "media_key": "3_2088777305514483713",
+                                      "media_results": {
+                                        "result": {
+                                          "media_key": "3_2088777305514483713"
+                                        }
+                                      },
+                                      "media_url_https": "https://pbs.twimg.com/media/HPzT5H4WoAE6PfW.jpg",
+                                      "original_info": {
+                                        "focus_rects": [
+                                          {
+                                            "h": 655,
+                                            "w": 1170,
+                                            "x": 0,
+                                            "y": 945
+                                          },
+                                          {
+                                            "h": 1170,
+                                            "w": 1170,
+                                            "x": 0,
+                                            "y": 475
+                                          },
+                                          {
+                                            "h": 1334,
+                                            "w": 1170,
+                                            "x": 0,
+                                            "y": 311
+                                          },
+                                          {
+                                            "h": 1645,
+                                            "w": 823,
+                                            "x": 40,
+                                            "y": 0
+                                          },
+                                          {
+                                            "h": 1645,
+                                            "w": 1170,
+                                            "x": 0,
+                                            "y": 0
+                                          }
+                                        ],
+                                        "height": 1645,
+                                        "width": 1170
+                                      },
+                                      "sizes": {
+                                        "large": {
+                                          "h": 1645,
+                                          "resize": "fit",
+                                          "w": 1170
+                                        },
+                                        "medium": {
+                                          "h": 1200,
+                                          "resize": "fit",
+                                          "w": 853
+                                        },
+                                        "small": {
+                                          "h": 680,
+                                          "resize": "fit",
+                                          "w": 484
+                                        },
+                                        "thumb": {
+                                          "h": 150,
+                                          "resize": "crop",
+                                          "w": 150
+                                        }
+                                      },
+                                      "type": "photo",
+                                      "url": "https://t.co/ldlk4gYivq"
+                                    }
+                                  ]
+                                },
+                                "favorite_count": 0,
+                                "favorited": false,
+                                "full_text": "@GenshinImpact America server \nUID:662033611 https://t.co/ldlk4gYivq",
+                                "id_str": "2088777309734031869",
+                                "in_reply_to_screen_name": "GenshinImpact",
+                                "in_reply_to_status_id_str": "2087720798702498234",
+                                "in_reply_to_user_id_str": "1072404907230060544",
+                                "is_quote_status": false,
+                                "lang": "ca",
+                                "possibly_sensitive": false,
+                                "possibly_sensitive_editable": true,
+                                "quote_count": 0,
+                                "reply_count": 0,
+                                "retweet_count": 0,
+                                "retweeted": false,
+                                "user_id_str": "1813331398851178496"
+                              },
+                              "quick_promote_eligibility": {
+                                "eligibility": "IneligibleNotVerified"
+                              },
+                              "rest_id": "2088777309734031869",
+                              "source": "<a href=\"http://twitter.com/download/iphone\" rel=\"nofollow\">Twitter for iPhone</a>",
+                              "unmention_data": {},
+                              "views": {
+                                "count": "274",
+                                "state": "EnabledWithCount"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  ],
+                  "metadata": {
+                    "conversationMetadata": {
+                      "allTweetIds": ["2088777309734031869"],
+                      "enableDeduplication": true
+                    }
+                  }
+                },
+                "entryId": "conversationthread-2088777309734031869",
+                "sortIndex": "2088929116056190956"
+              },
+              {
+                "content": {
+                  "__typename": "TimelineTimelineModule",
+                  "clientEventInfo": {
+                    "component": "tweet",
+                    "details": {
+                      "conversationDetails": {
+                        "conversationSection": "HighQuality"
+                      },
+                      "timelinesDetails": {
+                        "controllerData": "DAACDAAEDAABCgABAAAAAAAAAAEKAAIAAAAAAAAAAAoAAwAAAaAKBN5LAAAAAA=="
+                      }
+                    }
+                  },
+                  "displayType": "VerticalConversation",
+                  "entryType": "TimelineTimelineModule",
+                  "items": [
+                    {
+                      "entryId": "conversationthread-2088875563658490323-tweet-2088875563658490323",
+                      "item": {
+                        "clientEventInfo": {
+                          "component": "tweet",
+                          "details": {
+                            "conversationDetails": {
+                              "conversationSection": "HighQuality"
+                            },
+                            "timelinesDetails": {
+                              "controllerData": "DAACDAAEDAABCgABAAAAAAAAAAEKAAIAAAAAAAAAAAoAAwAAAaAKBN5LAAAAAA=="
+                            }
+                          },
+                          "element": "tweet"
+                        },
+                        "itemContent": {
+                          "__typename": "TimelineTweet",
+                          "itemType": "TimelineTweet",
+                          "tweetDisplayType": "Tweet",
+                          "tweet_results": {
+                            "result": {
+                              "__typename": "Tweet",
+                              "core": {
+                                "user_results": {
+                                  "result": {
+                                    "__typename": "User",
+                                    "affiliates_highlighted_label": {},
+                                    "avatar": {
+                                      "image_url": "https://pbs.twimg.com/profile_images/2030847637730344960/7x5k7In__normal.png"
+                                    },
+                                    "core": {
+                                      "created_at": "Mon Mar 09 03:26:22 +0000 2026",
+                                      "name": "Pha Dang",
+                                      "screen_name": "DangPha44444"
+                                    },
+                                    "dm_permissions": {
+                                      "can_dm": false
+                                    },
+                                    "follow_request_sent": false,
+                                    "has_graduated_access": true,
+                                    "id": "VXNlcjoyMDMwODQ3NTkyMTU5MTIxNDA4",
+                                    "is_blue_verified": false,
+                                    "legacy": {
+                                      "default_profile": true,
+                                      "default_profile_image": false,
+                                      "description": "a genshin player that can't speak eng well",
+                                      "entities": {
+                                        "description": {}
+                                      },
+                                      "fast_followers_count": 0,
+                                      "favourites_count": 81,
+                                      "follow_request_sent": false,
+                                      "followers_count": 4,
+                                      "friends_count": 46,
+                                      "has_custom_timelines": false,
+                                      "is_translator": false,
+                                      "listed_count": 0,
+                                      "media_count": 23,
+                                      "needs_phone_verification": false,
+                                      "normal_followers_count": 4,
+                                      "notifications": false,
+                                      "possibly_sensitive": false,
+                                      "profile_banner_url": "",
+                                      "profile_interstitial_type": "",
+                                      "statuses_count": 126,
+                                      "time_zone": "",
+                                      "translator_type": "none",
+                                      "url": "",
+                                      "utc_offset": 0,
+                                      "want_retweets": false,
+                                      "withheld_description": "",
+                                      "withheld_scope": ""
+                                    },
+                                    "location": {
+                                      "location": ""
+                                    },
+                                    "media_permissions": {
+                                      "can_media_tag": true
+                                    },
+                                    "parody_commentary_fan_label": "None",
+                                    "privacy": {
+                                      "protected": false
+                                    },
+                                    "profile_bio": {
+                                      "description": "a genshin player that can't speak eng well"
+                                    },
+                                    "profile_description_language": "en",
+                                    "profile_image_shape": "Circle",
+                                    "relationship_perspectives": {
+                                      "blocked_by": false,
+                                      "blocking": false,
+                                      "followed_by": false,
+                                      "following": false,
+                                      "muting": false
+                                    },
+                                    "rest_id": "2030847592159121408",
+                                    "super_follow_eligible": false,
+                                    "super_followed_by": false,
+                                    "super_following": false,
+                                    "verification": {
+                                      "verified": false
+                                    }
+                                  }
+                                }
+                              },
+                              "edit_control": {
+                                "edit_tweet_ids": ["2088875563658490323"],
+                                "editable_until_msecs": "1786865318000",
+                                "edits_remaining": "5",
+                                "is_edit_eligible": false
+                              },
+                              "grok_analysis_button": true,
+                              "grok_annotations": {},
+                              "has_birdwatch_notes": false,
+                              "is_translatable": false,
+                              "legacy": {
+                                "bookmark_count": 0,
+                                "bookmarked": false,
+                                "conversation_id_str": "2087720798702498234",
+                                "created_at": "Sun Aug 16 06:28:38 +0000 2026",
+                                "display_text_range": [15, 45],
+                                "entities": {
+                                  "media": [
+                                    {
+                                      "allow_download_status": {
+                                        "allow_download": true
+                                      },
+                                      "display_url": "pic.x.com/bVUV4yZxYz",
+                                      "expanded_url": "https://x.com/DangPha44444/status/2088875563658490323/photo/1",
+                                      "ext_media_availability": {
+                                        "status": "Available"
+                                      },
+                                      "features": {
+                                        "large": {
+                                          "faces": []
+                                        },
+                                        "medium": {
+                                          "faces": []
+                                        },
+                                        "orig": {
+                                          "faces": []
+                                        },
+                                        "small": {
+                                          "faces": []
+                                        }
+                                      },
+                                      "id_str": "2088875494385364992",
+                                      "indices": [46, 69],
+                                      "media_key": "3_2088875494385364992",
+                                      "media_results": {
+                                        "result": {
+                                          "media_key": "3_2088875494385364992"
+                                        }
+                                      },
+                                      "media_url_https": "https://pbs.twimg.com/media/HP0tMd7bsAAa3tx.png",
+                                      "original_info": {
+                                        "focus_rects": [
+                                          {
+                                            "h": 335,
+                                            "w": 599,
+                                            "x": 0,
+                                            "y": 481
+                                          },
+                                          {
+                                            "h": 599,
+                                            "w": 599,
+                                            "x": 0,
+                                            "y": 239
+                                          },
+                                          {
+                                            "h": 683,
+                                            "w": 599,
+                                            "x": 0,
+                                            "y": 155
+                                          },
+                                          {
+                                            "h": 838,
+                                            "w": 419,
+                                            "x": 104,
+                                            "y": 0
+                                          },
+                                          {
+                                            "h": 838,
+                                            "w": 599,
+                                            "x": 0,
+                                            "y": 0
+                                          }
+                                        ],
+                                        "height": 838,
+                                        "width": 599
+                                      },
+                                      "sizes": {
+                                        "large": {
+                                          "h": 838,
+                                          "resize": "fit",
+                                          "w": 599
+                                        },
+                                        "medium": {
+                                          "h": 838,
+                                          "resize": "fit",
+                                          "w": 599
+                                        },
+                                        "small": {
+                                          "h": 680,
+                                          "resize": "fit",
+                                          "w": 486
+                                        },
+                                        "thumb": {
+                                          "h": 150,
+                                          "resize": "crop",
+                                          "w": 150
+                                        }
+                                      },
+                                      "type": "photo",
+                                      "url": "https://t.co/bVUV4yZxYz"
+                                    }
+                                  ],
+                                  "user_mentions": [
+                                    {
+                                      "id_str": "1072404907230060544",
+                                      "indices": [0, 14],
+                                      "name": "Genshin Impact",
+                                      "screen_name": "GenshinImpact"
+                                    }
+                                  ]
+                                },
+                                "extended_entities": {
+                                  "media": [
+                                    {
+                                      "allow_download_status": {
+                                        "allow_download": true
+                                      },
+                                      "display_url": "pic.x.com/bVUV4yZxYz",
+                                      "expanded_url": "https://x.com/DangPha44444/status/2088875563658490323/photo/1",
+                                      "ext_media_availability": {
+                                        "status": "Available"
+                                      },
+                                      "features": {
+                                        "large": {
+                                          "faces": []
+                                        },
+                                        "medium": {
+                                          "faces": []
+                                        },
+                                        "orig": {
+                                          "faces": []
+                                        },
+                                        "small": {
+                                          "faces": []
+                                        }
+                                      },
+                                      "id_str": "2088875494385364992",
+                                      "indices": [46, 69],
+                                      "media_key": "3_2088875494385364992",
+                                      "media_results": {
+                                        "result": {
+                                          "media_key": "3_2088875494385364992"
+                                        }
+                                      },
+                                      "media_url_https": "https://pbs.twimg.com/media/HP0tMd7bsAAa3tx.png",
+                                      "original_info": {
+                                        "focus_rects": [
+                                          {
+                                            "h": 335,
+                                            "w": 599,
+                                            "x": 0,
+                                            "y": 481
+                                          },
+                                          {
+                                            "h": 599,
+                                            "w": 599,
+                                            "x": 0,
+                                            "y": 239
+                                          },
+                                          {
+                                            "h": 683,
+                                            "w": 599,
+                                            "x": 0,
+                                            "y": 155
+                                          },
+                                          {
+                                            "h": 838,
+                                            "w": 419,
+                                            "x": 104,
+                                            "y": 0
+                                          },
+                                          {
+                                            "h": 838,
+                                            "w": 599,
+                                            "x": 0,
+                                            "y": 0
+                                          }
+                                        ],
+                                        "height": 838,
+                                        "width": 599
+                                      },
+                                      "sizes": {
+                                        "large": {
+                                          "h": 838,
+                                          "resize": "fit",
+                                          "w": 599
+                                        },
+                                        "medium": {
+                                          "h": 838,
+                                          "resize": "fit",
+                                          "w": 599
+                                        },
+                                        "small": {
+                                          "h": 680,
+                                          "resize": "fit",
+                                          "w": 486
+                                        },
+                                        "thumb": {
+                                          "h": 150,
+                                          "resize": "crop",
+                                          "w": 150
+                                        }
+                                      },
+                                      "type": "photo",
+                                      "url": "https://t.co/bVUV4yZxYz"
+                                    }
+                                  ]
+                                },
+                                "favorite_count": 0,
+                                "favorited": false,
+                                "full_text": "@GenshinImpact UID 896507288\nืname Drago\nAsia https://t.co/bVUV4yZxYz",
+                                "id_str": "2088875563658490323",
+                                "in_reply_to_screen_name": "GenshinImpact",
+                                "in_reply_to_status_id_str": "2087720798702498234",
+                                "in_reply_to_user_id_str": "1072404907230060544",
+                                "is_quote_status": false,
+                                "lang": "et",
+                                "possibly_sensitive": false,
+                                "possibly_sensitive_editable": true,
+                                "quote_count": 0,
+                                "reply_count": 0,
+                                "retweet_count": 0,
+                                "retweeted": false,
+                                "user_id_str": "2030847592159121408"
+                              },
+                              "quick_promote_eligibility": {
+                                "eligibility": "IneligibleNotVerified"
+                              },
+                              "rest_id": "2088875563658490323",
+                              "source": "<a href=\"https://mobile.twitter.com\" rel=\"nofollow\">Twitter Web App</a>",
+                              "unmention_data": {},
+                              "views": {
+                                "count": "162",
+                                "state": "EnabledWithCount"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  ],
+                  "metadata": {
+                    "conversationMetadata": {
+                      "allTweetIds": ["2088875563658490323"],
+                      "enableDeduplication": true
+                    }
+                  }
+                },
+                "entryId": "conversationthread-2088875563658490323",
+                "sortIndex": "2088929116056190946"
+              },
+              {
+                "content": {
+                  "__typename": "TimelineTimelineModule",
+                  "clientEventInfo": {
+                    "component": "tweet",
+                    "details": {
+                      "conversationDetails": {
+                        "conversationSection": "HighQuality"
+                      },
+                      "timelinesDetails": {
+                        "controllerData": "DAACDAAEDAABCgABAAAAAAAAAAEKAAIAAAAAAAAAAAoAAwAAAaAKBN5LAAAAAA=="
+                      }
+                    }
+                  },
+                  "displayType": "VerticalConversation",
+                  "entryType": "TimelineTimelineModule",
+                  "items": [
+                    {
+                      "entryId": "conversationthread-2088470671080956058-tweet-2088470671080956058",
+                      "item": {
+                        "clientEventInfo": {
+                          "component": "tweet",
+                          "details": {
+                            "conversationDetails": {
+                              "conversationSection": "HighQuality"
+                            },
+                            "timelinesDetails": {
+                              "controllerData": "DAACDAAEDAABCgABAAAAAAAAAAEKAAIAAAAAAAAAAAoAAwAAAaAKBN5LAAAAAA=="
+                            }
+                          },
+                          "element": "tweet"
+                        },
+                        "itemContent": {
+                          "__typename": "TimelineTweet",
+                          "itemType": "TimelineTweet",
+                          "tweetDisplayType": "Tweet",
+                          "tweet_results": {
+                            "result": {
+                              "__typename": "Tweet",
+                              "core": {
+                                "user_results": {
+                                  "result": {
+                                    "__typename": "User",
+                                    "affiliates_highlighted_label": {},
+                                    "avatar": {
+                                      "image_url": "https://pbs.twimg.com/profile_images/2074866256696705024/r2yZbxC8_normal.jpg"
+                                    },
+                                    "core": {
+                                      "created_at": "Fri Nov 08 11:11:16 +0000 2024",
+                                      "name": "cossera282",
+                                      "screen_name": "ruekataa"
+                                    },
+                                    "dm_permissions": {
+                                      "can_dm": false
+                                    },
+                                    "follow_request_sent": false,
+                                    "has_graduated_access": true,
+                                    "id": "VXNlcjoxODU0ODQzOTA2NjgyNTAzMTY5",
+                                    "is_blue_verified": false,
+                                    "legacy": {
+                                      "default_profile": true,
+                                      "default_profile_image": false,
+                                      "description": "i draw sometimes",
+                                      "entities": {
+                                        "description": {}
+                                      },
+                                      "fast_followers_count": 0,
+                                      "favourites_count": 1096,
+                                      "follow_request_sent": false,
+                                      "followers_count": 6,
+                                      "friends_count": 64,
+                                      "has_custom_timelines": false,
+                                      "is_translator": false,
+                                      "listed_count": 0,
+                                      "media_count": 9,
+                                      "needs_phone_verification": false,
+                                      "normal_followers_count": 6,
+                                      "notifications": false,
+                                      "possibly_sensitive": false,
+                                      "profile_banner_url": "",
+                                      "profile_interstitial_type": "",
+                                      "statuses_count": 34,
+                                      "time_zone": "",
+                                      "translator_type": "none",
+                                      "url": "",
+                                      "utc_offset": 0,
+                                      "want_retweets": false,
+                                      "withheld_description": "",
+                                      "withheld_scope": ""
+                                    },
+                                    "location": {
+                                      "location": ""
+                                    },
+                                    "media_permissions": {
+                                      "can_media_tag": true
+                                    },
+                                    "parody_commentary_fan_label": "None",
+                                    "privacy": {
+                                      "protected": false
+                                    },
+                                    "professional": {
+                                      "category": [
+                                        {
+                                          "icon_name": "",
+                                          "id": 1017,
+                                          "name": "Artist"
+                                        }
+                                      ],
+                                      "professional_type": "Creator",
+                                      "rest_id": "1944787520816124070"
+                                    },
+                                    "profile_bio": {
+                                      "description": "i draw sometimes"
+                                    },
+                                    "profile_description_language": "en",
+                                    "profile_image_shape": "Circle",
+                                    "relationship_perspectives": {
+                                      "blocked_by": false,
+                                      "blocking": false,
+                                      "followed_by": false,
+                                      "following": false,
+                                      "muting": false
+                                    },
+                                    "rest_id": "1854843906682503169",
+                                    "super_follow_eligible": false,
+                                    "super_followed_by": false,
+                                    "super_following": false,
+                                    "verification": {
+                                      "verified": false
+                                    }
+                                  }
+                                }
+                              },
+                              "edit_control": {
+                                "edit_tweet_ids": ["2088470671080956058"],
+                                "editable_until_msecs": "1786768784000",
+                                "edits_remaining": "5",
+                                "is_edit_eligible": false
+                              },
+                              "grok_analysis_button": true,
+                              "grok_annotations": {},
+                              "has_birdwatch_notes": false,
+                              "is_translatable": false,
+                              "legacy": {
+                                "bookmark_count": 0,
+                                "bookmarked": false,
+                                "conversation_id_str": "2087720798702498234",
+                                "created_at": "Sat Aug 15 03:39:44 +0000 2026",
+                                "display_text_range": [15, 40],
+                                "entities": {
+                                  "media": [
+                                    {
+                                      "display_url": "pic.x.com/ArhPjjcwUD",
+                                      "expanded_url": "https://x.com/ruekataa/status/2088470671080956058/photo/1",
+                                      "ext_media_availability": {
+                                        "status": "Available"
+                                      },
+                                      "features": {
+                                        "large": {
+                                          "faces": [
+                                            {
+                                              "h": 47,
+                                              "w": 47,
+                                              "x": 992,
+                                              "y": 592
+                                            },
+                                            {
+                                              "h": 82,
+                                              "w": 82,
+                                              "x": 744,
+                                              "y": 646
+                                            }
+                                          ]
+                                        },
+                                        "medium": {
+                                          "faces": [
+                                            {
+                                              "h": 47,
+                                              "w": 47,
+                                              "x": 992,
+                                              "y": 592
+                                            },
+                                            {
+                                              "h": 82,
+                                              "w": 82,
+                                              "x": 744,
+                                              "y": 646
+                                            }
+                                          ]
+                                        },
+                                        "orig": {
+                                          "faces": [
+                                            {
+                                              "h": 47,
+                                              "w": 47,
+                                              "x": 992,
+                                              "y": 592
+                                            },
+                                            {
+                                              "h": 82,
+                                              "w": 82,
+                                              "x": 744,
+                                              "y": 646
+                                            }
+                                          ]
+                                        },
+                                        "small": {
+                                          "faces": [
+                                            {
+                                              "h": 29,
+                                              "w": 29,
+                                              "x": 624,
+                                              "y": 372
+                                            },
+                                            {
+                                              "h": 51,
+                                              "w": 51,
+                                              "x": 468,
+                                              "y": 406
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "id_str": "2088470665146028032",
+                                      "indices": [41, 64],
+                                      "media_key": "3_2088470665146028032",
+                                      "media_results": {
+                                        "result": {
+                                          "media_key": "3_2088470665146028032"
+                                        }
+                                      },
+                                      "media_url_https": "https://pbs.twimg.com/media/HPu9ATfaUAAPT6l.jpg",
+                                      "original_info": {
+                                        "focus_rects": [
+                                          {
+                                            "h": 605,
+                                            "w": 1080,
+                                            "x": 0,
+                                            "y": 475
+                                          },
+                                          {
+                                            "h": 1080,
+                                            "w": 1080,
+                                            "x": 0,
+                                            "y": 0
+                                          },
+                                          {
+                                            "h": 1080,
+                                            "w": 947,
+                                            "x": 133,
+                                            "y": 0
+                                          },
+                                          {
+                                            "h": 1080,
+                                            "w": 540,
+                                            "x": 540,
+                                            "y": 0
+                                          },
+                                          {
+                                            "h": 1080,
+                                            "w": 1080,
+                                            "x": 0,
+                                            "y": 0
+                                          }
+                                        ],
+                                        "height": 1080,
+                                        "width": 1080
+                                      },
+                                      "sizes": {
+                                        "large": {
+                                          "h": 1080,
+                                          "resize": "fit",
+                                          "w": 1080
+                                        },
+                                        "medium": {
+                                          "h": 1080,
+                                          "resize": "fit",
+                                          "w": 1080
+                                        },
+                                        "small": {
+                                          "h": 680,
+                                          "resize": "fit",
+                                          "w": 680
+                                        },
+                                        "thumb": {
+                                          "h": 150,
+                                          "resize": "crop",
+                                          "w": 150
+                                        }
+                                      },
+                                      "type": "photo",
+                                      "url": "https://t.co/ArhPjjcwUD"
+                                    }
+                                  ],
+                                  "user_mentions": [
+                                    {
+                                      "id_str": "1072404907230060544",
+                                      "indices": [0, 14],
+                                      "name": "Genshin Impact",
+                                      "screen_name": "GenshinImpact"
+                                    }
+                                  ]
+                                },
+                                "extended_entities": {
+                                  "media": [
+                                    {
+                                      "display_url": "pic.x.com/ArhPjjcwUD",
+                                      "expanded_url": "https://x.com/ruekataa/status/2088470671080956058/photo/1",
+                                      "ext_media_availability": {
+                                        "status": "Available"
+                                      },
+                                      "features": {
+                                        "large": {
+                                          "faces": [
+                                            {
+                                              "h": 47,
+                                              "w": 47,
+                                              "x": 992,
+                                              "y": 592
+                                            },
+                                            {
+                                              "h": 82,
+                                              "w": 82,
+                                              "x": 744,
+                                              "y": 646
+                                            }
+                                          ]
+                                        },
+                                        "medium": {
+                                          "faces": [
+                                            {
+                                              "h": 47,
+                                              "w": 47,
+                                              "x": 992,
+                                              "y": 592
+                                            },
+                                            {
+                                              "h": 82,
+                                              "w": 82,
+                                              "x": 744,
+                                              "y": 646
+                                            }
+                                          ]
+                                        },
+                                        "orig": {
+                                          "faces": [
+                                            {
+                                              "h": 47,
+                                              "w": 47,
+                                              "x": 992,
+                                              "y": 592
+                                            },
+                                            {
+                                              "h": 82,
+                                              "w": 82,
+                                              "x": 744,
+                                              "y": 646
+                                            }
+                                          ]
+                                        },
+                                        "small": {
+                                          "faces": [
+                                            {
+                                              "h": 29,
+                                              "w": 29,
+                                              "x": 624,
+                                              "y": 372
+                                            },
+                                            {
+                                              "h": 51,
+                                              "w": 51,
+                                              "x": 468,
+                                              "y": 406
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "id_str": "2088470665146028032",
+                                      "indices": [41, 64],
+                                      "media_key": "3_2088470665146028032",
+                                      "media_results": {
+                                        "result": {
+                                          "media_key": "3_2088470665146028032"
+                                        }
+                                      },
+                                      "media_url_https": "https://pbs.twimg.com/media/HPu9ATfaUAAPT6l.jpg",
+                                      "original_info": {
+                                        "focus_rects": [
+                                          {
+                                            "h": 605,
+                                            "w": 1080,
+                                            "x": 0,
+                                            "y": 475
+                                          },
+                                          {
+                                            "h": 1080,
+                                            "w": 1080,
+                                            "x": 0,
+                                            "y": 0
+                                          },
+                                          {
+                                            "h": 1080,
+                                            "w": 947,
+                                            "x": 133,
+                                            "y": 0
+                                          },
+                                          {
+                                            "h": 1080,
+                                            "w": 540,
+                                            "x": 540,
+                                            "y": 0
+                                          },
+                                          {
+                                            "h": 1080,
+                                            "w": 1080,
+                                            "x": 0,
+                                            "y": 0
+                                          }
+                                        ],
+                                        "height": 1080,
+                                        "width": 1080
+                                      },
+                                      "sizes": {
+                                        "large": {
+                                          "h": 1080,
+                                          "resize": "fit",
+                                          "w": 1080
+                                        },
+                                        "medium": {
+                                          "h": 1080,
+                                          "resize": "fit",
+                                          "w": 1080
+                                        },
+                                        "small": {
+                                          "h": 680,
+                                          "resize": "fit",
+                                          "w": 680
+                                        },
+                                        "thumb": {
+                                          "h": 150,
+                                          "resize": "crop",
+                                          "w": 150
+                                        }
+                                      },
+                                      "type": "photo",
+                                      "url": "https://t.co/ArhPjjcwUD"
+                                    }
+                                  ]
+                                },
+                                "favorite_count": 0,
+                                "favorited": false,
+                                "full_text": "@GenshinImpact uid 898005648 server Asia https://t.co/ArhPjjcwUD",
+                                "id_str": "2088470671080956058",
+                                "in_reply_to_screen_name": "GenshinImpact",
+                                "in_reply_to_status_id_str": "2087720798702498234",
+                                "in_reply_to_user_id_str": "1072404907230060544",
+                                "is_quote_status": false,
+                                "lang": "et",
+                                "possibly_sensitive": false,
+                                "possibly_sensitive_editable": true,
+                                "quote_count": 0,
+                                "reply_count": 0,
+                                "retweet_count": 0,
+                                "retweeted": false,
+                                "user_id_str": "1854843906682503169"
+                              },
+                              "quick_promote_eligibility": {
+                                "eligibility": "IneligibleNotVerified"
+                              },
+                              "rest_id": "2088470671080956058",
+                              "source": "<a href=\"http://twitter.com/download/android\" rel=\"nofollow\">Twitter for Android</a>",
+                              "unmention_data": {},
+                              "views": {
+                                "count": "420",
+                                "state": "EnabledWithCount"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  ],
+                  "metadata": {
+                    "conversationMetadata": {
+                      "allTweetIds": ["2088470671080956058"],
+                      "enableDeduplication": true
+                    }
+                  }
+                },
+                "entryId": "conversationthread-2088470671080956058",
+                "sortIndex": "2088929116056190936"
+              },
+              {
+                "content": {
+                  "__typename": "TimelineTimelineModule",
+                  "clientEventInfo": {
+                    "component": "tweet",
+                    "details": {
+                      "conversationDetails": {
+                        "conversationSection": "HighQuality"
+                      },
+                      "timelinesDetails": {
+                        "controllerData": "DAACDAAEDAABCgABAAAAAAAAAAEKAAIAAAAAAAAAAAoAAwAAAaAKBN5LAAAAAA=="
+                      }
+                    }
+                  },
+                  "displayType": "VerticalConversation",
+                  "entryType": "TimelineTimelineModule",
+                  "items": [
+                    {
+                      "entryId": "conversationthread-2088818583791194318-tweet-2088818583791194318",
+                      "item": {
+                        "clientEventInfo": {
+                          "component": "tweet",
+                          "details": {
+                            "conversationDetails": {
+                              "conversationSection": "HighQuality"
+                            },
+                            "timelinesDetails": {
+                              "controllerData": "DAACDAAEDAABCgABAAAAAAAAAAEKAAIAAAAAAAAAAAoAAwAAAaAKBN5LAAAAAA=="
+                            }
+                          },
+                          "element": "tweet"
+                        },
+                        "itemContent": {
+                          "__typename": "TimelineTweet",
+                          "itemType": "TimelineTweet",
+                          "tweetDisplayType": "Tweet",
+                          "tweet_results": {
+                            "result": {
+                              "__typename": "Tweet",
+                              "core": {
+                                "user_results": {
+                                  "result": {
+                                    "__typename": "User",
+                                    "affiliates_highlighted_label": {},
+                                    "avatar": {
+                                      "image_url": "https://pbs.twimg.com/profile_images/2082180864289681408/V3HAlLSz_normal.jpg"
+                                    },
+                                    "core": {
+                                      "created_at": "Sun Nov 13 00:34:06 +0000 2022",
+                                      "name": "_Tham.gg",
+                                      "screen_name": "1x_hello_exe"
+                                    },
+                                    "dm_permissions": {
+                                      "can_dm": false
+                                    },
+                                    "follow_request_sent": false,
+                                    "has_graduated_access": true,
+                                    "id": "VXNlcjoxNTkxNTkwMTE4NjMyMzI1MTIw",
+                                    "is_blue_verified": false,
+                                    "legacy": {
+                                      "default_profile": true,
+                                      "default_profile_image": false,
+                                      "description": "ชงโหดเหมือนโกดไคมา ( 🪽⚙️🔄🚫 )",
+                                      "entities": {
+                                        "description": {}
+                                      },
+                                      "fast_followers_count": 0,
+                                      "favourites_count": 935,
+                                      "follow_request_sent": false,
+                                      "followers_count": 29,
+                                      "friends_count": 253,
+                                      "has_custom_timelines": false,
+                                      "is_translator": false,
+                                      "listed_count": 0,
+                                      "media_count": 24,
+                                      "needs_phone_verification": false,
+                                      "normal_followers_count": 29,
+                                      "notifications": false,
+                                      "possibly_sensitive": false,
+                                      "profile_banner_url": "https://pbs.twimg.com/profile_banners/1591590118632325120/1785265577",
+                                      "profile_interstitial_type": "",
+                                      "statuses_count": 340,
+                                      "time_zone": "",
+                                      "translator_type": "none",
+                                      "url": "",
+                                      "utc_offset": 0,
+                                      "want_retweets": false,
+                                      "withheld_description": "",
+                                      "withheld_scope": ""
+                                    },
+                                    "location": {
+                                      "location": ""
+                                    },
+                                    "media_permissions": {
+                                      "can_media_tag": true
+                                    },
+                                    "parody_commentary_fan_label": "None",
+                                    "privacy": {
+                                      "protected": false
+                                    },
+                                    "profile_bio": {
+                                      "description": "ชงโหดเหมือนโกดไคมา ( 🪽⚙️🔄🚫 )"
+                                    },
+                                    "profile_description_language": "th",
+                                    "profile_image_shape": "Circle",
+                                    "relationship_perspectives": {
+                                      "blocked_by": false,
+                                      "blocking": false,
+                                      "followed_by": false,
+                                      "following": false,
+                                      "muting": false
+                                    },
+                                    "rest_id": "1591590118632325120",
+                                    "super_follow_eligible": false,
+                                    "super_followed_by": false,
+                                    "super_following": false,
+                                    "verification": {
+                                      "verified": false
+                                    }
+                                  }
+                                }
+                              },
+                              "edit_control": {
+                                "edit_tweet_ids": ["2088818583791194318"],
+                                "editable_until_msecs": "1786851733000",
+                                "edits_remaining": "5",
+                                "is_edit_eligible": false
+                              },
+                              "grok_analysis_button": true,
+                              "grok_annotations": {},
+                              "has_birdwatch_notes": false,
+                              "is_translatable": false,
+                              "legacy": {
+                                "bookmark_count": 0,
+                                "bookmarked": false,
+                                "conversation_id_str": "2087720798702498234",
+                                "created_at": "Sun Aug 16 02:42:13 +0000 2026",
+                                "display_text_range": [15, 42],
+                                "entities": {
+                                  "media": [
+                                    {
+                                      "display_url": "pic.x.com/898qkPcboF",
+                                      "expanded_url": "https://x.com/1x_hello_exe/status/2088818583791194318/photo/1",
+                                      "ext_media_availability": {
+                                        "status": "Available"
+                                      },
+                                      "features": {
+                                        "large": {
+                                          "faces": [
+                                            {
+                                              "h": 165,
+                                              "w": 165,
+                                              "x": 305,
+                                              "y": 578
+                                            },
+                                            {
+                                              "h": 161,
+                                              "w": 161,
+                                              "x": 399,
+                                              "y": 576
+                                            }
+                                          ]
+                                        },
+                                        "medium": {
+                                          "faces": [
+                                            {
+                                              "h": 117,
+                                              "w": 117,
+                                              "x": 217,
+                                              "y": 412
+                                            },
+                                            {
+                                              "h": 114,
+                                              "w": 114,
+                                              "x": 284,
+                                              "y": 410
+                                            }
+                                          ]
+                                        },
+                                        "orig": {
+                                          "faces": [
+                                            {
+                                              "h": 165,
+                                              "w": 165,
+                                              "x": 305,
+                                              "y": 578
+                                            },
+                                            {
+                                              "h": 161,
+                                              "w": 161,
+                                              "x": 399,
+                                              "y": 576
+                                            }
+                                          ]
+                                        },
+                                        "small": {
+                                          "faces": [
+                                            {
+                                              "h": 66,
+                                              "w": 66,
+                                              "x": 123,
+                                              "y": 233
+                                            },
+                                            {
+                                              "h": 65,
+                                              "w": 65,
+                                              "x": 161,
+                                              "y": 232
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "id_str": "2088818576283324416",
+                                      "indices": [43, 66],
+                                      "media_key": "3_2088818576283324416",
+                                      "media_results": {
+                                        "result": {
+                                          "media_key": "3_2088818576283324416"
+                                        }
+                                      },
+                                      "media_url_https": "https://pbs.twimg.com/media/HPz5bZea0AAYDD2.jpg",
+                                      "original_info": {
+                                        "focus_rects": [
+                                          {
+                                            "h": 672,
+                                            "w": 1200,
+                                            "x": 0,
+                                            "y": 884
+                                          },
+                                          {
+                                            "h": 1200,
+                                            "w": 1200,
+                                            "x": 0,
+                                            "y": 483
+                                          },
+                                          {
+                                            "h": 1368,
+                                            "w": 1200,
+                                            "x": 0,
+                                            "y": 315
+                                          },
+                                          {
+                                            "h": 1683,
+                                            "w": 842,
+                                            "x": 0,
+                                            "y": 0
+                                          },
+                                          {
+                                            "h": 1683,
+                                            "w": 1200,
+                                            "x": 0,
+                                            "y": 0
+                                          }
+                                        ],
+                                        "height": 1683,
+                                        "width": 1200
+                                      },
+                                      "sizes": {
+                                        "large": {
+                                          "h": 1683,
+                                          "resize": "fit",
+                                          "w": 1200
+                                        },
+                                        "medium": {
+                                          "h": 1200,
+                                          "resize": "fit",
+                                          "w": 856
+                                        },
+                                        "small": {
+                                          "h": 680,
+                                          "resize": "fit",
+                                          "w": 485
+                                        },
+                                        "thumb": {
+                                          "h": 150,
+                                          "resize": "crop",
+                                          "w": 150
+                                        }
+                                      },
+                                      "type": "photo",
+                                      "url": "https://t.co/898qkPcboF"
+                                    }
+                                  ],
+                                  "user_mentions": [
+                                    {
+                                      "id_str": "1072404907230060544",
+                                      "indices": [0, 14],
+                                      "name": "Genshin Impact",
+                                      "screen_name": "GenshinImpact"
+                                    }
+                                  ]
+                                },
+                                "extended_entities": {
+                                  "media": [
+                                    {
+                                      "display_url": "pic.x.com/898qkPcboF",
+                                      "expanded_url": "https://x.com/1x_hello_exe/status/2088818583791194318/photo/1",
+                                      "ext_media_availability": {
+                                        "status": "Available"
+                                      },
+                                      "features": {
+                                        "large": {
+                                          "faces": [
+                                            {
+                                              "h": 165,
+                                              "w": 165,
+                                              "x": 305,
+                                              "y": 578
+                                            },
+                                            {
+                                              "h": 161,
+                                              "w": 161,
+                                              "x": 399,
+                                              "y": 576
+                                            }
+                                          ]
+                                        },
+                                        "medium": {
+                                          "faces": [
+                                            {
+                                              "h": 117,
+                                              "w": 117,
+                                              "x": 217,
+                                              "y": 412
+                                            },
+                                            {
+                                              "h": 114,
+                                              "w": 114,
+                                              "x": 284,
+                                              "y": 410
+                                            }
+                                          ]
+                                        },
+                                        "orig": {
+                                          "faces": [
+                                            {
+                                              "h": 165,
+                                              "w": 165,
+                                              "x": 305,
+                                              "y": 578
+                                            },
+                                            {
+                                              "h": 161,
+                                              "w": 161,
+                                              "x": 399,
+                                              "y": 576
+                                            }
+                                          ]
+                                        },
+                                        "small": {
+                                          "faces": [
+                                            {
+                                              "h": 66,
+                                              "w": 66,
+                                              "x": 123,
+                                              "y": 233
+                                            },
+                                            {
+                                              "h": 65,
+                                              "w": 65,
+                                              "x": 161,
+                                              "y": 232
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "id_str": "2088818576283324416",
+                                      "indices": [43, 66],
+                                      "media_key": "3_2088818576283324416",
+                                      "media_results": {
+                                        "result": {
+                                          "media_key": "3_2088818576283324416"
+                                        }
+                                      },
+                                      "media_url_https": "https://pbs.twimg.com/media/HPz5bZea0AAYDD2.jpg",
+                                      "original_info": {
+                                        "focus_rects": [
+                                          {
+                                            "h": 672,
+                                            "w": 1200,
+                                            "x": 0,
+                                            "y": 884
+                                          },
+                                          {
+                                            "h": 1200,
+                                            "w": 1200,
+                                            "x": 0,
+                                            "y": 483
+                                          },
+                                          {
+                                            "h": 1368,
+                                            "w": 1200,
+                                            "x": 0,
+                                            "y": 315
+                                          },
+                                          {
+                                            "h": 1683,
+                                            "w": 842,
+                                            "x": 0,
+                                            "y": 0
+                                          },
+                                          {
+                                            "h": 1683,
+                                            "w": 1200,
+                                            "x": 0,
+                                            "y": 0
+                                          }
+                                        ],
+                                        "height": 1683,
+                                        "width": 1200
+                                      },
+                                      "sizes": {
+                                        "large": {
+                                          "h": 1683,
+                                          "resize": "fit",
+                                          "w": 1200
+                                        },
+                                        "medium": {
+                                          "h": 1200,
+                                          "resize": "fit",
+                                          "w": 856
+                                        },
+                                        "small": {
+                                          "h": 680,
+                                          "resize": "fit",
+                                          "w": 485
+                                        },
+                                        "thumb": {
+                                          "h": 150,
+                                          "resize": "crop",
+                                          "w": 150
+                                        }
+                                      },
+                                      "type": "photo",
+                                      "url": "https://t.co/898qkPcboF"
+                                    }
+                                  ]
+                                },
+                                "favorite_count": 0,
+                                "favorited": false,
+                                "full_text": "@GenshinImpact UID: 893390137\nServer: Asia https://t.co/898qkPcboF",
+                                "id_str": "2088818583791194318",
+                                "in_reply_to_screen_name": "GenshinImpact",
+                                "in_reply_to_status_id_str": "2087720798702498234",
+                                "in_reply_to_user_id_str": "1072404907230060544",
+                                "is_quote_status": false,
+                                "lang": "et",
+                                "possibly_sensitive": false,
+                                "possibly_sensitive_editable": true,
+                                "quote_count": 0,
+                                "reply_count": 0,
+                                "retweet_count": 0,
+                                "retweeted": false,
+                                "user_id_str": "1591590118632325120"
+                              },
+                              "quick_promote_eligibility": {
+                                "eligibility": "IneligibleNotVerified"
+                              },
+                              "rest_id": "2088818583791194318",
+                              "source": "<a href=\"http://twitter.com/download/android\" rel=\"nofollow\">Twitter for Android</a>",
+                              "unmention_data": {},
+                              "views": {
+                                "count": "307",
+                                "state": "EnabledWithCount"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  ],
+                  "metadata": {
+                    "conversationMetadata": {
+                      "allTweetIds": ["2088818583791194318"],
+                      "enableDeduplication": true
+                    }
+                  }
+                },
+                "entryId": "conversationthread-2088818583791194318",
+                "sortIndex": "2088929116056190926"
+              },
+              {
+                "content": {
+                  "__typename": "TimelineTimelineModule",
+                  "clientEventInfo": {
+                    "component": "tweet",
+                    "details": {
+                      "conversationDetails": {
+                        "conversationSection": "HighQuality"
+                      },
+                      "timelinesDetails": {
+                        "controllerData": "DAACDAAEDAABCgABAAAAAAAAAAEKAAIAAAAAAAAAAAoAAwAAAaAKBN5LAAAAAA=="
+                      }
+                    }
+                  },
+                  "displayType": "VerticalConversation",
+                  "entryType": "TimelineTimelineModule",
+                  "items": [
+                    {
+                      "entryId": "conversationthread-2088701597576548521-tweet-2088701597576548521",
+                      "item": {
+                        "clientEventInfo": {
+                          "component": "tweet",
+                          "details": {
+                            "conversationDetails": {
+                              "conversationSection": "HighQuality"
+                            },
+                            "timelinesDetails": {
+                              "controllerData": "DAACDAAEDAABCgABAAAAAAAAAAEKAAIAAAAAAAAAAAoAAwAAAaAKBN5LAAAAAA=="
+                            }
+                          },
+                          "element": "tweet"
+                        },
+                        "itemContent": {
+                          "__typename": "TimelineTweet",
+                          "itemType": "TimelineTweet",
+                          "tweetDisplayType": "Tweet",
+                          "tweet_results": {
+                            "result": {
+                              "__typename": "Tweet",
+                              "core": {
+                                "user_results": {
+                                  "result": {
+                                    "__typename": "User",
+                                    "affiliates_highlighted_label": {},
+                                    "avatar": {
+                                      "image_url": "https://pbs.twimg.com/profile_images/2061919477906780161/GKgHgaBa_normal.jpg"
+                                    },
+                                    "core": {
+                                      "created_at": "Thu Feb 05 21:49:46 +0000 2026",
+                                      "name": "buni",
+                                      "screen_name": "_nomkitty"
+                                    },
+                                    "dm_permissions": {
+                                      "can_dm": false
+                                    },
+                                    "follow_request_sent": false,
+                                    "has_graduated_access": true,
+                                    "id": "VXNlcjoyMDE5NTI4ODQ4MzcxNDgyNjI0",
+                                    "is_blue_verified": false,
+                                    "legacy": {
+                                      "default_profile": true,
+                                      "default_profile_image": false,
+                                      "description": "!+18 | he/him | hya! I mosty draw feminine men, please stay tuned for my post..",
+                                      "entities": {
+                                        "description": {},
+                                        "url": {
+                                          "urls": [
+                                            {
+                                              "display_url": "vgen.co/Nomkitty",
+                                              "expanded_url": "https://vgen.co/Nomkitty",
+                                              "indices": [0, 23],
+                                              "url": "https://t.co/qDNHzxqXpU"
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "fast_followers_count": 0,
+                                      "favourites_count": 1205,
+                                      "follow_request_sent": false,
+                                      "followers_count": 32,
+                                      "friends_count": 26,
+                                      "has_custom_timelines": false,
+                                      "is_translator": false,
+                                      "listed_count": 1,
+                                      "media_count": 30,
+                                      "needs_phone_verification": false,
+                                      "normal_followers_count": 32,
+                                      "notifications": false,
+                                      "possibly_sensitive": false,
+                                      "profile_banner_url": "https://pbs.twimg.com/profile_banners/2019528848371482624/1775448058",
+                                      "profile_interstitial_type": "",
+                                      "statuses_count": 91,
+                                      "time_zone": "",
+                                      "translator_type": "none",
+                                      "url": "https://t.co/qDNHzxqXpU",
+                                      "utc_offset": 0,
+                                      "want_retweets": false,
+                                      "withheld_description": "",
+                                      "withheld_scope": ""
+                                    },
+                                    "location": {
+                                      "location": ""
+                                    },
+                                    "media_permissions": {
+                                      "can_media_tag": true
+                                    },
+                                    "parody_commentary_fan_label": "None",
+                                    "privacy": {
+                                      "protected": false
+                                    },
+                                    "profile_bio": {
+                                      "description": "!+18 | he/him | hya! I mosty draw feminine men, please stay tuned for my post.."
+                                    },
+                                    "profile_description_language": "en",
+                                    "profile_image_shape": "Circle",
+                                    "relationship_perspectives": {
+                                      "blocked_by": false,
+                                      "blocking": false,
+                                      "followed_by": false,
+                                      "following": false,
+                                      "muting": false
+                                    },
+                                    "rest_id": "2019528848371482624",
+                                    "super_follow_eligible": false,
+                                    "super_followed_by": false,
+                                    "super_following": false,
+                                    "verification": {
+                                      "verified": false
+                                    }
+                                  }
+                                }
+                              },
+                              "edit_control": {
+                                "edit_tweet_ids": ["2088701597576548521"],
+                                "editable_until_msecs": "1786823841000",
+                                "edits_remaining": "5",
+                                "is_edit_eligible": false
+                              },
+                              "grok_analysis_button": true,
+                              "grok_annotations": {},
+                              "has_birdwatch_notes": false,
+                              "is_translatable": false,
+                              "legacy": {
+                                "bookmark_count": 0,
+                                "bookmarked": false,
+                                "conversation_id_str": "2087720798702498234",
+                                "created_at": "Sat Aug 15 18:57:21 +0000 2026",
+                                "display_text_range": [15, 45],
+                                "entities": {
+                                  "media": [
+                                    {
+                                      "display_url": "pic.x.com/PxcGheRBfo",
+                                      "expanded_url": "https://x.com/_nomkitty/status/2088701597576548521/photo/1",
+                                      "ext_media_availability": {
+                                        "status": "Available"
+                                      },
+                                      "features": {
+                                        "large": {
+                                          "faces": [
+                                            {
+                                              "h": 127,
+                                              "w": 127,
+                                              "x": 235,
+                                              "y": 468
+                                            },
+                                            {
+                                              "h": 127,
+                                              "w": 127,
+                                              "x": 309,
+                                              "y": 466
+                                            }
+                                          ]
+                                        },
+                                        "medium": {
+                                          "faces": [
+                                            {
+                                              "h": 113,
+                                              "w": 113,
+                                              "x": 210,
+                                              "y": 418
+                                            },
+                                            {
+                                              "h": 113,
+                                              "w": 113,
+                                              "x": 276,
+                                              "y": 417
+                                            }
+                                          ]
+                                        },
+                                        "orig": {
+                                          "faces": [
+                                            {
+                                              "h": 127,
+                                              "w": 127,
+                                              "x": 235,
+                                              "y": 468
+                                            },
+                                            {
+                                              "h": 127,
+                                              "w": 127,
+                                              "x": 309,
+                                              "y": 466
+                                            }
+                                          ]
+                                        },
+                                        "small": {
+                                          "faces": [
+                                            {
+                                              "h": 64,
+                                              "w": 64,
+                                              "x": 119,
+                                              "y": 237
+                                            },
+                                            {
+                                              "h": 64,
+                                              "w": 64,
+                                              "x": 156,
+                                              "y": 236
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "id_str": "2088701592904093696",
+                                      "indices": [46, 69],
+                                      "media_key": "3_2088701592904093696",
+                                      "media_results": {
+                                        "result": {
+                                          "media_key": "3_2088701592904093696"
+                                        }
+                                      },
+                                      "media_url_https": "https://pbs.twimg.com/media/HPyPCEbXUAArbRA.jpg",
+                                      "original_info": {
+                                        "focus_rects": [
+                                          {
+                                            "h": 522,
+                                            "w": 932,
+                                            "x": 0,
+                                            "y": 778
+                                          },
+                                          {
+                                            "h": 932,
+                                            "w": 932,
+                                            "x": 0,
+                                            "y": 409
+                                          },
+                                          {
+                                            "h": 1062,
+                                            "w": 932,
+                                            "x": 0,
+                                            "y": 279
+                                          },
+                                          {
+                                            "h": 1341,
+                                            "w": 671,
+                                            "x": 33,
+                                            "y": 0
+                                          },
+                                          {
+                                            "h": 1341,
+                                            "w": 932,
+                                            "x": 0,
+                                            "y": 0
+                                          }
+                                        ],
+                                        "height": 1341,
+                                        "width": 932
+                                      },
+                                      "sizes": {
+                                        "large": {
+                                          "h": 1341,
+                                          "resize": "fit",
+                                          "w": 932
+                                        },
+                                        "medium": {
+                                          "h": 1200,
+                                          "resize": "fit",
+                                          "w": 834
+                                        },
+                                        "small": {
+                                          "h": 680,
+                                          "resize": "fit",
+                                          "w": 473
+                                        },
+                                        "thumb": {
+                                          "h": 150,
+                                          "resize": "crop",
+                                          "w": 150
+                                        }
+                                      },
+                                      "type": "photo",
+                                      "url": "https://t.co/PxcGheRBfo"
+                                    }
+                                  ],
+                                  "user_mentions": [
+                                    {
+                                      "id_str": "1072404907230060544",
+                                      "indices": [0, 14],
+                                      "name": "Genshin Impact",
+                                      "screen_name": "GenshinImpact"
+                                    }
+                                  ]
+                                },
+                                "extended_entities": {
+                                  "media": [
+                                    {
+                                      "display_url": "pic.x.com/PxcGheRBfo",
+                                      "expanded_url": "https://x.com/_nomkitty/status/2088701597576548521/photo/1",
+                                      "ext_media_availability": {
+                                        "status": "Available"
+                                      },
+                                      "features": {
+                                        "large": {
+                                          "faces": [
+                                            {
+                                              "h": 127,
+                                              "w": 127,
+                                              "x": 235,
+                                              "y": 468
+                                            },
+                                            {
+                                              "h": 127,
+                                              "w": 127,
+                                              "x": 309,
+                                              "y": 466
+                                            }
+                                          ]
+                                        },
+                                        "medium": {
+                                          "faces": [
+                                            {
+                                              "h": 113,
+                                              "w": 113,
+                                              "x": 210,
+                                              "y": 418
+                                            },
+                                            {
+                                              "h": 113,
+                                              "w": 113,
+                                              "x": 276,
+                                              "y": 417
+                                            }
+                                          ]
+                                        },
+                                        "orig": {
+                                          "faces": [
+                                            {
+                                              "h": 127,
+                                              "w": 127,
+                                              "x": 235,
+                                              "y": 468
+                                            },
+                                            {
+                                              "h": 127,
+                                              "w": 127,
+                                              "x": 309,
+                                              "y": 466
+                                            }
+                                          ]
+                                        },
+                                        "small": {
+                                          "faces": [
+                                            {
+                                              "h": 64,
+                                              "w": 64,
+                                              "x": 119,
+                                              "y": 237
+                                            },
+                                            {
+                                              "h": 64,
+                                              "w": 64,
+                                              "x": 156,
+                                              "y": 236
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "id_str": "2088701592904093696",
+                                      "indices": [46, 69],
+                                      "media_key": "3_2088701592904093696",
+                                      "media_results": {
+                                        "result": {
+                                          "media_key": "3_2088701592904093696"
+                                        }
+                                      },
+                                      "media_url_https": "https://pbs.twimg.com/media/HPyPCEbXUAArbRA.jpg",
+                                      "original_info": {
+                                        "focus_rects": [
+                                          {
+                                            "h": 522,
+                                            "w": 932,
+                                            "x": 0,
+                                            "y": 778
+                                          },
+                                          {
+                                            "h": 932,
+                                            "w": 932,
+                                            "x": 0,
+                                            "y": 409
+                                          },
+                                          {
+                                            "h": 1062,
+                                            "w": 932,
+                                            "x": 0,
+                                            "y": 279
+                                          },
+                                          {
+                                            "h": 1341,
+                                            "w": 671,
+                                            "x": 33,
+                                            "y": 0
+                                          },
+                                          {
+                                            "h": 1341,
+                                            "w": 932,
+                                            "x": 0,
+                                            "y": 0
+                                          }
+                                        ],
+                                        "height": 1341,
+                                        "width": 932
+                                      },
+                                      "sizes": {
+                                        "large": {
+                                          "h": 1341,
+                                          "resize": "fit",
+                                          "w": 932
+                                        },
+                                        "medium": {
+                                          "h": 1200,
+                                          "resize": "fit",
+                                          "w": 834
+                                        },
+                                        "small": {
+                                          "h": 680,
+                                          "resize": "fit",
+                                          "w": 473
+                                        },
+                                        "thumb": {
+                                          "h": 150,
+                                          "resize": "crop",
+                                          "w": 150
+                                        }
+                                      },
+                                      "type": "photo",
+                                      "url": "https://t.co/PxcGheRBfo"
+                                    }
+                                  ]
+                                },
+                                "favorite_count": 0,
+                                "favorited": false,
+                                "full_text": "@GenshinImpact UID: 691899657\nServer: America https://t.co/PxcGheRBfo",
+                                "id_str": "2088701597576548521",
+                                "in_reply_to_screen_name": "GenshinImpact",
+                                "in_reply_to_status_id_str": "2087720798702498234",
+                                "in_reply_to_user_id_str": "1072404907230060544",
+                                "is_quote_status": false,
+                                "lang": "pt",
+                                "possibly_sensitive": false,
+                                "possibly_sensitive_editable": true,
+                                "quote_count": 0,
+                                "reply_count": 0,
+                                "retweet_count": 0,
+                                "retweeted": false,
+                                "user_id_str": "2019528848371482624"
+                              },
+                              "quick_promote_eligibility": {
+                                "eligibility": "IneligibleNotVerified"
+                              },
+                              "rest_id": "2088701597576548521",
+                              "source": "<a href=\"http://twitter.com/download/android\" rel=\"nofollow\">Twitter for Android</a>",
+                              "unmention_data": {},
+                              "views": {
+                                "count": "118",
+                                "state": "EnabledWithCount"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  ],
+                  "metadata": {
+                    "conversationMetadata": {
+                      "allTweetIds": ["2088701597576548521"],
+                      "enableDeduplication": true
+                    }
+                  }
+                },
+                "entryId": "conversationthread-2088701597576548521",
+                "sortIndex": "2088929116056190916"
+              },
+              {
+                "content": {
+                  "__typename": "TimelineTimelineModule",
+                  "clientEventInfo": {
+                    "component": "tweet",
+                    "details": {
+                      "conversationDetails": {
+                        "conversationSection": "HighQuality"
+                      },
+                      "timelinesDetails": {
+                        "controllerData": "DAACDAAEDAABCgABAAAAAAAAAAEKAAIAAAAAAAAAAAoAAwAAAaAKBN5LAAAAAA=="
+                      }
+                    }
+                  },
+                  "displayType": "VerticalConversation",
+                  "entryType": "TimelineTimelineModule",
+                  "items": [
+                    {
+                      "entryId": "conversationthread-2088924331447669070-tweet-2088924331447669070",
+                      "item": {
+                        "clientEventInfo": {
+                          "component": "tweet",
+                          "details": {
+                            "conversationDetails": {
+                              "conversationSection": "HighQuality"
+                            },
+                            "timelinesDetails": {
+                              "controllerData": "DAACDAAEDAABCgABAAAAAAAAAAEKAAIAAAAAAAAAAAoAAwAAAaAKBN5LAAAAAA=="
+                            }
+                          },
+                          "element": "tweet"
+                        },
+                        "itemContent": {
+                          "__typename": "TimelineTweet",
+                          "itemType": "TimelineTweet",
+                          "tweetDisplayType": "Tweet",
+                          "tweet_results": {
+                            "result": {
+                              "__typename": "Tweet",
+                              "card": {
+                                "legacy": {
+                                  "binding_values": [
+                                    {
+                                      "key": "photo_image_full_size_large",
+                                      "value": {
+                                        "image_value": {
+                                          "alt": "",
+                                          "height": 419,
+                                          "url": "https://pbs.twimg.com/card_img/2086637755459874816/3u0nQN4I?format=jpg&name=800x419",
+                                          "width": 800
+                                        },
+                                        "type": "IMAGE"
+                                      }
+                                    },
+                                    {
+                                      "key": "thumbnail_image",
+                                      "value": {
+                                        "image_value": {
+                                          "alt": "",
+                                          "height": 147,
+                                          "url": "https://pbs.twimg.com/card_img/2086637755459874816/3u0nQN4I?format=jpg&name=280x150",
+                                          "width": 280
+                                        },
+                                        "type": "IMAGE"
+                                      }
+                                    },
+                                    {
+                                      "key": "domain",
+                                      "value": {
+                                        "string_value": "snezhnayacareertest-en.belugacpn.jp",
+                                        "type": "STRING"
+                                      }
+                                    },
+                                    {
+                                      "key": "thumbnail_image_large",
+                                      "value": {
+                                        "image_value": {
+                                          "alt": "",
+                                          "height": 314,
+                                          "url": "https://pbs.twimg.com/card_img/2086637755459874816/3u0nQN4I?format=jpg&name=600x600",
+                                          "width": 600
+                                        },
+                                        "type": "IMAGE"
+                                      }
+                                    },
+                                    {
+                                      "key": "summary_photo_image_small",
+                                      "value": {
+                                        "image_value": {
+                                          "alt": "",
+                                          "height": 202,
+                                          "url": "https://pbs.twimg.com/card_img/2086637755459874816/3u0nQN4I?format=jpg&name=386x202",
+                                          "width": 386
+                                        },
+                                        "type": "IMAGE"
+                                      }
+                                    },
+                                    {
+                                      "key": "thumbnail_image_original",
+                                      "value": {
+                                        "image_value": {
+                                          "alt": "",
+                                          "height": 628,
+                                          "url": "https://pbs.twimg.com/card_img/2086637755459874816/3u0nQN4I?format=jpg&name=orig",
+                                          "width": 1200
+                                        },
+                                        "type": "IMAGE"
+                                      }
+                                    },
+                                    {
+                                      "key": "photo_image_full_size_small",
+                                      "value": {
+                                        "image_value": {
+                                          "alt": "",
+                                          "height": 202,
+                                          "url": "https://pbs.twimg.com/card_img/2086637755459874816/3u0nQN4I?format=jpg&name=386x202",
+                                          "width": 386
+                                        },
+                                        "type": "IMAGE"
+                                      }
+                                    },
+                                    {
+                                      "key": "summary_photo_image_large",
+                                      "value": {
+                                        "image_value": {
+                                          "alt": "",
+                                          "height": 419,
+                                          "url": "https://pbs.twimg.com/card_img/2086637755459874816/3u0nQN4I?format=jpg&name=800x419",
+                                          "width": 800
+                                        },
+                                        "type": "IMAGE"
+                                      }
+                                    },
+                                    {
+                                      "key": "thumbnail_image_small",
+                                      "value": {
+                                        "image_value": {
+                                          "alt": "",
+                                          "height": 75,
+                                          "url": "https://pbs.twimg.com/card_img/2086637755459874816/3u0nQN4I?format=jpg&name=144x144",
+                                          "width": 144
+                                        },
+                                        "type": "IMAGE"
+                                      }
+                                    },
+                                    {
+                                      "key": "thumbnail_image_x_large",
+                                      "value": {
+                                        "image_value": {
+                                          "alt": "",
+                                          "height": 628,
+                                          "url": "https://pbs.twimg.com/card_img/2086637755459874816/3u0nQN4I?format=png&name=2048x2048_2_exp",
+                                          "width": 1200
+                                        },
+                                        "type": "IMAGE"
+                                      }
+                                    },
+                                    {
+                                      "key": "photo_image_full_size_original",
+                                      "value": {
+                                        "image_value": {
+                                          "alt": "",
+                                          "height": 628,
+                                          "url": "https://pbs.twimg.com/card_img/2086637755459874816/3u0nQN4I?format=jpg&name=orig",
+                                          "width": 1200
+                                        },
+                                        "type": "IMAGE"
+                                      }
+                                    },
+                                    {
+                                      "key": "vanity_url",
+                                      "value": {
+                                        "scribe_key": "vanity_url",
+                                        "string_value": "snezhnayacareertest-en.belugacpn.jp",
+                                        "type": "STRING"
+                                      }
+                                    },
+                                    {
+                                      "key": "photo_image_full_size",
+                                      "value": {
+                                        "image_value": {
+                                          "alt": "",
+                                          "height": 314,
+                                          "url": "https://pbs.twimg.com/card_img/2086637755459874816/3u0nQN4I?format=jpg&name=600x314",
+                                          "width": 600
+                                        },
+                                        "type": "IMAGE"
+                                      }
+                                    },
+                                    {
+                                      "key": "thumbnail_image_color",
+                                      "value": {
+                                        "image_color_value": {
+                                          "palette": [
+                                            {
+                                              "percentage": 44.85,
+                                              "rgb": {
+                                                "blue": 247,
+                                                "green": 235,
+                                                "red": 219
+                                              }
+                                            },
+                                            {
+                                              "percentage": 19.2,
+                                              "rgb": {
+                                                "blue": 237,
+                                                "green": 182,
+                                                "red": 100
+                                              }
+                                            },
+                                            {
+                                              "percentage": 12.67,
+                                              "rgb": {
+                                                "blue": 101,
+                                                "green": 58,
+                                                "red": 38
+                                              }
+                                            },
+                                            {
+                                              "percentage": 3.52,
+                                              "rgb": {
+                                                "blue": 150,
+                                                "green": 227,
+                                                "red": 245
+                                              }
+                                            },
+                                            {
+                                              "percentage": 3.12,
+                                              "rgb": {
+                                                "blue": 74,
+                                                "green": 61,
+                                                "red": 53
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        "type": "IMAGE_COLOR"
+                                      }
+                                    },
+                                    {
+                                      "key": "title",
+                                      "value": {
+                                        "string_value": "Click to start test",
+                                        "type": "STRING"
+                                      }
+                                    },
+                                    {
+                                      "key": "summary_photo_image_color",
+                                      "value": {
+                                        "image_color_value": {
+                                          "palette": [
+                                            {
+                                              "percentage": 44.85,
+                                              "rgb": {
+                                                "blue": 247,
+                                                "green": 235,
+                                                "red": 219
+                                              }
+                                            },
+                                            {
+                                              "percentage": 19.2,
+                                              "rgb": {
+                                                "blue": 237,
+                                                "green": 182,
+                                                "red": 100
+                                              }
+                                            },
+                                            {
+                                              "percentage": 12.67,
+                                              "rgb": {
+                                                "blue": 101,
+                                                "green": 58,
+                                                "red": 38
+                                              }
+                                            },
+                                            {
+                                              "percentage": 3.52,
+                                              "rgb": {
+                                                "blue": 150,
+                                                "green": 227,
+                                                "red": 245
+                                              }
+                                            },
+                                            {
+                                              "percentage": 3.12,
+                                              "rgb": {
+                                                "blue": 74,
+                                                "green": 61,
+                                                "red": 53
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        "type": "IMAGE_COLOR"
+                                      }
+                                    },
+                                    {
+                                      "key": "summary_photo_image_x_large",
+                                      "value": {
+                                        "image_value": {
+                                          "alt": "",
+                                          "height": 628,
+                                          "url": "https://pbs.twimg.com/card_img/2086637755459874816/3u0nQN4I?format=png&name=2048x2048_2_exp",
+                                          "width": 1200
+                                        },
+                                        "type": "IMAGE"
+                                      }
+                                    },
+                                    {
+                                      "key": "summary_photo_image",
+                                      "value": {
+                                        "image_value": {
+                                          "alt": "",
+                                          "height": 314,
+                                          "url": "https://pbs.twimg.com/card_img/2086637755459874816/3u0nQN4I?format=jpg&name=600x314",
+                                          "width": 600
+                                        },
+                                        "type": "IMAGE"
+                                      }
+                                    },
+                                    {
+                                      "key": "photo_image_full_size_color",
+                                      "value": {
+                                        "image_color_value": {
+                                          "palette": [
+                                            {
+                                              "percentage": 44.85,
+                                              "rgb": {
+                                                "blue": 247,
+                                                "green": 235,
+                                                "red": 219
+                                              }
+                                            },
+                                            {
+                                              "percentage": 19.2,
+                                              "rgb": {
+                                                "blue": 237,
+                                                "green": 182,
+                                                "red": 100
+                                              }
+                                            },
+                                            {
+                                              "percentage": 12.67,
+                                              "rgb": {
+                                                "blue": 101,
+                                                "green": 58,
+                                                "red": 38
+                                              }
+                                            },
+                                            {
+                                              "percentage": 3.52,
+                                              "rgb": {
+                                                "blue": 150,
+                                                "green": 227,
+                                                "red": 245
+                                              }
+                                            },
+                                            {
+                                              "percentage": 3.12,
+                                              "rgb": {
+                                                "blue": 74,
+                                                "green": 61,
+                                                "red": 53
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        "type": "IMAGE_COLOR"
+                                      }
+                                    },
+                                    {
+                                      "key": "photo_image_full_size_x_large",
+                                      "value": {
+                                        "image_value": {
+                                          "alt": "",
+                                          "height": 628,
+                                          "url": "https://pbs.twimg.com/card_img/2086637755459874816/3u0nQN4I?format=png&name=2048x2048_2_exp",
+                                          "width": 1200
+                                        },
+                                        "type": "IMAGE"
+                                      }
+                                    },
+                                    {
+                                      "key": "card_url",
+                                      "value": {
+                                        "scribe_key": "card_url",
+                                        "string_value": "https://t.co/hiNh96yNrM",
+                                        "type": "STRING"
+                                      }
+                                    },
+                                    {
+                                      "key": "summary_photo_image_original",
+                                      "value": {
+                                        "image_value": {
+                                          "alt": "",
+                                          "height": 628,
+                                          "url": "https://pbs.twimg.com/card_img/2086637755459874816/3u0nQN4I?format=jpg&name=orig",
+                                          "width": 1200
+                                        },
+                                        "type": "IMAGE"
+                                      }
+                                    }
+                                  ],
+                                  "card_platform": {
+                                    "platform": {
+                                      "audience": {
+                                        "name": "production"
+                                      },
+                                      "device": {
+                                        "name": "Android",
+                                        "version": "12"
+                                      }
+                                    }
+                                  },
+                                  "name": "summary_large_image",
+                                  "url": "https://t.co/hiNh96yNrM",
+                                  "user_refs_results": []
+                                },
+                                "rest_id": "https://t.co/hiNh96yNrM"
+                              },
+                              "core": {
+                                "user_results": {
+                                  "result": {
+                                    "__typename": "User",
+                                    "affiliates_highlighted_label": {},
+                                    "avatar": {
+                                      "image_url": "https://pbs.twimg.com/profile_images/2082588973814497280/LkU8ej1Y_normal.jpg"
+                                    },
+                                    "core": {
+                                      "created_at": "Thu Apr 24 03:39:53 +0000 2025",
+                                      "name": "izzy 🍁",
+                                      "screen_name": "izzybbreezy"
+                                    },
+                                    "dm_permissions": {
+                                      "can_dm": false
+                                    },
+                                    "follow_request_sent": false,
+                                    "has_graduated_access": true,
+                                    "id": "VXNlcjoxOTE1MjQ5MjcwMTY2NTczMDU2",
+                                    "is_blue_verified": false,
+                                    "legacy": {
+                                      "default_profile": true,
+                                      "default_profile_image": false,
+                                      "description": "Conspirary theorist. 🤔🤔🇨🇦🇨🇦🇨🇦\nI’ve met cats and dogs smarter than Trevor and Corey.",
+                                      "entities": {
+                                        "description": {}
+                                      },
+                                      "fast_followers_count": 0,
+                                      "favourites_count": 16953,
+                                      "follow_request_sent": false,
+                                      "followers_count": 25,
+                                      "friends_count": 65,
+                                      "has_custom_timelines": false,
+                                      "is_translator": false,
+                                      "listed_count": 0,
+                                      "media_count": 896,
+                                      "needs_phone_verification": false,
+                                      "normal_followers_count": 25,
+                                      "notifications": false,
+                                      "possibly_sensitive": false,
+                                      "profile_banner_url": "https://pbs.twimg.com/profile_banners/1915249270166573056/1785362968",
+                                      "profile_interstitial_type": "",
+                                      "statuses_count": 12108,
+                                      "time_zone": "",
+                                      "translator_type": "none",
+                                      "url": "",
+                                      "utc_offset": 0,
+                                      "want_retweets": false,
+                                      "withheld_description": "",
+                                      "withheld_scope": ""
+                                    },
+                                    "location": {
+                                      "location": "Retard island"
+                                    },
+                                    "media_permissions": {
+                                      "can_media_tag": true
+                                    },
+                                    "parody_commentary_fan_label": "None",
+                                    "privacy": {
+                                      "protected": false
+                                    },
+                                    "profile_bio": {
+                                      "description": "Conspirary theorist. 🤔🤔🇨🇦🇨🇦🇨🇦\nI’ve met cats and dogs smarter than Trevor and Corey."
+                                    },
+                                    "profile_description_language": "en",
+                                    "profile_image_shape": "Circle",
+                                    "relationship_perspectives": {
+                                      "blocked_by": false,
+                                      "blocking": false,
+                                      "followed_by": false,
+                                      "following": false,
+                                      "muting": false
+                                    },
+                                    "rest_id": "1915249270166573056",
+                                    "super_follow_eligible": false,
+                                    "super_followed_by": false,
+                                    "super_following": false,
+                                    "verification": {
+                                      "verified": false
+                                    }
+                                  }
+                                }
+                              },
+                              "edit_control": {
+                                "edit_tweet_ids": ["2088924331447669070"],
+                                "editable_until_msecs": "1786876945000",
+                                "edits_remaining": "5",
+                                "is_edit_eligible": false
+                              },
+                              "grok_analysis_button": true,
+                              "grok_annotations": {},
+                              "has_birdwatch_notes": false,
+                              "is_translatable": false,
+                              "legacy": {
+                                "bookmark_count": 0,
+                                "bookmarked": false,
+                                "conversation_id_str": "2087720798702498234",
+                                "created_at": "Sun Aug 16 09:42:25 +0000 2026",
+                                "display_text_range": [15, 69],
+                                "entities": {
+                                  "urls": [
+                                    {
+                                      "display_url": "snezhnayacareertest-en.belugacpn.jp/7ad9ae3d.html?…",
+                                      "expanded_url": "https://snezhnayacareertest-en.belugacpn.jp/7ad9ae3d.html?q=ZxOVp0b5NH9YczyKF7zjQSkfQPT2fetEp4VjdEeT05v3RNlb-N9LubOt5-xsohfLUBR8FeCfljVoYIr5AB03Mqeyuu6o8025aHuj8-FgZRLIjvzGzpOgsOUDx4-AZKhPzmtqhtQ6qCTB0NgchX0RzcqH-AyFd1by-qdRuQ0wMzqLVQtRSHcErw==",
+                                      "indices": [46, 69],
+                                      "url": "https://t.co/hiNh96yNrM"
+                                    }
+                                  ],
+                                  "user_mentions": [
+                                    {
+                                      "id_str": "1072404907230060544",
+                                      "indices": [0, 14],
+                                      "name": "Genshin Impact",
+                                      "screen_name": "GenshinImpact"
+                                    }
+                                  ]
+                                },
+                                "favorite_count": 0,
+                                "favorited": false,
+                                "full_text": "@GenshinImpact UID 629645911 American server \nhttps://t.co/hiNh96yNrM",
+                                "id_str": "2088924331447669070",
+                                "in_reply_to_screen_name": "GenshinImpact",
+                                "in_reply_to_status_id_str": "2087720798702498234",
+                                "in_reply_to_user_id_str": "1072404907230060544",
+                                "is_quote_status": false,
+                                "lang": "en",
+                                "possibly_sensitive": false,
+                                "possibly_sensitive_editable": true,
+                                "quote_count": 0,
+                                "reply_count": 0,
+                                "retweet_count": 0,
+                                "retweeted": false,
+                                "user_id_str": "1915249270166573056"
+                              },
+                              "quick_promote_eligibility": {
+                                "eligibility": "IneligibleNotVerified"
+                              },
+                              "rest_id": "2088924331447669070",
+                              "source": "<a href=\"http://twitter.com/#!/download/ipad\" rel=\"nofollow\">Twitter for iPad</a>",
+                              "unmention_data": {},
+                              "views": {
+                                "count": "8",
+                                "state": "EnabledWithCount"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  ],
+                  "metadata": {
+                    "conversationMetadata": {
+                      "allTweetIds": ["2088924331447669070"],
+                      "enableDeduplication": true
+                    }
+                  }
+                },
+                "entryId": "conversationthread-2088924331447669070",
+                "sortIndex": "2088929116056190906"
+              },
+              {
+                "content": {
+                  "__typename": "TimelineTimelineModule",
+                  "clientEventInfo": {
+                    "component": "tweet",
+                    "details": {
+                      "conversationDetails": {
+                        "conversationSection": "HighQuality"
+                      },
+                      "timelinesDetails": {
+                        "controllerData": "DAACDAAEDAABCgABAAAAAAAAAAEKAAIAAAAAAAAAAAoAAwAAAaAKBN5LAAAAAA=="
+                      }
+                    }
+                  },
+                  "displayType": "VerticalConversation",
+                  "entryType": "TimelineTimelineModule",
+                  "items": [
+                    {
+                      "entryId": "conversationthread-2088458540088222143-tweet-2088458540088222143",
+                      "item": {
+                        "clientEventInfo": {
+                          "component": "tweet",
+                          "details": {
+                            "conversationDetails": {
+                              "conversationSection": "HighQuality"
+                            },
+                            "timelinesDetails": {
+                              "controllerData": "DAACDAAEDAABCgABAAAAAAAAAAEKAAIAAAAAAAAAAAoAAwAAAaAKBN5LAAAAAA=="
+                            }
+                          },
+                          "element": "tweet"
+                        },
+                        "itemContent": {
+                          "__typename": "TimelineTweet",
+                          "itemType": "TimelineTweet",
+                          "tweetDisplayType": "Tweet",
+                          "tweet_results": {
+                            "result": {
+                              "__typename": "Tweet",
+                              "core": {
+                                "user_results": {
+                                  "result": {
+                                    "__typename": "User",
+                                    "affiliates_highlighted_label": {},
+                                    "avatar": {
+                                      "image_url": "https://pbs.twimg.com/profile_images/2012685659681488896/QfZRghXd_normal.jpg"
+                                    },
+                                    "core": {
+                                      "created_at": "Thu Jan 01 20:21:34 +0000 2026",
+                                      "name": "lalita",
+                                      "screen_name": "interrrlude"
+                                    },
+                                    "dm_permissions": {
+                                      "can_dm": false
+                                    },
+                                    "follow_request_sent": false,
+                                    "has_graduated_access": true,
+                                    "id": "VXNlcjoyMDA2ODIyNzU1MzY3NTMwNTAy",
+                                    "is_blue_verified": false,
+                                    "legacy": {
+                                      "default_profile": true,
+                                      "default_profile_image": false,
+                                      "description": "19 | #edtwt | gw: 50kg",
+                                      "entities": {
+                                        "description": {}
+                                      },
+                                      "fast_followers_count": 0,
+                                      "favourites_count": 163,
+                                      "follow_request_sent": false,
+                                      "followers_count": 15,
+                                      "friends_count": 18,
+                                      "has_custom_timelines": false,
+                                      "is_translator": false,
+                                      "listed_count": 0,
+                                      "media_count": 1,
+                                      "needs_phone_verification": false,
+                                      "normal_followers_count": 15,
+                                      "notifications": false,
+                                      "possibly_sensitive": false,
+                                      "profile_banner_url": "https://pbs.twimg.com/profile_banners/2006822755367530502/1767649972",
+                                      "profile_interstitial_type": "",
+                                      "statuses_count": 64,
+                                      "time_zone": "",
+                                      "translator_type": "none",
+                                      "url": "",
+                                      "utc_offset": 0,
+                                      "want_retweets": false,
+                                      "withheld_description": "",
+                                      "withheld_scope": ""
+                                    },
+                                    "location": {
+                                      "location": ""
+                                    },
+                                    "media_permissions": {
+                                      "can_media_tag": false
+                                    },
+                                    "parody_commentary_fan_label": "None",
+                                    "privacy": {
+                                      "protected": false
+                                    },
+                                    "profile_bio": {
+                                      "description": "19 | #edtwt | gw: 50kg"
+                                    },
+                                    "profile_description_language": "id",
+                                    "profile_image_shape": "Circle",
+                                    "relationship_perspectives": {
+                                      "blocked_by": false,
+                                      "blocking": false,
+                                      "followed_by": false,
+                                      "following": false,
+                                      "muting": false
+                                    },
+                                    "rest_id": "2006822755367530502",
+                                    "super_follow_eligible": false,
+                                    "super_followed_by": false,
+                                    "super_following": false,
+                                    "verification": {
+                                      "verified": false
+                                    }
+                                  }
+                                }
+                              },
+                              "edit_control": {
+                                "edit_tweet_ids": ["2088458540088222143"],
+                                "editable_until_msecs": "1786765892000",
+                                "edits_remaining": "5",
+                                "is_edit_eligible": false
+                              },
+                              "grok_analysis_button": true,
+                              "grok_annotations": {},
+                              "has_birdwatch_notes": false,
+                              "is_translatable": false,
+                              "legacy": {
+                                "bookmark_count": 0,
+                                "bookmarked": false,
+                                "conversation_id_str": "2087720798702498234",
+                                "created_at": "Sat Aug 15 02:51:32 +0000 2026",
+                                "display_text_range": [15, 38],
+                                "entities": {
+                                  "media": [
+                                    {
+                                      "display_url": "pic.x.com/f7oN788XL1",
+                                      "expanded_url": "https://x.com/interrrlude/status/2088458540088222143/photo/1",
+                                      "ext_media_availability": {
+                                        "status": "Available"
+                                      },
+                                      "features": {
+                                        "large": {
+                                          "faces": []
+                                        },
+                                        "medium": {
+                                          "faces": []
+                                        },
+                                        "orig": {
+                                          "faces": []
+                                        },
+                                        "small": {
+                                          "faces": []
+                                        }
+                                      },
+                                      "id_str": "2088458536074293248",
+                                      "indices": [39, 62],
+                                      "media_key": "3_2088458536074293248",
+                                      "media_results": {
+                                        "result": {
+                                          "media_key": "3_2088458536074293248"
+                                        }
+                                      },
+                                      "media_url_https": "https://pbs.twimg.com/media/HPux-TLXMAA-Ds-.jpg",
+                                      "original_info": {
+                                        "focus_rects": [
+                                          {
+                                            "h": 655,
+                                            "w": 1170,
+                                            "x": 0,
+                                            "y": 686
+                                          },
+                                          {
+                                            "h": 1170,
+                                            "w": 1170,
+                                            "x": 0,
+                                            "y": 171
+                                          },
+                                          {
+                                            "h": 1334,
+                                            "w": 1170,
+                                            "x": 0,
+                                            "y": 7
+                                          },
+                                          {
+                                            "h": 1341,
+                                            "w": 671,
+                                            "x": 250,
+                                            "y": 0
+                                          },
+                                          {
+                                            "h": 1341,
+                                            "w": 1170,
+                                            "x": 0,
+                                            "y": 0
+                                          }
+                                        ],
+                                        "height": 1341,
+                                        "width": 1170
+                                      },
+                                      "sizes": {
+                                        "large": {
+                                          "h": 1341,
+                                          "resize": "fit",
+                                          "w": 1170
+                                        },
+                                        "medium": {
+                                          "h": 1200,
+                                          "resize": "fit",
+                                          "w": 1047
+                                        },
+                                        "small": {
+                                          "h": 680,
+                                          "resize": "fit",
+                                          "w": 593
+                                        },
+                                        "thumb": {
+                                          "h": 150,
+                                          "resize": "crop",
+                                          "w": 150
+                                        }
+                                      },
+                                      "type": "photo",
+                                      "url": "https://t.co/f7oN788XL1"
+                                    }
+                                  ],
+                                  "user_mentions": [
+                                    {
+                                      "id_str": "1072404907230060544",
+                                      "indices": [0, 14],
+                                      "name": "Genshin Impact",
+                                      "screen_name": "GenshinImpact"
+                                    }
+                                  ]
+                                },
+                                "extended_entities": {
+                                  "media": [
+                                    {
+                                      "display_url": "pic.x.com/f7oN788XL1",
+                                      "expanded_url": "https://x.com/interrrlude/status/2088458540088222143/photo/1",
+                                      "ext_media_availability": {
+                                        "status": "Available"
+                                      },
+                                      "features": {
+                                        "large": {
+                                          "faces": []
+                                        },
+                                        "medium": {
+                                          "faces": []
+                                        },
+                                        "orig": {
+                                          "faces": []
+                                        },
+                                        "small": {
+                                          "faces": []
+                                        }
+                                      },
+                                      "id_str": "2088458536074293248",
+                                      "indices": [39, 62],
+                                      "media_key": "3_2088458536074293248",
+                                      "media_results": {
+                                        "result": {
+                                          "media_key": "3_2088458536074293248"
+                                        }
+                                      },
+                                      "media_url_https": "https://pbs.twimg.com/media/HPux-TLXMAA-Ds-.jpg",
+                                      "original_info": {
+                                        "focus_rects": [
+                                          {
+                                            "h": 655,
+                                            "w": 1170,
+                                            "x": 0,
+                                            "y": 686
+                                          },
+                                          {
+                                            "h": 1170,
+                                            "w": 1170,
+                                            "x": 0,
+                                            "y": 171
+                                          },
+                                          {
+                                            "h": 1334,
+                                            "w": 1170,
+                                            "x": 0,
+                                            "y": 7
+                                          },
+                                          {
+                                            "h": 1341,
+                                            "w": 671,
+                                            "x": 250,
+                                            "y": 0
+                                          },
+                                          {
+                                            "h": 1341,
+                                            "w": 1170,
+                                            "x": 0,
+                                            "y": 0
+                                          }
+                                        ],
+                                        "height": 1341,
+                                        "width": 1170
+                                      },
+                                      "sizes": {
+                                        "large": {
+                                          "h": 1341,
+                                          "resize": "fit",
+                                          "w": 1170
+                                        },
+                                        "medium": {
+                                          "h": 1200,
+                                          "resize": "fit",
+                                          "w": 1047
+                                        },
+                                        "small": {
+                                          "h": 680,
+                                          "resize": "fit",
+                                          "w": 593
+                                        },
+                                        "thumb": {
+                                          "h": 150,
+                                          "resize": "crop",
+                                          "w": 150
+                                        }
+                                      },
+                                      "type": "photo",
+                                      "url": "https://t.co/f7oN788XL1"
+                                    }
+                                  ]
+                                },
+                                "favorite_count": 0,
+                                "favorited": false,
+                                "full_text": "@GenshinImpact uid 622559028 server NA https://t.co/f7oN788XL1",
+                                "id_str": "2088458540088222143",
+                                "in_reply_to_screen_name": "GenshinImpact",
+                                "in_reply_to_status_id_str": "2087720798702498234",
+                                "in_reply_to_user_id_str": "1072404907230060544",
+                                "is_quote_status": false,
+                                "lang": "tl",
+                                "possibly_sensitive": false,
+                                "possibly_sensitive_editable": true,
+                                "quote_count": 0,
+                                "reply_count": 0,
+                                "retweet_count": 0,
+                                "retweeted": false,
+                                "user_id_str": "2006822755367530502"
+                              },
+                              "quick_promote_eligibility": {
+                                "eligibility": "IneligibleNotVerified"
+                              },
+                              "rest_id": "2088458540088222143",
+                              "source": "<a href=\"http://twitter.com/download/iphone\" rel=\"nofollow\">Twitter for iPhone</a>",
+                              "unmention_data": {},
+                              "views": {
+                                "count": "612",
+                                "state": "EnabledWithCount"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  ],
+                  "metadata": {
+                    "conversationMetadata": {
+                      "allTweetIds": ["2088458540088222143"],
+                      "enableDeduplication": true
+                    }
+                  }
+                },
+                "entryId": "conversationthread-2088458540088222143",
+                "sortIndex": "2088929116056190896"
+              },
+              {
+                "content": {
+                  "__typename": "TimelineTimelineModule",
+                  "clientEventInfo": {
+                    "component": "tweet",
+                    "details": {
+                      "conversationDetails": {
+                        "conversationSection": "HighQuality"
+                      },
+                      "timelinesDetails": {
+                        "controllerData": "DAACDAAEDAABCgABAAAAAAAAAAEKAAIAAAAAAAAAAAoAAwAAAaAKBN5LAAAAAA=="
+                      }
+                    }
+                  },
+                  "displayType": "VerticalConversation",
+                  "entryType": "TimelineTimelineModule",
+                  "items": [
+                    {
+                      "entryId": "conversationthread-2088081894038503496-tweet-2088081894038503496",
+                      "item": {
+                        "clientEventInfo": {
+                          "component": "tweet",
+                          "details": {
+                            "conversationDetails": {
+                              "conversationSection": "HighQuality"
+                            },
+                            "timelinesDetails": {
+                              "controllerData": "DAACDAAEDAABCgABAAAAAAAAAAEKAAIAAAAAAAAAAAoAAwAAAaAKBN5LAAAAAA=="
+                            }
+                          },
+                          "element": "tweet"
+                        },
+                        "itemContent": {
+                          "__typename": "TimelineTweet",
+                          "itemType": "TimelineTweet",
+                          "tweetDisplayType": "Tweet",
+                          "tweet_results": {
+                            "result": {
+                              "__typename": "Tweet",
+                              "core": {
+                                "user_results": {
+                                  "result": {
+                                    "__typename": "User",
+                                    "affiliates_highlighted_label": {},
+                                    "avatar": {
+                                      "image_url": "https://pbs.twimg.com/profile_images/2044597276820013056/t-xulcxx_normal.jpg"
+                                    },
+                                    "core": {
+                                      "created_at": "Thu Apr 16 02:01:54 +0000 2026",
+                                      "name": "Diluc of shtwt !!",
+                                      "screen_name": "spcfx2"
+                                    },
+                                    "dm_permissions": {
+                                      "can_dm": false
+                                    },
+                                    "follow_request_sent": false,
+                                    "has_graduated_access": true,
+                                    "id": "VXNlcjoyMDQ0NTk3MDYyOTM5OTE4MzM2",
+                                    "is_blue_verified": false,
+                                    "legacy": {
+                                      "default_profile": true,
+                                      "default_profile_image": false,
+                                      "description": "19 | he/him | #shtwt",
+                                      "entities": {
+                                        "description": {}
+                                      },
+                                      "fast_followers_count": 0,
+                                      "favourites_count": 4577,
+                                      "follow_request_sent": false,
+                                      "followers_count": 15,
+                                      "friends_count": 55,
+                                      "has_custom_timelines": false,
+                                      "is_translator": false,
+                                      "listed_count": 0,
+                                      "media_count": 3,
+                                      "needs_phone_verification": false,
+                                      "normal_followers_count": 15,
+                                      "notifications": false,
+                                      "possibly_sensitive": false,
+                                      "profile_banner_url": "https://pbs.twimg.com/profile_banners/2044597062939918336/1776305084",
+                                      "profile_interstitial_type": "",
+                                      "statuses_count": 328,
+                                      "time_zone": "",
+                                      "translator_type": "none",
+                                      "url": "",
+                                      "utc_offset": 0,
+                                      "want_retweets": false,
+                                      "withheld_description": "",
+                                      "withheld_scope": ""
+                                    },
+                                    "location": {
+                                      "location": ""
+                                    },
+                                    "media_permissions": {
+                                      "can_media_tag": true
+                                    },
+                                    "parody_commentary_fan_label": "None",
+                                    "privacy": {
+                                      "protected": false
+                                    },
+                                    "profile_bio": {
+                                      "description": "19 | he/him | #shtwt"
+                                    },
+                                    "profile_description_language": "en",
+                                    "profile_image_shape": "Circle",
+                                    "relationship_perspectives": {
+                                      "blocked_by": false,
+                                      "blocking": false,
+                                      "followed_by": false,
+                                      "following": false,
+                                      "muting": false
+                                    },
+                                    "rest_id": "2044597062939918336",
+                                    "super_follow_eligible": false,
+                                    "super_followed_by": false,
+                                    "super_following": false,
+                                    "verification": {
+                                      "verified": false
+                                    }
+                                  }
+                                }
+                              },
+                              "edit_control": {
+                                "edit_tweet_ids": ["2088081894038503496"],
+                                "editable_until_msecs": "1786676092000",
+                                "edits_remaining": "5",
+                                "is_edit_eligible": false
+                              },
+                              "grok_analysis_button": true,
+                              "grok_annotations": {},
+                              "has_birdwatch_notes": false,
+                              "is_translatable": false,
+                              "legacy": {
+                                "bookmark_count": 0,
+                                "bookmarked": false,
+                                "conversation_id_str": "2087720798702498234",
+                                "created_at": "Fri Aug 14 01:54:52 +0000 2026",
+                                "display_text_range": [15, 42],
+                                "entities": {
+                                  "media": [
+                                    {
+                                      "display_url": "pic.x.com/DWmgPgV4oH",
+                                      "expanded_url": "https://x.com/spcfx2/status/2088081894038503496/photo/1",
+                                      "ext_media_availability": {
+                                        "status": "Available"
+                                      },
+                                      "features": {
+                                        "large": {
+                                          "faces": [
+                                            {
+                                              "h": 45,
+                                              "w": 45,
+                                              "x": 1008,
+                                              "y": 586
+                                            }
+                                          ]
+                                        },
+                                        "medium": {
+                                          "faces": [
+                                            {
+                                              "h": 45,
+                                              "w": 45,
+                                              "x": 1008,
+                                              "y": 586
+                                            }
+                                          ]
+                                        },
+                                        "orig": {
+                                          "faces": [
+                                            {
+                                              "h": 45,
+                                              "w": 45,
+                                              "x": 1008,
+                                              "y": 586
+                                            }
+                                          ]
+                                        },
+                                        "small": {
+                                          "faces": [
+                                            {
+                                              "h": 26,
+                                              "w": 26,
+                                              "x": 585,
+                                              "y": 340
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "id_str": "2088081891077349376",
+                                      "indices": [43, 66],
+                                      "media_key": "3_2088081891077349376",
+                                      "media_results": {
+                                        "result": {
+                                          "media_key": "3_2088081891077349376"
+                                        }
+                                      },
+                                      "media_url_https": "https://pbs.twimg.com/media/HPpbarOXYAA3IBf.jpg",
+                                      "original_info": {
+                                        "focus_rects": [
+                                          {
+                                            "h": 655,
+                                            "w": 1170,
+                                            "x": 0,
+                                            "y": 509
+                                          },
+                                          {
+                                            "h": 1164,
+                                            "w": 1164,
+                                            "x": 0,
+                                            "y": 0
+                                          },
+                                          {
+                                            "h": 1164,
+                                            "w": 1021,
+                                            "x": 0,
+                                            "y": 0
+                                          },
+                                          {
+                                            "h": 1164,
+                                            "w": 582,
+                                            "x": 89,
+                                            "y": 0
+                                          },
+                                          {
+                                            "h": 1164,
+                                            "w": 1170,
+                                            "x": 0,
+                                            "y": 0
+                                          }
+                                        ],
+                                        "height": 1164,
+                                        "width": 1170
+                                      },
+                                      "sizes": {
+                                        "large": {
+                                          "h": 1164,
+                                          "resize": "fit",
+                                          "w": 1170
+                                        },
+                                        "medium": {
+                                          "h": 1164,
+                                          "resize": "fit",
+                                          "w": 1170
+                                        },
+                                        "small": {
+                                          "h": 677,
+                                          "resize": "fit",
+                                          "w": 680
+                                        },
+                                        "thumb": {
+                                          "h": 150,
+                                          "resize": "crop",
+                                          "w": 150
+                                        }
+                                      },
+                                      "type": "photo",
+                                      "url": "https://t.co/DWmgPgV4oH"
+                                    }
+                                  ],
+                                  "user_mentions": [
+                                    {
+                                      "id_str": "1072404907230060544",
+                                      "indices": [0, 14],
+                                      "name": "Genshin Impact",
+                                      "screen_name": "GenshinImpact"
+                                    }
+                                  ]
+                                },
+                                "extended_entities": {
+                                  "media": [
+                                    {
+                                      "display_url": "pic.x.com/DWmgPgV4oH",
+                                      "expanded_url": "https://x.com/spcfx2/status/2088081894038503496/photo/1",
+                                      "ext_media_availability": {
+                                        "status": "Available"
+                                      },
+                                      "features": {
+                                        "large": {
+                                          "faces": [
+                                            {
+                                              "h": 45,
+                                              "w": 45,
+                                              "x": 1008,
+                                              "y": 586
+                                            }
+                                          ]
+                                        },
+                                        "medium": {
+                                          "faces": [
+                                            {
+                                              "h": 45,
+                                              "w": 45,
+                                              "x": 1008,
+                                              "y": 586
+                                            }
+                                          ]
+                                        },
+                                        "orig": {
+                                          "faces": [
+                                            {
+                                              "h": 45,
+                                              "w": 45,
+                                              "x": 1008,
+                                              "y": 586
+                                            }
+                                          ]
+                                        },
+                                        "small": {
+                                          "faces": [
+                                            {
+                                              "h": 26,
+                                              "w": 26,
+                                              "x": 585,
+                                              "y": 340
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "id_str": "2088081891077349376",
+                                      "indices": [43, 66],
+                                      "media_key": "3_2088081891077349376",
+                                      "media_results": {
+                                        "result": {
+                                          "media_key": "3_2088081891077349376"
+                                        }
+                                      },
+                                      "media_url_https": "https://pbs.twimg.com/media/HPpbarOXYAA3IBf.jpg",
+                                      "original_info": {
+                                        "focus_rects": [
+                                          {
+                                            "h": 655,
+                                            "w": 1170,
+                                            "x": 0,
+                                            "y": 509
+                                          },
+                                          {
+                                            "h": 1164,
+                                            "w": 1164,
+                                            "x": 0,
+                                            "y": 0
+                                          },
+                                          {
+                                            "h": 1164,
+                                            "w": 1021,
+                                            "x": 0,
+                                            "y": 0
+                                          },
+                                          {
+                                            "h": 1164,
+                                            "w": 582,
+                                            "x": 89,
+                                            "y": 0
+                                          },
+                                          {
+                                            "h": 1164,
+                                            "w": 1170,
+                                            "x": 0,
+                                            "y": 0
+                                          }
+                                        ],
+                                        "height": 1164,
+                                        "width": 1170
+                                      },
+                                      "sizes": {
+                                        "large": {
+                                          "h": 1164,
+                                          "resize": "fit",
+                                          "w": 1170
+                                        },
+                                        "medium": {
+                                          "h": 1164,
+                                          "resize": "fit",
+                                          "w": 1170
+                                        },
+                                        "small": {
+                                          "h": 677,
+                                          "resize": "fit",
+                                          "w": 680
+                                        },
+                                        "thumb": {
+                                          "h": 150,
+                                          "resize": "crop",
+                                          "w": 150
+                                        }
+                                      },
+                                      "type": "photo",
+                                      "url": "https://t.co/DWmgPgV4oH"
+                                    }
+                                  ]
+                                },
+                                "favorite_count": 0,
+                                "favorited": false,
+                                "full_text": "@GenshinImpact America / NA\nUID: 659479216 https://t.co/DWmgPgV4oH",
+                                "id_str": "2088081894038503496",
+                                "in_reply_to_screen_name": "GenshinImpact",
+                                "in_reply_to_status_id_str": "2087720798702498234",
+                                "in_reply_to_user_id_str": "1072404907230060544",
+                                "is_quote_status": false,
+                                "lang": "nl",
+                                "possibly_sensitive": false,
+                                "possibly_sensitive_editable": true,
+                                "quote_count": 0,
+                                "reply_count": 0,
+                                "retweet_count": 0,
+                                "retweeted": false,
+                                "user_id_str": "2044597062939918336"
+                              },
+                              "quick_promote_eligibility": {
+                                "eligibility": "IneligibleNotVerified"
+                              },
+                              "rest_id": "2088081894038503496",
+                              "source": "<a href=\"http://twitter.com/download/iphone\" rel=\"nofollow\">Twitter for iPhone</a>",
+                              "unmention_data": {},
+                              "views": {
+                                "count": "592",
+                                "state": "EnabledWithCount"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  ],
+                  "metadata": {
+                    "conversationMetadata": {
+                      "allTweetIds": ["2088081894038503496"],
+                      "enableDeduplication": true
+                    }
+                  }
+                },
+                "entryId": "conversationthread-2088081894038503496",
+                "sortIndex": "2088929116056190886"
+              },
+              {
+                "content": {
+                  "__typename": "TimelineTimelineModule",
+                  "clientEventInfo": {
+                    "component": "tweet",
+                    "details": {
+                      "conversationDetails": {
+                        "conversationSection": "HighQuality"
+                      },
+                      "timelinesDetails": {
+                        "controllerData": "DAACDAAEDAABCgABAAAAAAAAAAEKAAIAAAAAAAAAAAoAAwAAAaAKBN5LAAAAAA=="
+                      }
+                    }
+                  },
+                  "displayType": "VerticalConversation",
+                  "entryType": "TimelineTimelineModule",
+                  "items": [
+                    {
+                      "entryId": "conversationthread-2088396478590939303-tweet-2088396478590939303",
+                      "item": {
+                        "clientEventInfo": {
+                          "component": "tweet",
+                          "details": {
+                            "conversationDetails": {
+                              "conversationSection": "HighQuality"
+                            },
+                            "timelinesDetails": {
+                              "controllerData": "DAACDAAEDAABCgABAAAAAAAAAAEKAAIAAAAAAAAAAAoAAwAAAaAKBN5LAAAAAA=="
+                            }
+                          },
+                          "element": "tweet"
+                        },
+                        "itemContent": {
+                          "__typename": "TimelineTweet",
+                          "itemType": "TimelineTweet",
+                          "tweetDisplayType": "Tweet",
+                          "tweet_results": {
+                            "result": {
+                              "__typename": "Tweet",
+                              "core": {
+                                "user_results": {
+                                  "result": {
+                                    "__typename": "User",
+                                    "affiliates_highlighted_label": {},
+                                    "avatar": {
+                                      "image_url": "https://pbs.twimg.com/profile_images/2052121075949912064/5C6Y6byx_normal.jpg"
+                                    },
+                                    "core": {
+                                      "created_at": "Thu Jul 31 20:05:04 +0000 2025",
+                                      "name": "𝚛𝚢𝚊𝚗 - 💫🎵",
+                                      "screen_name": "rrrrrryanross"
+                                    },
+                                    "dm_permissions": {
+                                      "can_dm": false
+                                    },
+                                    "follow_request_sent": false,
+                                    "has_graduated_access": true,
+                                    "id": "VXNlcjoxOTUxMDExMTk4OTE0MjExODQy",
+                                    "is_blue_verified": false,
+                                    "legacy": {
+                                      "default_profile": true,
+                                      "default_profile_image": false,
+                                      "description": "hi i like p!atd okay...?",
+                                      "entities": {
+                                        "description": {}
+                                      },
+                                      "fast_followers_count": 0,
+                                      "favourites_count": 993,
+                                      "follow_request_sent": false,
+                                      "followers_count": 7,
+                                      "friends_count": 41,
+                                      "has_custom_timelines": false,
+                                      "is_translator": false,
+                                      "listed_count": 0,
+                                      "media_count": 5,
+                                      "needs_phone_verification": false,
+                                      "normal_followers_count": 7,
+                                      "notifications": false,
+                                      "possibly_sensitive": false,
+                                      "profile_banner_url": "https://pbs.twimg.com/profile_banners/1951011198914211842/1778098766",
+                                      "profile_interstitial_type": "",
+                                      "statuses_count": 240,
+                                      "time_zone": "",
+                                      "translator_type": "none",
+                                      "url": "",
+                                      "utc_offset": 0,
+                                      "want_retweets": false,
+                                      "withheld_description": "",
+                                      "withheld_scope": ""
+                                    },
+                                    "location": {
+                                      "location": ""
+                                    },
+                                    "media_permissions": {
+                                      "can_media_tag": true
+                                    },
+                                    "parody_commentary_fan_label": "None",
+                                    "privacy": {
+                                      "protected": false
+                                    },
+                                    "profile_bio": {
+                                      "description": "hi i like p!atd okay...?"
+                                    },
+                                    "profile_description_language": "en",
+                                    "profile_image_shape": "Circle",
+                                    "relationship_perspectives": {
+                                      "blocked_by": false,
+                                      "blocking": false,
+                                      "followed_by": false,
+                                      "following": false,
+                                      "muting": false
+                                    },
+                                    "rest_id": "1951011198914211842",
+                                    "super_follow_eligible": false,
+                                    "super_followed_by": false,
+                                    "super_following": false,
+                                    "verification": {
+                                      "verified": false
+                                    }
+                                  }
+                                }
+                              },
+                              "edit_control": {
+                                "edit_tweet_ids": ["2088396478590939303"],
+                                "editable_until_msecs": "1786751095000",
+                                "edits_remaining": "5",
+                                "is_edit_eligible": false
+                              },
+                              "grok_analysis_button": true,
+                              "grok_annotations": {},
+                              "has_birdwatch_notes": false,
+                              "is_translatable": false,
+                              "legacy": {
+                                "bookmark_count": 0,
+                                "bookmarked": false,
+                                "conversation_id_str": "2087720798702498234",
+                                "created_at": "Fri Aug 14 22:44:55 +0000 2026",
+                                "display_text_range": [15, 44],
+                                "entities": {
+                                  "media": [
+                                    {
+                                      "display_url": "pic.x.com/LSquxJu3bl",
+                                      "expanded_url": "https://x.com/rrrrrryanross/status/2088396478590939303/photo/1",
+                                      "ext_media_availability": {
+                                        "status": "Available"
+                                      },
+                                      "features": {
+                                        "large": {
+                                          "faces": []
+                                        },
+                                        "medium": {
+                                          "faces": []
+                                        },
+                                        "orig": {
+                                          "faces": []
+                                        },
+                                        "small": {
+                                          "faces": []
+                                        }
+                                      },
+                                      "id_str": "2088396475038359552",
+                                      "indices": [45, 68],
+                                      "media_key": "3_2088396475038359552",
+                                      "media_results": {
+                                        "result": {
+                                          "media_key": "3_2088396475038359552"
+                                        }
+                                      },
+                                      "media_url_https": "https://pbs.twimg.com/media/HPt5h3zW4AAREuA.jpg",
+                                      "original_info": {
+                                        "focus_rects": [
+                                          {
+                                            "h": 605,
+                                            "w": 1080,
+                                            "x": 0,
+                                            "y": 530
+                                          },
+                                          {
+                                            "h": 1080,
+                                            "w": 1080,
+                                            "x": 0,
+                                            "y": 55
+                                          },
+                                          {
+                                            "h": 1135,
+                                            "w": 996,
+                                            "x": 42,
+                                            "y": 0
+                                          },
+                                          {
+                                            "h": 1135,
+                                            "w": 568,
+                                            "x": 256,
+                                            "y": 0
+                                          },
+                                          {
+                                            "h": 1135,
+                                            "w": 1080,
+                                            "x": 0,
+                                            "y": 0
+                                          }
+                                        ],
+                                        "height": 1135,
+                                        "width": 1080
+                                      },
+                                      "sizes": {
+                                        "large": {
+                                          "h": 1135,
+                                          "resize": "fit",
+                                          "w": 1080
+                                        },
+                                        "medium": {
+                                          "h": 1135,
+                                          "resize": "fit",
+                                          "w": 1080
+                                        },
+                                        "small": {
+                                          "h": 680,
+                                          "resize": "fit",
+                                          "w": 647
+                                        },
+                                        "thumb": {
+                                          "h": 150,
+                                          "resize": "crop",
+                                          "w": 150
+                                        }
+                                      },
+                                      "type": "photo",
+                                      "url": "https://t.co/LSquxJu3bl"
+                                    }
+                                  ],
+                                  "user_mentions": [
+                                    {
+                                      "id_str": "1072404907230060544",
+                                      "indices": [0, 14],
+                                      "name": "Genshin Impact",
+                                      "screen_name": "GenshinImpact"
+                                    }
+                                  ]
+                                },
+                                "extended_entities": {
+                                  "media": [
+                                    {
+                                      "display_url": "pic.x.com/LSquxJu3bl",
+                                      "expanded_url": "https://x.com/rrrrrryanross/status/2088396478590939303/photo/1",
+                                      "ext_media_availability": {
+                                        "status": "Available"
+                                      },
+                                      "features": {
+                                        "large": {
+                                          "faces": []
+                                        },
+                                        "medium": {
+                                          "faces": []
+                                        },
+                                        "orig": {
+                                          "faces": []
+                                        },
+                                        "small": {
+                                          "faces": []
+                                        }
+                                      },
+                                      "id_str": "2088396475038359552",
+                                      "indices": [45, 68],
+                                      "media_key": "3_2088396475038359552",
+                                      "media_results": {
+                                        "result": {
+                                          "media_key": "3_2088396475038359552"
+                                        }
+                                      },
+                                      "media_url_https": "https://pbs.twimg.com/media/HPt5h3zW4AAREuA.jpg",
+                                      "original_info": {
+                                        "focus_rects": [
+                                          {
+                                            "h": 605,
+                                            "w": 1080,
+                                            "x": 0,
+                                            "y": 530
+                                          },
+                                          {
+                                            "h": 1080,
+                                            "w": 1080,
+                                            "x": 0,
+                                            "y": 55
+                                          },
+                                          {
+                                            "h": 1135,
+                                            "w": 996,
+                                            "x": 42,
+                                            "y": 0
+                                          },
+                                          {
+                                            "h": 1135,
+                                            "w": 568,
+                                            "x": 256,
+                                            "y": 0
+                                          },
+                                          {
+                                            "h": 1135,
+                                            "w": 1080,
+                                            "x": 0,
+                                            "y": 0
+                                          }
+                                        ],
+                                        "height": 1135,
+                                        "width": 1080
+                                      },
+                                      "sizes": {
+                                        "large": {
+                                          "h": 1135,
+                                          "resize": "fit",
+                                          "w": 1080
+                                        },
+                                        "medium": {
+                                          "h": 1135,
+                                          "resize": "fit",
+                                          "w": 1080
+                                        },
+                                        "small": {
+                                          "h": 680,
+                                          "resize": "fit",
+                                          "w": 647
+                                        },
+                                        "thumb": {
+                                          "h": 150,
+                                          "resize": "crop",
+                                          "w": 150
+                                        }
+                                      },
+                                      "type": "photo",
+                                      "url": "https://t.co/LSquxJu3bl"
+                                    }
+                                  ]
+                                },
+                                "favorite_count": 0,
+                                "favorited": false,
+                                "full_text": "@GenshinImpact America server\nUid: 675895324 https://t.co/LSquxJu3bl",
+                                "id_str": "2088396478590939303",
+                                "in_reply_to_screen_name": "GenshinImpact",
+                                "in_reply_to_status_id_str": "2087720798702498234",
+                                "in_reply_to_user_id_str": "1072404907230060544",
+                                "is_quote_status": false,
+                                "lang": "ca",
+                                "possibly_sensitive": false,
+                                "possibly_sensitive_editable": true,
+                                "quote_count": 0,
+                                "reply_count": 0,
+                                "retweet_count": 0,
+                                "retweeted": false,
+                                "user_id_str": "1951011198914211842"
+                              },
+                              "quick_promote_eligibility": {
+                                "eligibility": "IneligibleNotVerified"
+                              },
+                              "rest_id": "2088396478590939303",
+                              "source": "<a href=\"http://twitter.com/download/android\" rel=\"nofollow\">Twitter for Android</a>",
+                              "unmention_data": {},
+                              "views": {
+                                "count": "255",
+                                "state": "EnabledWithCount"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  ],
+                  "metadata": {
+                    "conversationMetadata": {
+                      "allTweetIds": ["2088396478590939303"],
+                      "enableDeduplication": true
+                    }
+                  }
+                },
+                "entryId": "conversationthread-2088396478590939303",
+                "sortIndex": "2088929116056190876"
+              },
+              {
+                "content": {
+                  "__typename": "TimelineTimelineModule",
+                  "clientEventInfo": {
+                    "component": "tweet",
+                    "details": {
+                      "conversationDetails": {
+                        "conversationSection": "HighQuality"
+                      },
+                      "timelinesDetails": {
+                        "controllerData": "DAACDAAEDAABCgABAAAAAAAAAAEKAAIAAAAAAAAAAAoAAwAAAaAKBN5LAAAAAA=="
+                      }
+                    }
+                  },
+                  "displayType": "VerticalConversation",
+                  "entryType": "TimelineTimelineModule",
+                  "items": [
+                    {
+                      "entryId": "conversationthread-2088876329798365199-tweet-2088876329798365199",
+                      "item": {
+                        "clientEventInfo": {
+                          "component": "tweet",
+                          "details": {
+                            "conversationDetails": {
+                              "conversationSection": "HighQuality"
+                            },
+                            "timelinesDetails": {
+                              "controllerData": "DAACDAAEDAABCgABAAAAAAAAAAEKAAIAAAAAAAAAAAoAAwAAAaAKBN5LAAAAAA=="
+                            }
+                          },
+                          "element": "tweet"
+                        },
+                        "itemContent": {
+                          "__typename": "TimelineTweet",
+                          "itemType": "TimelineTweet",
+                          "tweetDisplayType": "Tweet",
+                          "tweet_results": {
+                            "result": {
+                              "__typename": "Tweet",
+                              "core": {
+                                "user_results": {
+                                  "result": {
+                                    "__typename": "User",
+                                    "affiliates_highlighted_label": {},
+                                    "avatar": {
+                                      "image_url": "https://pbs.twimg.com/profile_images/2055141951461306368/Yd78ml0z_normal.jpg"
+                                    },
+                                    "core": {
+                                      "created_at": "Fri May 15 04:23:06 +0000 2026",
+                                      "name": "Kåt",
+                                      "screen_name": "katxton"
+                                    },
+                                    "dm_permissions": {
+                                      "can_dm": true
+                                    },
+                                    "follow_request_sent": false,
+                                    "has_graduated_access": true,
+                                    "id": "VXNlcjoyMDU1MTQxODc0MTQ3NjcyMDY0",
+                                    "is_blue_verified": false,
+                                    "legacy": {
+                                      "default_profile": true,
+                                      "default_profile_image": false,
+                                      "description": "M2x\ni like space.\nburntout.artist\ngnshn uid 800900153",
+                                      "entities": {
+                                        "description": {}
+                                      },
+                                      "fast_followers_count": 0,
+                                      "favourites_count": 205,
+                                      "follow_request_sent": false,
+                                      "followers_count": 1,
+                                      "friends_count": 44,
+                                      "has_custom_timelines": false,
+                                      "is_translator": false,
+                                      "listed_count": 0,
+                                      "media_count": 7,
+                                      "needs_phone_verification": false,
+                                      "normal_followers_count": 1,
+                                      "notifications": false,
+                                      "possibly_sensitive": false,
+                                      "profile_banner_url": "https://pbs.twimg.com/profile_banners/2055141874147672064/1778819188",
+                                      "profile_interstitial_type": "",
+                                      "statuses_count": 108,
+                                      "time_zone": "",
+                                      "translator_type": "none",
+                                      "url": "",
+                                      "utc_offset": 0,
+                                      "want_retweets": false,
+                                      "withheld_description": "",
+                                      "withheld_scope": ""
+                                    },
+                                    "location": {
+                                      "location": ""
+                                    },
+                                    "media_permissions": {
+                                      "can_media_tag": true
+                                    },
+                                    "parody_commentary_fan_label": "None",
+                                    "privacy": {
+                                      "protected": false
+                                    },
+                                    "profile_bio": {
+                                      "description": "M2x\ni like space.\nburntout.artist\ngnshn uid 800900153"
+                                    },
+                                    "profile_description_language": "en",
+                                    "profile_image_shape": "Circle",
+                                    "relationship_perspectives": {
+                                      "blocked_by": false,
+                                      "blocking": false,
+                                      "followed_by": false,
+                                      "following": false,
+                                      "muting": false
+                                    },
+                                    "rest_id": "2055141874147672064",
+                                    "super_follow_eligible": false,
+                                    "super_followed_by": false,
+                                    "super_following": false,
+                                    "verification": {
+                                      "verified": false
+                                    }
+                                  }
+                                }
+                              },
+                              "edit_control": {
+                                "edit_tweet_ids": ["2088876329798365199"],
+                                "editable_until_msecs": "1786865501000",
+                                "edits_remaining": "5",
+                                "is_edit_eligible": false
+                              },
+                              "grok_analysis_button": true,
+                              "grok_annotations": {},
+                              "has_birdwatch_notes": false,
+                              "is_translatable": false,
+                              "legacy": {
+                                "bookmark_count": 0,
+                                "bookmarked": false,
+                                "conversation_id_str": "2087720798702498234",
+                                "created_at": "Sun Aug 16 06:31:41 +0000 2026",
+                                "display_text_range": [15, 42],
+                                "entities": {
+                                  "media": [
+                                    {
+                                      "allow_download_status": {
+                                        "allow_download": true
+                                      },
+                                      "display_url": "pic.x.com/Fqypkk2mfu",
+                                      "expanded_url": "https://x.com/katxton/status/2088876329798365199/photo/1",
+                                      "ext_media_availability": {
+                                        "status": "Available"
+                                      },
+                                      "features": {
+                                        "large": {
+                                          "faces": []
+                                        },
+                                        "medium": {
+                                          "faces": []
+                                        },
+                                        "orig": {
+                                          "faces": []
+                                        },
+                                        "small": {
+                                          "faces": []
+                                        }
+                                      },
+                                      "id_str": "2088876300144631809",
+                                      "indices": [43, 66],
+                                      "media_key": "3_2088876300144631809",
+                                      "media_results": {
+                                        "result": {
+                                          "media_key": "3_2088876300144631809"
+                                        }
+                                      },
+                                      "media_url_https": "https://pbs.twimg.com/media/HP0t7XnaYAEEYNp.png",
+                                      "original_info": {
+                                        "focus_rects": [
+                                          {
+                                            "h": 218,
+                                            "w": 389,
+                                            "x": 0,
+                                            "y": 196
+                                          },
+                                          {
+                                            "h": 389,
+                                            "w": 389,
+                                            "x": 0,
+                                            "y": 25
+                                          },
+                                          {
+                                            "h": 414,
+                                            "w": 363,
+                                            "x": 0,
+                                            "y": 0
+                                          },
+                                          {
+                                            "h": 414,
+                                            "w": 207,
+                                            "x": 31,
+                                            "y": 0
+                                          },
+                                          {
+                                            "h": 414,
+                                            "w": 389,
+                                            "x": 0,
+                                            "y": 0
+                                          }
+                                        ],
+                                        "height": 414,
+                                        "width": 389
+                                      },
+                                      "sizes": {
+                                        "large": {
+                                          "h": 414,
+                                          "resize": "fit",
+                                          "w": 389
+                                        },
+                                        "medium": {
+                                          "h": 414,
+                                          "resize": "fit",
+                                          "w": 389
+                                        },
+                                        "small": {
+                                          "h": 414,
+                                          "resize": "fit",
+                                          "w": 389
+                                        },
+                                        "thumb": {
+                                          "h": 150,
+                                          "resize": "crop",
+                                          "w": 150
+                                        }
+                                      },
+                                      "type": "photo",
+                                      "url": "https://t.co/Fqypkk2mfu"
+                                    }
+                                  ],
+                                  "user_mentions": [
+                                    {
+                                      "id_str": "1072404907230060544",
+                                      "indices": [0, 14],
+                                      "name": "Genshin Impact",
+                                      "screen_name": "GenshinImpact"
+                                    }
+                                  ]
+                                },
+                                "extended_entities": {
+                                  "media": [
+                                    {
+                                      "allow_download_status": {
+                                        "allow_download": true
+                                      },
+                                      "display_url": "pic.x.com/Fqypkk2mfu",
+                                      "expanded_url": "https://x.com/katxton/status/2088876329798365199/photo/1",
+                                      "ext_media_availability": {
+                                        "status": "Available"
+                                      },
+                                      "features": {
+                                        "large": {
+                                          "faces": []
+                                        },
+                                        "medium": {
+                                          "faces": []
+                                        },
+                                        "orig": {
+                                          "faces": []
+                                        },
+                                        "small": {
+                                          "faces": []
+                                        }
+                                      },
+                                      "id_str": "2088876300144631809",
+                                      "indices": [43, 66],
+                                      "media_key": "3_2088876300144631809",
+                                      "media_results": {
+                                        "result": {
+                                          "media_key": "3_2088876300144631809"
+                                        }
+                                      },
+                                      "media_url_https": "https://pbs.twimg.com/media/HP0t7XnaYAEEYNp.png",
+                                      "original_info": {
+                                        "focus_rects": [
+                                          {
+                                            "h": 218,
+                                            "w": 389,
+                                            "x": 0,
+                                            "y": 196
+                                          },
+                                          {
+                                            "h": 389,
+                                            "w": 389,
+                                            "x": 0,
+                                            "y": 25
+                                          },
+                                          {
+                                            "h": 414,
+                                            "w": 363,
+                                            "x": 0,
+                                            "y": 0
+                                          },
+                                          {
+                                            "h": 414,
+                                            "w": 207,
+                                            "x": 31,
+                                            "y": 0
+                                          },
+                                          {
+                                            "h": 414,
+                                            "w": 389,
+                                            "x": 0,
+                                            "y": 0
+                                          }
+                                        ],
+                                        "height": 414,
+                                        "width": 389
+                                      },
+                                      "sizes": {
+                                        "large": {
+                                          "h": 414,
+                                          "resize": "fit",
+                                          "w": 389
+                                        },
+                                        "medium": {
+                                          "h": 414,
+                                          "resize": "fit",
+                                          "w": 389
+                                        },
+                                        "small": {
+                                          "h": 414,
+                                          "resize": "fit",
+                                          "w": 389
+                                        },
+                                        "thumb": {
+                                          "h": 150,
+                                          "resize": "crop",
+                                          "w": 150
+                                        }
+                                      },
+                                      "type": "photo",
+                                      "url": "https://t.co/Fqypkk2mfu"
+                                    }
+                                  ]
+                                },
+                                "favorite_count": 0,
+                                "favorited": false,
+                                "full_text": "@GenshinImpact Asia server\nUID : 800900153 https://t.co/Fqypkk2mfu",
+                                "id_str": "2088876329798365199",
+                                "in_reply_to_screen_name": "GenshinImpact",
+                                "in_reply_to_status_id_str": "2087720798702498234",
+                                "in_reply_to_user_id_str": "1072404907230060544",
+                                "is_quote_status": false,
+                                "lang": "no",
+                                "possibly_sensitive": false,
+                                "possibly_sensitive_editable": true,
+                                "quote_count": 0,
+                                "reply_count": 0,
+                                "retweet_count": 0,
+                                "retweeted": false,
+                                "user_id_str": "2055141874147672064"
+                              },
+                              "quick_promote_eligibility": {
+                                "eligibility": "IneligibleNotVerified"
+                              },
+                              "rest_id": "2088876329798365199",
+                              "source": "<a href=\"https://mobile.twitter.com\" rel=\"nofollow\">Twitter Web App</a>",
+                              "unmention_data": {},
+                              "views": {
+                                "count": "111",
+                                "state": "EnabledWithCount"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  ],
+                  "metadata": {
+                    "conversationMetadata": {
+                      "allTweetIds": ["2088876329798365199"],
+                      "enableDeduplication": true
+                    }
+                  }
+                },
+                "entryId": "conversationthread-2088876329798365199",
+                "sortIndex": "2088929116056190866"
+              },
+              {
+                "content": {
+                  "__typename": "TimelineTimelineModule",
+                  "clientEventInfo": {
+                    "component": "tweet",
+                    "details": {
+                      "conversationDetails": {
+                        "conversationSection": "HighQuality"
+                      },
+                      "timelinesDetails": {
+                        "controllerData": "DAACDAAEDAABCgABAAAAAAAAAAEKAAIAAAAAAAAAAAoAAwAAAaAKBN5LAAAAAA=="
+                      }
+                    }
+                  },
+                  "displayType": "VerticalConversation",
+                  "entryType": "TimelineTimelineModule",
+                  "items": [
+                    {
+                      "entryId": "conversationthread-2088069347738522081-tweet-2088069347738522081",
+                      "item": {
+                        "clientEventInfo": {
+                          "component": "tweet",
+                          "details": {
+                            "conversationDetails": {
+                              "conversationSection": "HighQuality"
+                            },
+                            "timelinesDetails": {
+                              "controllerData": "DAACDAAEDAABCgABAAAAAAAAAAEKAAIAAAAAAAAAAAoAAwAAAaAKBN5LAAAAAA=="
+                            }
+                          },
+                          "element": "tweet"
+                        },
+                        "itemContent": {
+                          "__typename": "TimelineTweet",
+                          "itemType": "TimelineTweet",
+                          "tweetDisplayType": "Tweet",
+                          "tweet_results": {
+                            "result": {
+                              "__typename": "Tweet",
+                              "core": {
+                                "user_results": {
+                                  "result": {
+                                    "__typename": "User",
+                                    "affiliates_highlighted_label": {},
+                                    "avatar": {
+                                      "image_url": "https://pbs.twimg.com/profile_images/1521597454554214407/A3EJH1dy_normal.jpg"
+                                    },
+                                    "core": {
+                                      "created_at": "Tue May 03 21:07:57 +0000 2022",
+                                      "name": "Brit Pal",
+                                      "screen_name": "Ryud1ce"
+                                    },
+                                    "dm_permissions": {
+                                      "can_dm": false
+                                    },
+                                    "follow_request_sent": false,
+                                    "has_graduated_access": true,
+                                    "id": "VXNlcjoxNTIxNTk3Mzg3NTE2NTYzNDU2",
+                                    "is_blue_verified": false,
+                                    "legacy": {
+                                      "default_profile": true,
+                                      "default_profile_image": false,
+                                      "description": "",
+                                      "entities": {
+                                        "description": {}
+                                      },
+                                      "fast_followers_count": 0,
+                                      "favourites_count": 29887,
+                                      "follow_request_sent": false,
+                                      "followers_count": 55,
+                                      "friends_count": 106,
+                                      "has_custom_timelines": true,
+                                      "is_translator": false,
+                                      "listed_count": 0,
+                                      "media_count": 7,
+                                      "needs_phone_verification": false,
+                                      "normal_followers_count": 55,
+                                      "notifications": false,
+                                      "possibly_sensitive": false,
+                                      "profile_banner_url": "",
+                                      "profile_interstitial_type": "",
+                                      "statuses_count": 1895,
+                                      "time_zone": "",
+                                      "translator_type": "none",
+                                      "url": "",
+                                      "utc_offset": 0,
+                                      "want_retweets": false,
+                                      "withheld_description": "",
+                                      "withheld_scope": ""
+                                    },
+                                    "location": {
+                                      "location": ""
+                                    },
+                                    "media_permissions": {
+                                      "can_media_tag": true
+                                    },
+                                    "parody_commentary_fan_label": "None",
+                                    "privacy": {
+                                      "protected": false
+                                    },
+                                    "profile_bio": {
+                                      "description": ""
+                                    },
+                                    "profile_image_shape": "Circle",
+                                    "relationship_perspectives": {
+                                      "blocked_by": false,
+                                      "blocking": false,
+                                      "followed_by": false,
+                                      "following": false,
+                                      "muting": false
+                                    },
+                                    "rest_id": "1521597387516563456",
+                                    "super_follow_eligible": false,
+                                    "super_followed_by": false,
+                                    "super_following": false,
+                                    "verification": {
+                                      "verified": false
+                                    }
+                                  }
+                                }
+                              },
+                              "edit_control": {
+                                "edit_tweet_ids": ["2088069347738522081"],
+                                "editable_until_msecs": "1786673101000",
+                                "edits_remaining": "5",
+                                "is_edit_eligible": false
+                              },
+                              "grok_analysis_button": true,
+                              "grok_annotations": {},
+                              "has_birdwatch_notes": false,
+                              "is_translatable": false,
+                              "legacy": {
+                                "bookmark_count": 0,
+                                "bookmarked": false,
+                                "conversation_id_str": "2087720798702498234",
+                                "created_at": "Fri Aug 14 01:05:01 +0000 2026",
+                                "display_text_range": [15, 29],
+                                "entities": {
+                                  "media": [
+                                    {
+                                      "display_url": "pic.x.com/OZtcB4MJX2",
+                                      "expanded_url": "https://x.com/Ryud1ce/status/2088069347738522081/photo/1",
+                                      "ext_media_availability": {
+                                        "status": "Available"
+                                      },
+                                      "features": {
+                                        "large": {
+                                          "faces": [
+                                            {
+                                              "h": 45,
+                                              "w": 45,
+                                              "x": 993,
+                                              "y": 565
+                                            }
+                                          ]
+                                        },
+                                        "medium": {
+                                          "faces": [
+                                            {
+                                              "h": 45,
+                                              "w": 45,
+                                              "x": 993,
+                                              "y": 565
+                                            }
+                                          ]
+                                        },
+                                        "orig": {
+                                          "faces": [
+                                            {
+                                              "h": 45,
+                                              "w": 45,
+                                              "x": 993,
+                                              "y": 565
+                                            }
+                                          ]
+                                        },
+                                        "small": {
+                                          "faces": [
+                                            {
+                                              "h": 28,
+                                              "w": 28,
+                                              "x": 625,
+                                              "y": 355
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "id_str": "2088069343775010816",
+                                      "indices": [30, 53],
+                                      "media_key": "3_2088069343775010816",
+                                      "media_results": {
+                                        "result": {
+                                          "media_key": "3_2088069343775010816"
+                                        }
+                                      },
+                                      "media_url_https": "https://pbs.twimg.com/media/HPpQAU4XsAAYmhf.jpg",
+                                      "original_info": {
+                                        "focus_rects": [
+                                          {
+                                            "h": 605,
+                                            "w": 1080,
+                                            "x": 0,
+                                            "y": 475
+                                          },
+                                          {
+                                            "h": 1080,
+                                            "w": 1080,
+                                            "x": 0,
+                                            "y": 0
+                                          },
+                                          {
+                                            "h": 1080,
+                                            "w": 947,
+                                            "x": 133,
+                                            "y": 0
+                                          },
+                                          {
+                                            "h": 1080,
+                                            "w": 540,
+                                            "x": 459,
+                                            "y": 0
+                                          },
+                                          {
+                                            "h": 1080,
+                                            "w": 1080,
+                                            "x": 0,
+                                            "y": 0
+                                          }
+                                        ],
+                                        "height": 1080,
+                                        "width": 1080
+                                      },
+                                      "sizes": {
+                                        "large": {
+                                          "h": 1080,
+                                          "resize": "fit",
+                                          "w": 1080
+                                        },
+                                        "medium": {
+                                          "h": 1080,
+                                          "resize": "fit",
+                                          "w": 1080
+                                        },
+                                        "small": {
+                                          "h": 680,
+                                          "resize": "fit",
+                                          "w": 680
+                                        },
+                                        "thumb": {
+                                          "h": 150,
+                                          "resize": "crop",
+                                          "w": 150
+                                        }
+                                      },
+                                      "type": "photo",
+                                      "url": "https://t.co/OZtcB4MJX2"
+                                    }
+                                  ],
+                                  "user_mentions": [
+                                    {
+                                      "id_str": "1072404907230060544",
+                                      "indices": [0, 14],
+                                      "name": "Genshin Impact",
+                                      "screen_name": "GenshinImpact"
+                                    }
+                                  ]
+                                },
+                                "extended_entities": {
+                                  "media": [
+                                    {
+                                      "display_url": "pic.x.com/OZtcB4MJX2",
+                                      "expanded_url": "https://x.com/Ryud1ce/status/2088069347738522081/photo/1",
+                                      "ext_media_availability": {
+                                        "status": "Available"
+                                      },
+                                      "features": {
+                                        "large": {
+                                          "faces": [
+                                            {
+                                              "h": 45,
+                                              "w": 45,
+                                              "x": 993,
+                                              "y": 565
+                                            }
+                                          ]
+                                        },
+                                        "medium": {
+                                          "faces": [
+                                            {
+                                              "h": 45,
+                                              "w": 45,
+                                              "x": 993,
+                                              "y": 565
+                                            }
+                                          ]
+                                        },
+                                        "orig": {
+                                          "faces": [
+                                            {
+                                              "h": 45,
+                                              "w": 45,
+                                              "x": 993,
+                                              "y": 565
+                                            }
+                                          ]
+                                        },
+                                        "small": {
+                                          "faces": [
+                                            {
+                                              "h": 28,
+                                              "w": 28,
+                                              "x": 625,
+                                              "y": 355
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "id_str": "2088069343775010816",
+                                      "indices": [30, 53],
+                                      "media_key": "3_2088069343775010816",
+                                      "media_results": {
+                                        "result": {
+                                          "media_key": "3_2088069343775010816"
+                                        }
+                                      },
+                                      "media_url_https": "https://pbs.twimg.com/media/HPpQAU4XsAAYmhf.jpg",
+                                      "original_info": {
+                                        "focus_rects": [
+                                          {
+                                            "h": 605,
+                                            "w": 1080,
+                                            "x": 0,
+                                            "y": 475
+                                          },
+                                          {
+                                            "h": 1080,
+                                            "w": 1080,
+                                            "x": 0,
+                                            "y": 0
+                                          },
+                                          {
+                                            "h": 1080,
+                                            "w": 947,
+                                            "x": 133,
+                                            "y": 0
+                                          },
+                                          {
+                                            "h": 1080,
+                                            "w": 540,
+                                            "x": 459,
+                                            "y": 0
+                                          },
+                                          {
+                                            "h": 1080,
+                                            "w": 1080,
+                                            "x": 0,
+                                            "y": 0
+                                          }
+                                        ],
+                                        "height": 1080,
+                                        "width": 1080
+                                      },
+                                      "sizes": {
+                                        "large": {
+                                          "h": 1080,
+                                          "resize": "fit",
+                                          "w": 1080
+                                        },
+                                        "medium": {
+                                          "h": 1080,
+                                          "resize": "fit",
+                                          "w": 1080
+                                        },
+                                        "small": {
+                                          "h": 680,
+                                          "resize": "fit",
+                                          "w": 680
+                                        },
+                                        "thumb": {
+                                          "h": 150,
+                                          "resize": "crop",
+                                          "w": 150
+                                        }
+                                      },
+                                      "type": "photo",
+                                      "url": "https://t.co/OZtcB4MJX2"
+                                    }
+                                  ]
+                                },
+                                "favorite_count": 0,
+                                "favorited": false,
+                                "full_text": "@GenshinImpact UID: 606617592 https://t.co/OZtcB4MJX2",
+                                "id_str": "2088069347738522081",
+                                "in_reply_to_screen_name": "GenshinImpact",
+                                "in_reply_to_status_id_str": "2087720798702498234",
+                                "in_reply_to_user_id_str": "1072404907230060544",
+                                "is_quote_status": false,
+                                "lang": "und",
+                                "possibly_sensitive": false,
+                                "possibly_sensitive_editable": true,
+                                "quote_count": 0,
+                                "reply_count": 0,
+                                "retweet_count": 0,
+                                "retweeted": false,
+                                "user_id_str": "1521597387516563456"
+                              },
+                              "quick_promote_eligibility": {
+                                "eligibility": "IneligibleNotVerified"
+                              },
+                              "rest_id": "2088069347738522081",
+                              "source": "<a href=\"http://twitter.com/download/android\" rel=\"nofollow\">Twitter for Android</a>",
+                              "unmention_data": {},
+                              "views": {
+                                "count": "171",
+                                "state": "EnabledWithCount"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  ],
+                  "metadata": {
+                    "conversationMetadata": {
+                      "allTweetIds": ["2088069347738522081"],
+                      "enableDeduplication": true
+                    }
+                  }
+                },
+                "entryId": "conversationthread-2088069347738522081",
+                "sortIndex": "2088929116056190856"
+              },
+              {
+                "content": {
+                  "__typename": "TimelineTimelineModule",
+                  "clientEventInfo": {
+                    "component": "tweet",
+                    "details": {
+                      "conversationDetails": {
+                        "conversationSection": "HighQuality"
+                      },
+                      "timelinesDetails": {
+                        "controllerData": "DAACDAAEDAABCgABAAAAAAAAAAEKAAIAAAAAAAAAAAoAAwAAAaAKBN5LAAAAAA=="
+                      }
+                    }
+                  },
+                  "displayType": "VerticalConversation",
+                  "entryType": "TimelineTimelineModule",
+                  "items": [
+                    {
+                      "entryId": "conversationthread-2088859755565469848-tweet-2088859755565469848",
+                      "item": {
+                        "clientEventInfo": {
+                          "component": "tweet",
+                          "details": {
+                            "conversationDetails": {
+                              "conversationSection": "HighQuality"
+                            },
+                            "timelinesDetails": {
+                              "controllerData": "DAACDAAEDAABCgABAAAAAAAAAAEKAAIAAAAAAAAAAAoAAwAAAaAKBN5LAAAAAA=="
+                            }
+                          },
+                          "element": "tweet"
+                        },
+                        "itemContent": {
+                          "__typename": "TimelineTweet",
+                          "itemType": "TimelineTweet",
+                          "tweetDisplayType": "Tweet",
+                          "tweet_results": {
+                            "result": {
+                              "__typename": "Tweet",
+                              "card": {
+                                "legacy": {
+                                  "binding_values": [
+                                    {
+                                      "key": "photo_image_full_size_large",
+                                      "value": {
+                                        "image_value": {
+                                          "alt": "",
+                                          "height": 419,
+                                          "url": "https://pbs.twimg.com/card_img/2087720956575813633/hJghuv6c?format=jpg&name=800x419",
+                                          "width": 800
+                                        },
+                                        "type": "IMAGE"
+                                      }
+                                    },
+                                    {
+                                      "key": "thumbnail_image",
+                                      "value": {
+                                        "image_value": {
+                                          "alt": "",
+                                          "height": 147,
+                                          "url": "https://pbs.twimg.com/card_img/2087720956575813633/hJghuv6c?format=jpg&name=280x150",
+                                          "width": 280
+                                        },
+                                        "type": "IMAGE"
+                                      }
+                                    },
+                                    {
+                                      "key": "domain",
+                                      "value": {
+                                        "string_value": "snezhnayacareertest-en.belugacpn.jp",
+                                        "type": "STRING"
+                                      }
+                                    },
+                                    {
+                                      "key": "thumbnail_image_large",
+                                      "value": {
+                                        "image_value": {
+                                          "alt": "",
+                                          "height": 314,
+                                          "url": "https://pbs.twimg.com/card_img/2087720956575813633/hJghuv6c?format=jpg&name=600x600",
+                                          "width": 600
+                                        },
+                                        "type": "IMAGE"
+                                      }
+                                    },
+                                    {
+                                      "key": "summary_photo_image_small",
+                                      "value": {
+                                        "image_value": {
+                                          "alt": "",
+                                          "height": 202,
+                                          "url": "https://pbs.twimg.com/card_img/2087720956575813633/hJghuv6c?format=jpg&name=386x202",
+                                          "width": 386
+                                        },
+                                        "type": "IMAGE"
+                                      }
+                                    },
+                                    {
+                                      "key": "thumbnail_image_original",
+                                      "value": {
+                                        "image_value": {
+                                          "alt": "",
+                                          "height": 628,
+                                          "url": "https://pbs.twimg.com/card_img/2087720956575813633/hJghuv6c?format=jpg&name=orig",
+                                          "width": 1200
+                                        },
+                                        "type": "IMAGE"
+                                      }
+                                    },
+                                    {
+                                      "key": "photo_image_full_size_small",
+                                      "value": {
+                                        "image_value": {
+                                          "alt": "",
+                                          "height": 202,
+                                          "url": "https://pbs.twimg.com/card_img/2087720956575813633/hJghuv6c?format=jpg&name=386x202",
+                                          "width": 386
+                                        },
+                                        "type": "IMAGE"
+                                      }
+                                    },
+                                    {
+                                      "key": "summary_photo_image_large",
+                                      "value": {
+                                        "image_value": {
+                                          "alt": "",
+                                          "height": 419,
+                                          "url": "https://pbs.twimg.com/card_img/2087720956575813633/hJghuv6c?format=jpg&name=800x419",
+                                          "width": 800
+                                        },
+                                        "type": "IMAGE"
+                                      }
+                                    },
+                                    {
+                                      "key": "thumbnail_image_small",
+                                      "value": {
+                                        "image_value": {
+                                          "alt": "",
+                                          "height": 75,
+                                          "url": "https://pbs.twimg.com/card_img/2087720956575813633/hJghuv6c?format=jpg&name=144x144",
+                                          "width": 144
+                                        },
+                                        "type": "IMAGE"
+                                      }
+                                    },
+                                    {
+                                      "key": "thumbnail_image_x_large",
+                                      "value": {
+                                        "image_value": {
+                                          "alt": "",
+                                          "height": 628,
+                                          "url": "https://pbs.twimg.com/card_img/2087720956575813633/hJghuv6c?format=png&name=2048x2048_2_exp",
+                                          "width": 1200
+                                        },
+                                        "type": "IMAGE"
+                                      }
+                                    },
+                                    {
+                                      "key": "photo_image_full_size_original",
+                                      "value": {
+                                        "image_value": {
+                                          "alt": "",
+                                          "height": 628,
+                                          "url": "https://pbs.twimg.com/card_img/2087720956575813633/hJghuv6c?format=jpg&name=orig",
+                                          "width": 1200
+                                        },
+                                        "type": "IMAGE"
+                                      }
+                                    },
+                                    {
+                                      "key": "vanity_url",
+                                      "value": {
+                                        "scribe_key": "vanity_url",
+                                        "string_value": "snezhnayacareertest-en.belugacpn.jp",
+                                        "type": "STRING"
+                                      }
+                                    },
+                                    {
+                                      "key": "photo_image_full_size",
+                                      "value": {
+                                        "image_value": {
+                                          "alt": "",
+                                          "height": 314,
+                                          "url": "https://pbs.twimg.com/card_img/2087720956575813633/hJghuv6c?format=jpg&name=600x314",
+                                          "width": 600
+                                        },
+                                        "type": "IMAGE"
+                                      }
+                                    },
+                                    {
+                                      "key": "thumbnail_image_color",
+                                      "value": {
+                                        "image_color_value": {
+                                          "palette": [
+                                            {
+                                              "percentage": 44.85,
+                                              "rgb": {
+                                                "blue": 247,
+                                                "green": 235,
+                                                "red": 219
+                                              }
+                                            },
+                                            {
+                                              "percentage": 19.2,
+                                              "rgb": {
+                                                "blue": 237,
+                                                "green": 182,
+                                                "red": 100
+                                              }
+                                            },
+                                            {
+                                              "percentage": 12.67,
+                                              "rgb": {
+                                                "blue": 101,
+                                                "green": 58,
+                                                "red": 38
+                                              }
+                                            },
+                                            {
+                                              "percentage": 3.52,
+                                              "rgb": {
+                                                "blue": 150,
+                                                "green": 227,
+                                                "red": 245
+                                              }
+                                            },
+                                            {
+                                              "percentage": 3.12,
+                                              "rgb": {
+                                                "blue": 74,
+                                                "green": 61,
+                                                "red": 53
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        "type": "IMAGE_COLOR"
+                                      }
+                                    },
+                                    {
+                                      "key": "title",
+                                      "value": {
+                                        "string_value": "Click to start test",
+                                        "type": "STRING"
+                                      }
+                                    },
+                                    {
+                                      "key": "summary_photo_image_color",
+                                      "value": {
+                                        "image_color_value": {
+                                          "palette": [
+                                            {
+                                              "percentage": 44.85,
+                                              "rgb": {
+                                                "blue": 247,
+                                                "green": 235,
+                                                "red": 219
+                                              }
+                                            },
+                                            {
+                                              "percentage": 19.2,
+                                              "rgb": {
+                                                "blue": 237,
+                                                "green": 182,
+                                                "red": 100
+                                              }
+                                            },
+                                            {
+                                              "percentage": 12.67,
+                                              "rgb": {
+                                                "blue": 101,
+                                                "green": 58,
+                                                "red": 38
+                                              }
+                                            },
+                                            {
+                                              "percentage": 3.52,
+                                              "rgb": {
+                                                "blue": 150,
+                                                "green": 227,
+                                                "red": 245
+                                              }
+                                            },
+                                            {
+                                              "percentage": 3.12,
+                                              "rgb": {
+                                                "blue": 74,
+                                                "green": 61,
+                                                "red": 53
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        "type": "IMAGE_COLOR"
+                                      }
+                                    },
+                                    {
+                                      "key": "summary_photo_image_x_large",
+                                      "value": {
+                                        "image_value": {
+                                          "alt": "",
+                                          "height": 628,
+                                          "url": "https://pbs.twimg.com/card_img/2087720956575813633/hJghuv6c?format=png&name=2048x2048_2_exp",
+                                          "width": 1200
+                                        },
+                                        "type": "IMAGE"
+                                      }
+                                    },
+                                    {
+                                      "key": "summary_photo_image",
+                                      "value": {
+                                        "image_value": {
+                                          "alt": "",
+                                          "height": 314,
+                                          "url": "https://pbs.twimg.com/card_img/2087720956575813633/hJghuv6c?format=jpg&name=600x314",
+                                          "width": 600
+                                        },
+                                        "type": "IMAGE"
+                                      }
+                                    },
+                                    {
+                                      "key": "photo_image_full_size_color",
+                                      "value": {
+                                        "image_color_value": {
+                                          "palette": [
+                                            {
+                                              "percentage": 44.85,
+                                              "rgb": {
+                                                "blue": 247,
+                                                "green": 235,
+                                                "red": 219
+                                              }
+                                            },
+                                            {
+                                              "percentage": 19.2,
+                                              "rgb": {
+                                                "blue": 237,
+                                                "green": 182,
+                                                "red": 100
+                                              }
+                                            },
+                                            {
+                                              "percentage": 12.67,
+                                              "rgb": {
+                                                "blue": 101,
+                                                "green": 58,
+                                                "red": 38
+                                              }
+                                            },
+                                            {
+                                              "percentage": 3.52,
+                                              "rgb": {
+                                                "blue": 150,
+                                                "green": 227,
+                                                "red": 245
+                                              }
+                                            },
+                                            {
+                                              "percentage": 3.12,
+                                              "rgb": {
+                                                "blue": 74,
+                                                "green": 61,
+                                                "red": 53
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        "type": "IMAGE_COLOR"
+                                      }
+                                    },
+                                    {
+                                      "key": "photo_image_full_size_x_large",
+                                      "value": {
+                                        "image_value": {
+                                          "alt": "",
+                                          "height": 628,
+                                          "url": "https://pbs.twimg.com/card_img/2087720956575813633/hJghuv6c?format=png&name=2048x2048_2_exp",
+                                          "width": 1200
+                                        },
+                                        "type": "IMAGE"
+                                      }
+                                    },
+                                    {
+                                      "key": "card_url",
+                                      "value": {
+                                        "scribe_key": "card_url",
+                                        "string_value": "https://t.co/aq4kUk7QvX",
+                                        "type": "STRING"
+                                      }
+                                    },
+                                    {
+                                      "key": "summary_photo_image_original",
+                                      "value": {
+                                        "image_value": {
+                                          "alt": "",
+                                          "height": 628,
+                                          "url": "https://pbs.twimg.com/card_img/2087720956575813633/hJghuv6c?format=jpg&name=orig",
+                                          "width": 1200
+                                        },
+                                        "type": "IMAGE"
+                                      }
+                                    }
+                                  ],
+                                  "card_platform": {
+                                    "platform": {
+                                      "audience": {
+                                        "name": "production"
+                                      },
+                                      "device": {
+                                        "name": "Android",
+                                        "version": "12"
+                                      }
+                                    }
+                                  },
+                                  "name": "summary_large_image",
+                                  "url": "https://t.co/aq4kUk7QvX",
+                                  "user_refs_results": []
+                                },
+                                "rest_id": "https://t.co/aq4kUk7QvX"
+                              },
+                              "core": {
+                                "user_results": {
+                                  "result": {
+                                    "__typename": "User",
+                                    "affiliates_highlighted_label": {},
+                                    "avatar": {
+                                      "image_url": "https://pbs.twimg.com/profile_images/2002306468616286208/5CnOBK8D_normal.jpg"
+                                    },
+                                    "core": {
+                                      "created_at": "Tue Jul 05 21:27:38 +0000 2022",
+                                      "name": "faith 🐩",
+                                      "screen_name": "fairywafers"
+                                    },
+                                    "dm_permissions": {
+                                      "can_dm": false
+                                    },
+                                    "follow_request_sent": false,
+                                    "has_graduated_access": true,
+                                    "id": "VXNlcjoxNTQ0NDMyODEzOTk0MzAzNDg4",
+                                    "is_blue_verified": false,
+                                    "legacy": {
+                                      "default_profile": true,
+                                      "default_profile_image": false,
+                                      "description": "brianne howey enthusiast",
+                                      "entities": {
+                                        "description": {}
+                                      },
+                                      "fast_followers_count": 0,
+                                      "favourites_count": 248117,
+                                      "follow_request_sent": false,
+                                      "followers_count": 27,
+                                      "friends_count": 480,
+                                      "has_custom_timelines": false,
+                                      "is_translator": false,
+                                      "listed_count": 0,
+                                      "media_count": 18,
+                                      "needs_phone_verification": false,
+                                      "normal_followers_count": 27,
+                                      "notifications": false,
+                                      "possibly_sensitive": false,
+                                      "profile_banner_url": "https://pbs.twimg.com/profile_banners/1544432813994303488/1758126051",
+                                      "profile_interstitial_type": "",
+                                      "statuses_count": 4179,
+                                      "time_zone": "",
+                                      "translator_type": "none",
+                                      "url": "",
+                                      "utc_offset": 0,
+                                      "want_retweets": false,
+                                      "withheld_description": "",
+                                      "withheld_scope": ""
+                                    },
+                                    "location": {
+                                      "location": ""
+                                    },
+                                    "media_permissions": {
+                                      "can_media_tag": false
+                                    },
+                                    "parody_commentary_fan_label": "None",
+                                    "privacy": {
+                                      "protected": false
+                                    },
+                                    "profile_bio": {
+                                      "description": "brianne howey enthusiast"
+                                    },
+                                    "profile_image_shape": "Circle",
+                                    "relationship_perspectives": {
+                                      "blocked_by": false,
+                                      "blocking": false,
+                                      "followed_by": false,
+                                      "following": false,
+                                      "muting": false
+                                    },
+                                    "rest_id": "1544432813994303488",
+                                    "super_follow_eligible": false,
+                                    "super_followed_by": false,
+                                    "super_following": false,
+                                    "verification": {
+                                      "verified": false
+                                    }
+                                  }
+                                }
+                              },
+                              "edit_control": {
+                                "edit_tweet_ids": ["2088859755565469848"],
+                                "editable_until_msecs": "1786861549000",
+                                "edits_remaining": "5",
+                                "is_edit_eligible": false
+                              },
+                              "grok_analysis_button": true,
+                              "grok_annotations": {},
+                              "has_birdwatch_notes": false,
+                              "is_translatable": false,
+                              "legacy": {
+                                "bookmark_count": 0,
+                                "bookmarked": false,
+                                "conversation_id_str": "2087720798702498234",
+                                "created_at": "Sun Aug 16 05:25:49 +0000 2026",
+                                "display_text_range": [15, 106],
+                                "entities": {
+                                  "hashtags": [
+                                    {
+                                      "indices": [47, 67],
+                                      "text": "SnezhnayaCareerTest"
+                                    }
+                                  ],
+                                  "urls": [
+                                    {
+                                      "display_url": "snezhnayacareertest-en.belugacpn.jp/7ad9ae3d.html?…",
+                                      "expanded_url": "https://snezhnayacareertest-en.belugacpn.jp/7ad9ae3d.html?q=Tz2xCTYOB82dzNesWSRDKYmijfS87jjovVhvr2sotEx67IR5sBsEGPSCLyFgpiR1SNS4nPesQ2ixpvN-DkmLPwUtXDVwIOAEiE7EAYWwqjBEQB7p38hXTL5WRyl_HQpYzTJJZ82mcAwzK8LWh0eRQegLKnpLaPe5aqAHvQFIwJnmSgEG8MrbHQ==",
+                                      "indices": [83, 106],
+                                      "url": "https://t.co/aq4kUk7QvX"
+                                    }
+                                  ],
+                                  "user_mentions": [
+                                    {
+                                      "id_str": "1072404907230060544",
+                                      "indices": [0, 14],
+                                      "name": "Genshin Impact",
+                                      "screen_name": "GenshinImpact"
+                                    },
+                                    {
+                                      "id_str": "1072404907230060544",
+                                      "indices": [68, 82],
+                                      "name": "Genshin Impact",
+                                      "screen_name": "GenshinImpact"
+                                    }
+                                  ]
+                                },
+                                "favorite_count": 0,
+                                "favorited": false,
+                                "full_text": "@GenshinImpact UID: 624803261\nserver: america\n\n#SnezhnayaCareerTest @GenshinImpact\nhttps://t.co/aq4kUk7QvX",
+                                "id_str": "2088859755565469848",
+                                "in_reply_to_screen_name": "GenshinImpact",
+                                "in_reply_to_status_id_str": "2087720798702498234",
+                                "in_reply_to_user_id_str": "1072404907230060544",
+                                "is_quote_status": false,
+                                "lang": "pt",
+                                "possibly_sensitive": false,
+                                "possibly_sensitive_editable": true,
+                                "quote_count": 0,
+                                "reply_count": 0,
+                                "retweet_count": 0,
+                                "retweeted": false,
+                                "user_id_str": "1544432813994303488"
+                              },
+                              "quick_promote_eligibility": {
+                                "eligibility": "IneligibleNotVerified"
+                              },
+                              "rest_id": "2088859755565469848",
+                              "source": "<a href=\"http://twitter.com/download/iphone\" rel=\"nofollow\">Twitter for iPhone</a>",
+                              "unmention_data": {},
+                              "views": {
+                                "count": "32",
+                                "state": "EnabledWithCount"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  ],
+                  "metadata": {
+                    "conversationMetadata": {
+                      "allTweetIds": ["2088859755565469848"],
+                      "enableDeduplication": true
+                    }
+                  }
+                },
+                "entryId": "conversationthread-2088859755565469848",
+                "sortIndex": "2088929116056190846"
+              },
+              {
+                "content": {
+                  "__typename": "TimelineTimelineModule",
+                  "clientEventInfo": {
+                    "component": "tweet",
+                    "details": {
+                      "conversationDetails": {
+                        "conversationSection": "HighQuality"
+                      },
+                      "timelinesDetails": {
+                        "controllerData": "DAACDAAEDAABCgABAAAAAAAAAAEKAAIAAAAAAAAAAAoAAwAAAaAKBN5LAAAAAA=="
+                      }
+                    }
+                  },
+                  "displayType": "VerticalConversation",
+                  "entryType": "TimelineTimelineModule",
+                  "items": [
+                    {
+                      "entryId": "conversationthread-2088713953413341193-tweet-2088713953413341193",
+                      "item": {
+                        "clientEventInfo": {
+                          "component": "tweet",
+                          "details": {
+                            "conversationDetails": {
+                              "conversationSection": "HighQuality"
+                            },
+                            "timelinesDetails": {
+                              "controllerData": "DAACDAAEDAABCgABAAAAAAAAAAEKAAIAAAAAAAAAAAoAAwAAAaAKBN5LAAAAAA=="
+                            }
+                          },
+                          "element": "tweet"
+                        },
+                        "itemContent": {
+                          "__typename": "TimelineTweet",
+                          "itemType": "TimelineTweet",
+                          "tweetDisplayType": "Tweet",
+                          "tweet_results": {
+                            "result": {
+                              "__typename": "Tweet",
+                              "core": {
+                                "user_results": {
+                                  "result": {
+                                    "__typename": "User",
+                                    "affiliates_highlighted_label": {},
+                                    "avatar": {
+                                      "image_url": "https://pbs.twimg.com/profile_images/1437906587864080386/TjdNR3UV_normal.jpg"
+                                    },
+                                    "core": {
+                                      "created_at": "Tue Sep 14 07:56:38 +0000 2021",
+                                      "name": "Kessho Tetsu",
+                                      "screen_name": "AkiNakata1"
+                                    },
+                                    "dm_permissions": {
+                                      "can_dm": true
+                                    },
+                                    "follow_request_sent": false,
+                                    "has_graduated_access": true,
+                                    "id": "VXNlcjoxNDM3Njg2Njc2MDE3NDY3Mzky",
+                                    "is_blue_verified": false,
+                                    "legacy": {
+                                      "default_profile": true,
+                                      "default_profile_image": false,
+                                      "description": "Editor📱/ 20+ yr old Girl💜 / Democrat",
+                                      "entities": {
+                                        "description": {}
+                                      },
+                                      "fast_followers_count": 0,
+                                      "favourites_count": 110,
+                                      "follow_request_sent": false,
+                                      "followers_count": 18,
+                                      "friends_count": 983,
+                                      "has_custom_timelines": false,
+                                      "is_translator": false,
+                                      "listed_count": 0,
+                                      "media_count": 24,
+                                      "needs_phone_verification": false,
+                                      "normal_followers_count": 18,
+                                      "notifications": false,
+                                      "pinned_tweet_ids_str": [
+                                        "1907317282755539053"
+                                      ],
+                                      "possibly_sensitive": false,
+                                      "profile_banner_url": "https://pbs.twimg.com/profile_banners/1437686676017467392/1640657564",
+                                      "profile_interstitial_type": "",
+                                      "statuses_count": 88,
+                                      "time_zone": "",
+                                      "translator_type": "none",
+                                      "url": "",
+                                      "utc_offset": 0,
+                                      "want_retweets": false,
+                                      "withheld_description": "",
+                                      "withheld_scope": ""
+                                    },
+                                    "location": {
+                                      "location": "Los Angeles, CA"
+                                    },
+                                    "media_permissions": {
+                                      "can_media_tag": true
+                                    },
+                                    "parody_commentary_fan_label": "None",
+                                    "privacy": {
+                                      "protected": false
+                                    },
+                                    "profile_bio": {
+                                      "description": "Editor📱/ 20+ yr old Girl💜 / Democrat"
+                                    },
+                                    "profile_description_language": "en",
+                                    "profile_image_shape": "Circle",
+                                    "relationship_perspectives": {
+                                      "blocked_by": false,
+                                      "blocking": false,
+                                      "followed_by": false,
+                                      "following": false,
+                                      "muting": false
+                                    },
+                                    "rest_id": "1437686676017467392",
+                                    "super_follow_eligible": false,
+                                    "super_followed_by": false,
+                                    "super_following": false,
+                                    "verification": {
+                                      "verified": false
+                                    }
+                                  }
+                                }
+                              },
+                              "edit_control": {
+                                "edit_tweet_ids": ["2088713953413341193"],
+                                "editable_until_msecs": "1786826787000",
+                                "edits_remaining": "5",
+                                "is_edit_eligible": false
+                              },
+                              "grok_analysis_button": true,
+                              "grok_annotations": {},
+                              "has_birdwatch_notes": false,
+                              "is_translatable": false,
+                              "legacy": {
+                                "bookmark_count": 0,
+                                "bookmarked": false,
+                                "conversation_id_str": "2087720798702498234",
+                                "created_at": "Sat Aug 15 19:46:27 +0000 2026",
+                                "display_text_range": [15, 40],
+                                "entities": {
+                                  "media": [
+                                    {
+                                      "display_url": "pic.x.com/s8k8kvfI9D",
+                                      "expanded_url": "https://x.com/AkiNakata1/status/2088713953413341193/photo/1",
+                                      "ext_media_availability": {
+                                        "status": "Available"
+                                      },
+                                      "features": {
+                                        "large": {
+                                          "faces": []
+                                        },
+                                        "medium": {
+                                          "faces": []
+                                        },
+                                        "orig": {
+                                          "faces": []
+                                        },
+                                        "small": {
+                                          "faces": []
+                                        }
+                                      },
+                                      "id_str": "2088713949990862848",
+                                      "indices": [41, 64],
+                                      "media_key": "3_2088713949990862848",
+                                      "media_results": {
+                                        "result": {
+                                          "media_key": "3_2088713949990862848"
+                                        }
+                                      },
+                                      "media_url_https": "https://pbs.twimg.com/media/HPyaRWKbwAA0vHd.jpg",
+                                      "original_info": {
+                                        "focus_rects": [
+                                          {
+                                            "h": 403,
+                                            "w": 720,
+                                            "x": 0,
+                                            "y": 239
+                                          },
+                                          {
+                                            "h": 720,
+                                            "w": 720,
+                                            "x": 0,
+                                            "y": 80
+                                          },
+                                          {
+                                            "h": 821,
+                                            "w": 720,
+                                            "x": 0,
+                                            "y": 30
+                                          },
+                                          {
+                                            "h": 1440,
+                                            "w": 720,
+                                            "x": 0,
+                                            "y": 0
+                                          },
+                                          {
+                                            "h": 1600,
+                                            "w": 720,
+                                            "x": 0,
+                                            "y": 0
+                                          }
+                                        ],
+                                        "height": 1600,
+                                        "width": 720
+                                      },
+                                      "sizes": {
+                                        "large": {
+                                          "h": 1600,
+                                          "resize": "fit",
+                                          "w": 720
+                                        },
+                                        "medium": {
+                                          "h": 1200,
+                                          "resize": "fit",
+                                          "w": 540
+                                        },
+                                        "small": {
+                                          "h": 680,
+                                          "resize": "fit",
+                                          "w": 306
+                                        },
+                                        "thumb": {
+                                          "h": 150,
+                                          "resize": "crop",
+                                          "w": 150
+                                        }
+                                      },
+                                      "type": "photo",
+                                      "url": "https://t.co/s8k8kvfI9D"
+                                    }
+                                  ],
+                                  "user_mentions": [
+                                    {
+                                      "id_str": "1072404907230060544",
+                                      "indices": [0, 14],
+                                      "name": "Genshin Impact",
+                                      "screen_name": "GenshinImpact"
+                                    }
+                                  ]
+                                },
+                                "extended_entities": {
+                                  "media": [
+                                    {
+                                      "display_url": "pic.x.com/s8k8kvfI9D",
+                                      "expanded_url": "https://x.com/AkiNakata1/status/2088713953413341193/photo/1",
+                                      "ext_media_availability": {
+                                        "status": "Available"
+                                      },
+                                      "features": {
+                                        "large": {
+                                          "faces": []
+                                        },
+                                        "medium": {
+                                          "faces": []
+                                        },
+                                        "orig": {
+                                          "faces": []
+                                        },
+                                        "small": {
+                                          "faces": []
+                                        }
+                                      },
+                                      "id_str": "2088713949990862848",
+                                      "indices": [41, 64],
+                                      "media_key": "3_2088713949990862848",
+                                      "media_results": {
+                                        "result": {
+                                          "media_key": "3_2088713949990862848"
+                                        }
+                                      },
+                                      "media_url_https": "https://pbs.twimg.com/media/HPyaRWKbwAA0vHd.jpg",
+                                      "original_info": {
+                                        "focus_rects": [
+                                          {
+                                            "h": 403,
+                                            "w": 720,
+                                            "x": 0,
+                                            "y": 239
+                                          },
+                                          {
+                                            "h": 720,
+                                            "w": 720,
+                                            "x": 0,
+                                            "y": 80
+                                          },
+                                          {
+                                            "h": 821,
+                                            "w": 720,
+                                            "x": 0,
+                                            "y": 30
+                                          },
+                                          {
+                                            "h": 1440,
+                                            "w": 720,
+                                            "x": 0,
+                                            "y": 0
+                                          },
+                                          {
+                                            "h": 1600,
+                                            "w": 720,
+                                            "x": 0,
+                                            "y": 0
+                                          }
+                                        ],
+                                        "height": 1600,
+                                        "width": 720
+                                      },
+                                      "sizes": {
+                                        "large": {
+                                          "h": 1600,
+                                          "resize": "fit",
+                                          "w": 720
+                                        },
+                                        "medium": {
+                                          "h": 1200,
+                                          "resize": "fit",
+                                          "w": 540
+                                        },
+                                        "small": {
+                                          "h": 680,
+                                          "resize": "fit",
+                                          "w": 306
+                                        },
+                                        "thumb": {
+                                          "h": 150,
+                                          "resize": "crop",
+                                          "w": 150
+                                        }
+                                      },
+                                      "type": "photo",
+                                      "url": "https://t.co/s8k8kvfI9D"
+                                    }
+                                  ]
+                                },
+                                "favorite_count": 0,
+                                "favorited": false,
+                                "full_text": "@GenshinImpact UID: 635219734\nSERVER: NA https://t.co/s8k8kvfI9D",
+                                "id_str": "2088713953413341193",
+                                "in_reply_to_screen_name": "GenshinImpact",
+                                "in_reply_to_status_id_str": "2087720798702498234",
+                                "in_reply_to_user_id_str": "1072404907230060544",
+                                "is_quote_status": false,
+                                "lang": "tl",
+                                "possibly_sensitive": false,
+                                "possibly_sensitive_editable": true,
+                                "quote_count": 0,
+                                "reply_count": 0,
+                                "retweet_count": 0,
+                                "retweeted": false,
+                                "user_id_str": "1437686676017467392"
+                              },
+                              "quick_promote_eligibility": {
+                                "eligibility": "IneligibleNotVerified"
+                              },
+                              "rest_id": "2088713953413341193",
+                              "source": "<a href=\"http://twitter.com/download/android\" rel=\"nofollow\">Twitter for Android</a>",
+                              "unmention_data": {},
+                              "views": {
+                                "count": "156",
+                                "state": "EnabledWithCount"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  ],
+                  "metadata": {
+                    "conversationMetadata": {
+                      "allTweetIds": ["2088713953413341193"],
+                      "enableDeduplication": true
+                    }
+                  }
+                },
+                "entryId": "conversationthread-2088713953413341193",
+                "sortIndex": "2088929116056190836"
+              },
+              {
+                "content": {
+                  "__typename": "TimelineTimelineModule",
+                  "clientEventInfo": {
+                    "component": "tweet",
+                    "details": {
+                      "conversationDetails": {
+                        "conversationSection": "HighQuality"
+                      },
+                      "timelinesDetails": {
+                        "controllerData": "DAACDAAEDAABCgABAAAAAAAAAAEKAAIAAAAAAAAAAAoAAwAAAaAKBN5LAAAAAA=="
+                      }
+                    }
+                  },
+                  "displayType": "VerticalConversation",
+                  "entryType": "TimelineTimelineModule",
+                  "items": [
+                    {
+                      "entryId": "conversationthread-2088829819295252788-tweet-2088829819295252788",
+                      "item": {
+                        "clientEventInfo": {
+                          "component": "tweet",
+                          "details": {
+                            "conversationDetails": {
+                              "conversationSection": "HighQuality"
+                            },
+                            "timelinesDetails": {
+                              "controllerData": "DAACDAAEDAABCgABAAAAAAAAAAEKAAIAAAAAAAAAAAoAAwAAAaAKBN5LAAAAAA=="
+                            }
+                          },
+                          "element": "tweet"
+                        },
+                        "itemContent": {
+                          "__typename": "TimelineTweet",
+                          "itemType": "TimelineTweet",
+                          "tweetDisplayType": "Tweet",
+                          "tweet_results": {
+                            "result": {
+                              "__typename": "Tweet",
+                              "core": {
+                                "user_results": {
+                                  "result": {
+                                    "__typename": "User",
+                                    "affiliates_highlighted_label": {},
+                                    "avatar": {
+                                      "image_url": "https://pbs.twimg.com/profile_images/1982017852837167104/WBnElsX5_normal.jpg"
+                                    },
+                                    "core": {
+                                      "created_at": "Sat Oct 25 08:42:48 +0000 2025",
+                                      "name": "kaeya 🦭💜",
+                                      "screen_name": "ruiribb0n"
+                                    },
+                                    "dm_permissions": {
+                                      "can_dm": true
+                                    },
+                                    "follow_request_sent": false,
+                                    "has_graduated_access": true,
+                                    "id": "VXNlcjoxOTgyMDAzOTQzMDk0Nzc1ODA4",
+                                    "is_blue_verified": false,
+                                    "legacy": {
+                                      "default_profile": true,
+                                      "default_profile_image": false,
+                                      "description": "he/she bigender 19 yro who naps a lot and rlly likes cute stuff",
+                                      "entities": {
+                                        "description": {},
+                                        "url": {
+                                          "urls": [
+                                            {
+                                              "display_url": "madmagician.carrd.co",
+                                              "expanded_url": "https://madmagician.carrd.co/",
+                                              "indices": [0, 23],
+                                              "url": "https://t.co/ZzqiW6H9fo"
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "fast_followers_count": 0,
+                                      "favourites_count": 2628,
+                                      "follow_request_sent": false,
+                                      "followers_count": 12,
+                                      "friends_count": 61,
+                                      "has_custom_timelines": false,
+                                      "is_translator": false,
+                                      "listed_count": 0,
+                                      "media_count": 1,
+                                      "needs_phone_verification": false,
+                                      "normal_followers_count": 12,
+                                      "notifications": false,
+                                      "possibly_sensitive": false,
+                                      "profile_banner_url": "https://pbs.twimg.com/profile_banners/1982003943094775808/1761384866",
+                                      "profile_interstitial_type": "",
+                                      "statuses_count": 1657,
+                                      "time_zone": "",
+                                      "translator_type": "none",
+                                      "url": "https://t.co/ZzqiW6H9fo",
+                                      "utc_offset": 0,
+                                      "want_retweets": false,
+                                      "withheld_description": "",
+                                      "withheld_scope": ""
+                                    },
+                                    "location": {
+                                      "location": ""
+                                    },
+                                    "media_permissions": {
+                                      "can_media_tag": true
+                                    },
+                                    "parody_commentary_fan_label": "None",
+                                    "privacy": {
+                                      "protected": false
+                                    },
+                                    "profile_bio": {
+                                      "description": "he/she bigender 19 yro who naps a lot and rlly likes cute stuff"
+                                    },
+                                    "profile_description_language": "en",
+                                    "profile_image_shape": "Circle",
+                                    "relationship_perspectives": {
+                                      "blocked_by": false,
+                                      "blocking": false,
+                                      "followed_by": false,
+                                      "following": false,
+                                      "muting": false
+                                    },
+                                    "rest_id": "1982003943094775808",
+                                    "super_follow_eligible": false,
+                                    "super_followed_by": false,
+                                    "super_following": false,
+                                    "verification": {
+                                      "verified": false
+                                    }
+                                  }
+                                }
+                              },
+                              "edit_control": {
+                                "edit_tweet_ids": ["2088829819295252788"],
+                                "editable_until_msecs": "1786854412000",
+                                "edits_remaining": "5",
+                                "is_edit_eligible": false
+                              },
+                              "grok_analysis_button": true,
+                              "grok_annotations": {},
+                              "has_birdwatch_notes": false,
+                              "is_translatable": false,
+                              "legacy": {
+                                "bookmark_count": 0,
+                                "bookmarked": false,
+                                "conversation_id_str": "2087720798702498234",
+                                "created_at": "Sun Aug 16 03:26:52 +0000 2026",
+                                "display_text_range": [15, 51],
+                                "entities": {
+                                  "media": [
+                                    {
+                                      "allow_download_status": {
+                                        "allow_download": true
+                                      },
+                                      "display_url": "pic.x.com/5LB36v7224",
+                                      "expanded_url": "https://x.com/ruiribb0n/status/2088829819295252788/photo/1",
+                                      "ext_media_availability": {
+                                        "status": "Available"
+                                      },
+                                      "features": {
+                                        "large": {
+                                          "faces": [
+                                            {
+                                              "h": 45,
+                                              "w": 45,
+                                              "x": 1008,
+                                              "y": 579
+                                            },
+                                            {
+                                              "h": 155,
+                                              "w": 155,
+                                              "x": 301,
+                                              "y": 551
+                                            }
+                                          ]
+                                        },
+                                        "medium": {
+                                          "faces": [
+                                            {
+                                              "h": 44,
+                                              "w": 44,
+                                              "x": 1002,
+                                              "y": 576
+                                            },
+                                            {
+                                              "h": 154,
+                                              "w": 154,
+                                              "x": 299,
+                                              "y": 548
+                                            }
+                                          ]
+                                        },
+                                        "orig": {
+                                          "faces": [
+                                            {
+                                              "h": 45,
+                                              "w": 45,
+                                              "x": 1008,
+                                              "y": 579
+                                            },
+                                            {
+                                              "h": 155,
+                                              "w": 155,
+                                              "x": 301,
+                                              "y": 551
+                                            }
+                                          ]
+                                        },
+                                        "small": {
+                                          "faces": [
+                                            {
+                                              "h": 25,
+                                              "w": 25,
+                                              "x": 568,
+                                              "y": 326
+                                            },
+                                            {
+                                              "h": 87,
+                                              "w": 87,
+                                              "x": 169,
+                                              "y": 310
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "id_str": "2088829814257881089",
+                                      "indices": [52, 75],
+                                      "media_key": "3_2088829814257881089",
+                                      "media_results": {
+                                        "result": {
+                                          "media_key": "3_2088829814257881089"
+                                        }
+                                      },
+                                      "media_url_https": "https://pbs.twimg.com/media/HP0DpiMWEAEDBMZ.jpg",
+                                      "original_info": {
+                                        "focus_rects": [
+                                          {
+                                            "h": 655,
+                                            "w": 1170,
+                                            "x": 0,
+                                            "y": 551
+                                          },
+                                          {
+                                            "h": 1170,
+                                            "w": 1170,
+                                            "x": 0,
+                                            "y": 36
+                                          },
+                                          {
+                                            "h": 1206,
+                                            "w": 1058,
+                                            "x": 0,
+                                            "y": 0
+                                          },
+                                          {
+                                            "h": 1206,
+                                            "w": 603,
+                                            "x": 151,
+                                            "y": 0
+                                          },
+                                          {
+                                            "h": 1206,
+                                            "w": 1170,
+                                            "x": 0,
+                                            "y": 0
+                                          }
+                                        ],
+                                        "height": 1206,
+                                        "width": 1170
+                                      },
+                                      "sizes": {
+                                        "large": {
+                                          "h": 1206,
+                                          "resize": "fit",
+                                          "w": 1170
+                                        },
+                                        "medium": {
+                                          "h": 1200,
+                                          "resize": "fit",
+                                          "w": 1164
+                                        },
+                                        "small": {
+                                          "h": 680,
+                                          "resize": "fit",
+                                          "w": 660
+                                        },
+                                        "thumb": {
+                                          "h": 150,
+                                          "resize": "crop",
+                                          "w": 150
+                                        }
+                                      },
+                                      "type": "photo",
+                                      "url": "https://t.co/5LB36v7224"
+                                    }
+                                  ],
+                                  "user_mentions": [
+                                    {
+                                      "id_str": "1072404907230060544",
+                                      "indices": [0, 14],
+                                      "name": "Genshin Impact",
+                                      "screen_name": "GenshinImpact"
+                                    }
+                                  ]
+                                },
+                                "extended_entities": {
+                                  "media": [
+                                    {
+                                      "allow_download_status": {
+                                        "allow_download": true
+                                      },
+                                      "display_url": "pic.x.com/5LB36v7224",
+                                      "expanded_url": "https://x.com/ruiribb0n/status/2088829819295252788/photo/1",
+                                      "ext_media_availability": {
+                                        "status": "Available"
+                                      },
+                                      "features": {
+                                        "large": {
+                                          "faces": [
+                                            {
+                                              "h": 45,
+                                              "w": 45,
+                                              "x": 1008,
+                                              "y": 579
+                                            },
+                                            {
+                                              "h": 155,
+                                              "w": 155,
+                                              "x": 301,
+                                              "y": 551
+                                            }
+                                          ]
+                                        },
+                                        "medium": {
+                                          "faces": [
+                                            {
+                                              "h": 44,
+                                              "w": 44,
+                                              "x": 1002,
+                                              "y": 576
+                                            },
+                                            {
+                                              "h": 154,
+                                              "w": 154,
+                                              "x": 299,
+                                              "y": 548
+                                            }
+                                          ]
+                                        },
+                                        "orig": {
+                                          "faces": [
+                                            {
+                                              "h": 45,
+                                              "w": 45,
+                                              "x": 1008,
+                                              "y": 579
+                                            },
+                                            {
+                                              "h": 155,
+                                              "w": 155,
+                                              "x": 301,
+                                              "y": 551
+                                            }
+                                          ]
+                                        },
+                                        "small": {
+                                          "faces": [
+                                            {
+                                              "h": 25,
+                                              "w": 25,
+                                              "x": 568,
+                                              "y": 326
+                                            },
+                                            {
+                                              "h": 87,
+                                              "w": 87,
+                                              "x": 169,
+                                              "y": 310
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "id_str": "2088829814257881089",
+                                      "indices": [52, 75],
+                                      "media_key": "3_2088829814257881089",
+                                      "media_results": {
+                                        "result": {
+                                          "media_key": "3_2088829814257881089"
+                                        }
+                                      },
+                                      "media_url_https": "https://pbs.twimg.com/media/HP0DpiMWEAEDBMZ.jpg",
+                                      "original_info": {
+                                        "focus_rects": [
+                                          {
+                                            "h": 655,
+                                            "w": 1170,
+                                            "x": 0,
+                                            "y": 551
+                                          },
+                                          {
+                                            "h": 1170,
+                                            "w": 1170,
+                                            "x": 0,
+                                            "y": 36
+                                          },
+                                          {
+                                            "h": 1206,
+                                            "w": 1058,
+                                            "x": 0,
+                                            "y": 0
+                                          },
+                                          {
+                                            "h": 1206,
+                                            "w": 603,
+                                            "x": 151,
+                                            "y": 0
+                                          },
+                                          {
+                                            "h": 1206,
+                                            "w": 1170,
+                                            "x": 0,
+                                            "y": 0
+                                          }
+                                        ],
+                                        "height": 1206,
+                                        "width": 1170
+                                      },
+                                      "sizes": {
+                                        "large": {
+                                          "h": 1206,
+                                          "resize": "fit",
+                                          "w": 1170
+                                        },
+                                        "medium": {
+                                          "h": 1200,
+                                          "resize": "fit",
+                                          "w": 1164
+                                        },
+                                        "small": {
+                                          "h": 680,
+                                          "resize": "fit",
+                                          "w": 660
+                                        },
+                                        "thumb": {
+                                          "h": 150,
+                                          "resize": "crop",
+                                          "w": 150
+                                        }
+                                      },
+                                      "type": "photo",
+                                      "url": "https://t.co/5LB36v7224"
+                                    }
+                                  ]
+                                },
+                                "favorite_count": 0,
+                                "favorited": false,
+                                "full_text": "@GenshinImpact UID: 614608928\nServer: North America https://t.co/5LB36v7224",
+                                "id_str": "2088829819295252788",
+                                "in_reply_to_screen_name": "GenshinImpact",
+                                "in_reply_to_status_id_str": "2087720798702498234",
+                                "in_reply_to_user_id_str": "1072404907230060544",
+                                "is_quote_status": false,
+                                "lang": "en",
+                                "possibly_sensitive": false,
+                                "possibly_sensitive_editable": true,
+                                "quote_count": 0,
+                                "reply_count": 0,
+                                "retweet_count": 0,
+                                "retweeted": false,
+                                "user_id_str": "1982003943094775808"
+                              },
+                              "quick_promote_eligibility": {
+                                "eligibility": "IneligibleNotVerified"
+                              },
+                              "rest_id": "2088829819295252788",
+                              "source": "<a href=\"http://twitter.com/download/iphone\" rel=\"nofollow\">Twitter for iPhone</a>",
+                              "unmention_data": {},
+                              "views": {
+                                "count": "302",
+                                "state": "EnabledWithCount"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  ],
+                  "metadata": {
+                    "conversationMetadata": {
+                      "allTweetIds": ["2088829819295252788"],
+                      "enableDeduplication": true
+                    }
+                  }
+                },
+                "entryId": "conversationthread-2088829819295252788",
+                "sortIndex": "2088929116056190826"
+              },
+              {
+                "content": {
+                  "__typename": "TimelineTimelineModule",
+                  "clientEventInfo": {
+                    "component": "tweet",
+                    "details": {
+                      "conversationDetails": {
+                        "conversationSection": "HighQuality"
+                      },
+                      "timelinesDetails": {
+                        "controllerData": "DAACDAAEDAABCgABAAAAAAAAAAEKAAIAAAAAAAAAAAoAAwAAAaAKBN5LAAAAAA=="
+                      }
+                    }
+                  },
+                  "displayType": "VerticalConversation",
+                  "entryType": "TimelineTimelineModule",
+                  "items": [
+                    {
+                      "entryId": "conversationthread-2088784120000458797-tweet-2088784120000458797",
+                      "item": {
+                        "clientEventInfo": {
+                          "component": "tweet",
+                          "details": {
+                            "conversationDetails": {
+                              "conversationSection": "HighQuality"
+                            },
+                            "timelinesDetails": {
+                              "controllerData": "DAACDAAEDAABCgABAAAAAAAAAAEKAAIAAAAAAAAAAAoAAwAAAaAKBN5LAAAAAA=="
+                            }
+                          },
+                          "element": "tweet"
+                        },
+                        "itemContent": {
+                          "__typename": "TimelineTweet",
+                          "itemType": "TimelineTweet",
+                          "tweetDisplayType": "Tweet",
+                          "tweet_results": {
+                            "result": {
+                              "__typename": "Tweet",
+                              "core": {
+                                "user_results": {
+                                  "result": {
+                                    "__typename": "User",
+                                    "affiliates_highlighted_label": {},
+                                    "avatar": {
+                                      "image_url": "https://pbs.twimg.com/profile_images/1770335938927079424/mbjwQJCn_normal.jpg"
+                                    },
+                                    "core": {
+                                      "created_at": "Tue Mar 19 14:59:48 +0000 2024",
+                                      "name": "Ravya Kidzovka",
+                                      "screen_name": "R_Kidzovka"
+                                    },
+                                    "dm_permissions": {
+                                      "can_dm": false
+                                    },
+                                    "follow_request_sent": false,
+                                    "has_graduated_access": true,
+                                    "id": "VXNlcjoxNzcwMTAyNzEyNjk0MzgyNTky",
+                                    "is_blue_verified": false,
+                                    "legacy": {
+                                      "default_profile": true,
+                                      "default_profile_image": false,
+                                      "description": "",
+                                      "entities": {
+                                        "description": {}
+                                      },
+                                      "fast_followers_count": 0,
+                                      "favourites_count": 220,
+                                      "follow_request_sent": false,
+                                      "followers_count": 0,
+                                      "friends_count": 6,
+                                      "has_custom_timelines": false,
+                                      "is_translator": false,
+                                      "listed_count": 0,
+                                      "media_count": 2,
+                                      "needs_phone_verification": false,
+                                      "normal_followers_count": 0,
+                                      "notifications": false,
+                                      "possibly_sensitive": false,
+                                      "profile_banner_url": "https://pbs.twimg.com/profile_banners/1770102712694382592/1710916083",
+                                      "profile_interstitial_type": "",
+                                      "statuses_count": 2,
+                                      "time_zone": "",
+                                      "translator_type": "none",
+                                      "url": "",
+                                      "utc_offset": 0,
+                                      "want_retweets": false,
+                                      "withheld_description": "",
+                                      "withheld_scope": ""
+                                    },
+                                    "location": {
+                                      "location": ""
+                                    },
+                                    "media_permissions": {
+                                      "can_media_tag": true
+                                    },
+                                    "parody_commentary_fan_label": "None",
+                                    "privacy": {
+                                      "protected": false
+                                    },
+                                    "profile_bio": {
+                                      "description": ""
+                                    },
+                                    "profile_image_shape": "Circle",
+                                    "relationship_perspectives": {
+                                      "blocked_by": false,
+                                      "blocking": false,
+                                      "followed_by": false,
+                                      "following": false,
+                                      "muting": false
+                                    },
+                                    "rest_id": "1770102712694382592",
+                                    "super_follow_eligible": false,
+                                    "super_followed_by": false,
+                                    "super_following": false,
+                                    "verification": {
+                                      "verified": false
+                                    }
+                                  }
+                                }
+                              },
+                              "edit_control": {
+                                "edit_tweet_ids": ["2088784120000458797"],
+                                "editable_until_msecs": "1786843516000",
+                                "edits_remaining": "5",
+                                "is_edit_eligible": false
+                              },
+                              "grok_analysis_button": true,
+                              "grok_annotations": {},
+                              "has_birdwatch_notes": false,
+                              "is_translatable": false,
+                              "legacy": {
+                                "bookmark_count": 1,
+                                "bookmarked": false,
+                                "conversation_id_str": "2087720798702498234",
+                                "created_at": "Sun Aug 16 00:25:16 +0000 2026",
+                                "display_text_range": [15, 43],
+                                "entities": {
+                                  "media": [
+                                    {
+                                      "display_url": "pic.x.com/iT5puDXFt4",
+                                      "expanded_url": "https://x.com/R_Kidzovka/status/2088784120000458797/photo/1",
+                                      "ext_media_availability": {
+                                        "status": "Available"
+                                      },
+                                      "features": {
+                                        "large": {
+                                          "faces": [
+                                            {
+                                              "h": 141,
+                                              "w": 141,
+                                              "x": 280,
+                                              "y": 698
+                                            }
+                                          ]
+                                        },
+                                        "medium": {
+                                          "faces": [
+                                            {
+                                              "h": 97,
+                                              "w": 97,
+                                              "x": 194,
+                                              "y": 484
+                                            }
+                                          ]
+                                        },
+                                        "orig": {
+                                          "faces": [
+                                            {
+                                              "h": 141,
+                                              "w": 141,
+                                              "x": 280,
+                                              "y": 698
+                                            }
+                                          ]
+                                        },
+                                        "small": {
+                                          "faces": [
+                                            {
+                                              "h": 55,
+                                              "w": 55,
+                                              "x": 110,
+                                              "y": 274
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "id_str": "2088784102157873152",
+                                      "indices": [44, 67],
+                                      "media_key": "3_2088784102157873152",
+                                      "media_results": {
+                                        "result": {
+                                          "media_key": "3_2088784102157873152"
+                                        }
+                                      },
+                                      "media_url_https": "https://pbs.twimg.com/media/HPzaEvWacAApYvy.jpg",
+                                      "original_info": {
+                                        "focus_rects": [
+                                          {
+                                            "h": 605,
+                                            "w": 1080,
+                                            "x": 0,
+                                            "y": 1037
+                                          },
+                                          {
+                                            "h": 1080,
+                                            "w": 1080,
+                                            "x": 0,
+                                            "y": 648
+                                          },
+                                          {
+                                            "h": 1231,
+                                            "w": 1080,
+                                            "x": 0,
+                                            "y": 497
+                                          },
+                                          {
+                                            "h": 1728,
+                                            "w": 864,
+                                            "x": 0,
+                                            "y": 0
+                                          },
+                                          {
+                                            "h": 1728,
+                                            "w": 1080,
+                                            "x": 0,
+                                            "y": 0
+                                          }
+                                        ],
+                                        "height": 1728,
+                                        "width": 1080
+                                      },
+                                      "sizes": {
+                                        "large": {
+                                          "h": 1728,
+                                          "resize": "fit",
+                                          "w": 1080
+                                        },
+                                        "medium": {
+                                          "h": 1200,
+                                          "resize": "fit",
+                                          "w": 750
+                                        },
+                                        "small": {
+                                          "h": 680,
+                                          "resize": "fit",
+                                          "w": 425
+                                        },
+                                        "thumb": {
+                                          "h": 150,
+                                          "resize": "crop",
+                                          "w": 150
+                                        }
+                                      },
+                                      "type": "photo",
+                                      "url": "https://t.co/iT5puDXFt4"
+                                    }
+                                  ],
+                                  "user_mentions": [
+                                    {
+                                      "id_str": "1072404907230060544",
+                                      "indices": [0, 14],
+                                      "name": "Genshin Impact",
+                                      "screen_name": "GenshinImpact"
+                                    }
+                                  ]
+                                },
+                                "extended_entities": {
+                                  "media": [
+                                    {
+                                      "display_url": "pic.x.com/iT5puDXFt4",
+                                      "expanded_url": "https://x.com/R_Kidzovka/status/2088784120000458797/photo/1",
+                                      "ext_media_availability": {
+                                        "status": "Available"
+                                      },
+                                      "features": {
+                                        "large": {
+                                          "faces": [
+                                            {
+                                              "h": 141,
+                                              "w": 141,
+                                              "x": 280,
+                                              "y": 698
+                                            }
+                                          ]
+                                        },
+                                        "medium": {
+                                          "faces": [
+                                            {
+                                              "h": 97,
+                                              "w": 97,
+                                              "x": 194,
+                                              "y": 484
+                                            }
+                                          ]
+                                        },
+                                        "orig": {
+                                          "faces": [
+                                            {
+                                              "h": 141,
+                                              "w": 141,
+                                              "x": 280,
+                                              "y": 698
+                                            }
+                                          ]
+                                        },
+                                        "small": {
+                                          "faces": [
+                                            {
+                                              "h": 55,
+                                              "w": 55,
+                                              "x": 110,
+                                              "y": 274
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "id_str": "2088784102157873152",
+                                      "indices": [44, 67],
+                                      "media_key": "3_2088784102157873152",
+                                      "media_results": {
+                                        "result": {
+                                          "media_key": "3_2088784102157873152"
+                                        }
+                                      },
+                                      "media_url_https": "https://pbs.twimg.com/media/HPzaEvWacAApYvy.jpg",
+                                      "original_info": {
+                                        "focus_rects": [
+                                          {
+                                            "h": 605,
+                                            "w": 1080,
+                                            "x": 0,
+                                            "y": 1037
+                                          },
+                                          {
+                                            "h": 1080,
+                                            "w": 1080,
+                                            "x": 0,
+                                            "y": 648
+                                          },
+                                          {
+                                            "h": 1231,
+                                            "w": 1080,
+                                            "x": 0,
+                                            "y": 497
+                                          },
+                                          {
+                                            "h": 1728,
+                                            "w": 864,
+                                            "x": 0,
+                                            "y": 0
+                                          },
+                                          {
+                                            "h": 1728,
+                                            "w": 1080,
+                                            "x": 0,
+                                            "y": 0
+                                          }
+                                        ],
+                                        "height": 1728,
+                                        "width": 1080
+                                      },
+                                      "sizes": {
+                                        "large": {
+                                          "h": 1728,
+                                          "resize": "fit",
+                                          "w": 1080
+                                        },
+                                        "medium": {
+                                          "h": 1200,
+                                          "resize": "fit",
+                                          "w": 750
+                                        },
+                                        "small": {
+                                          "h": 680,
+                                          "resize": "fit",
+                                          "w": 425
+                                        },
+                                        "thumb": {
+                                          "h": 150,
+                                          "resize": "crop",
+                                          "w": 150
+                                        }
+                                      },
+                                      "type": "photo",
+                                      "url": "https://t.co/iT5puDXFt4"
+                                    }
+                                  ]
+                                },
+                                "favorite_count": 0,
+                                "favorited": false,
+                                "full_text": "@GenshinImpact UID: 1815820896\nServer: Asia https://t.co/iT5puDXFt4",
+                                "id_str": "2088784120000458797",
+                                "in_reply_to_screen_name": "GenshinImpact",
+                                "in_reply_to_status_id_str": "2087720798702498234",
+                                "in_reply_to_user_id_str": "1072404907230060544",
+                                "is_quote_status": false,
+                                "lang": "et",
+                                "possibly_sensitive": false,
+                                "possibly_sensitive_editable": true,
+                                "quote_count": 0,
+                                "reply_count": 0,
+                                "retweet_count": 0,
+                                "retweeted": false,
+                                "user_id_str": "1770102712694382592"
+                              },
+                              "quick_promote_eligibility": {
+                                "eligibility": "IneligibleNotVerified"
+                              },
+                              "rest_id": "2088784120000458797",
+                              "source": "<a href=\"http://twitter.com/download/android\" rel=\"nofollow\">Twitter for Android</a>",
+                              "unmention_data": {},
+                              "views": {
+                                "count": "376",
+                                "state": "EnabledWithCount"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  ],
+                  "metadata": {
+                    "conversationMetadata": {
+                      "allTweetIds": ["2088784120000458797"],
+                      "enableDeduplication": true
+                    }
+                  }
+                },
+                "entryId": "conversationthread-2088784120000458797",
+                "sortIndex": "2088929116056190816"
+              },
+              {
+                "content": {
+                  "__typename": "TimelineTimelineModule",
+                  "clientEventInfo": {
+                    "component": "tweet",
+                    "details": {
+                      "conversationDetails": {
+                        "conversationSection": "HighQuality"
+                      },
+                      "timelinesDetails": {
+                        "controllerData": "DAACDAAEDAABCgABAAAAAAAAAAEKAAIAAAAAAAAAAAoAAwAAAaAKBN5LAAAAAA=="
+                      }
+                    }
+                  },
+                  "displayType": "VerticalConversation",
+                  "entryType": "TimelineTimelineModule",
+                  "items": [
+                    {
+                      "entryId": "conversationthread-2088886533206282540-tweet-2088886533206282540",
+                      "item": {
+                        "clientEventInfo": {
+                          "component": "tweet",
+                          "details": {
+                            "conversationDetails": {
+                              "conversationSection": "HighQuality"
+                            },
+                            "timelinesDetails": {
+                              "controllerData": "DAACDAAEDAABCgABAAAAAAAAAAEKAAIAAAAAAAAAAAoAAwAAAaAKBN5LAAAAAA=="
+                            }
+                          },
+                          "element": "tweet"
+                        },
+                        "itemContent": {
+                          "__typename": "TimelineTweet",
+                          "itemType": "TimelineTweet",
+                          "tweetDisplayType": "Tweet",
+                          "tweet_results": {
+                            "result": {
+                              "__typename": "Tweet",
+                              "core": {
+                                "user_results": {
+                                  "result": {
+                                    "__typename": "User",
+                                    "affiliates_highlighted_label": {},
+                                    "avatar": {
+                                      "image_url": "https://pbs.twimg.com/profile_images/1842462150205542400/aDhpIa9j_normal.jpg"
+                                    },
+                                    "core": {
+                                      "created_at": "Sun Mar 29 03:43:50 +0000 2020",
+                                      "name": "Unname5331",
+                                      "screen_name": "unname5331"
+                                    },
+                                    "dm_permissions": {
+                                      "can_dm": false
+                                    },
+                                    "follow_request_sent": false,
+                                    "has_graduated_access": true,
+                                    "id": "VXNlcjoxMjQ0MTA3OTI4NTcyODUwMTc2",
+                                    "is_blue_verified": false,
+                                    "legacy": {
+                                      "default_profile": true,
+                                      "default_profile_image": false,
+                                      "description": "",
+                                      "entities": {
+                                        "description": {}
+                                      },
+                                      "fast_followers_count": 0,
+                                      "favourites_count": 0,
+                                      "follow_request_sent": false,
+                                      "followers_count": 0,
+                                      "friends_count": 5,
+                                      "has_custom_timelines": false,
+                                      "is_translator": false,
+                                      "listed_count": 0,
+                                      "media_count": 3,
+                                      "needs_phone_verification": false,
+                                      "normal_followers_count": 0,
+                                      "notifications": false,
+                                      "possibly_sensitive": false,
+                                      "profile_banner_url": "",
+                                      "profile_interstitial_type": "",
+                                      "statuses_count": 7,
+                                      "time_zone": "",
+                                      "translator_type": "none",
+                                      "url": "",
+                                      "utc_offset": 0,
+                                      "want_retweets": false,
+                                      "withheld_description": "",
+                                      "withheld_scope": ""
+                                    },
+                                    "location": {
+                                      "location": ""
+                                    },
+                                    "media_permissions": {
+                                      "can_media_tag": true
+                                    },
+                                    "parody_commentary_fan_label": "None",
+                                    "privacy": {
+                                      "protected": false
+                                    },
+                                    "profile_bio": {
+                                      "description": ""
+                                    },
+                                    "profile_image_shape": "Circle",
+                                    "relationship_perspectives": {
+                                      "blocked_by": false,
+                                      "blocking": false,
+                                      "followed_by": false,
+                                      "following": false,
+                                      "muting": false
+                                    },
+                                    "rest_id": "1244107928572850176",
+                                    "super_follow_eligible": false,
+                                    "super_followed_by": false,
+                                    "super_following": false,
+                                    "verification": {
+                                      "verified": false
+                                    }
+                                  }
+                                }
+                              },
+                              "edit_control": {
+                                "edit_tweet_ids": ["2088886533206282540"],
+                                "editable_until_msecs": "1786867933000",
+                                "edits_remaining": "5",
+                                "is_edit_eligible": false
+                              },
+                              "grok_analysis_button": true,
+                              "grok_annotations": {},
+                              "has_birdwatch_notes": false,
+                              "is_translatable": false,
+                              "legacy": {
+                                "bookmark_count": 0,
+                                "bookmarked": false,
+                                "conversation_id_str": "2087720798702498234",
+                                "created_at": "Sun Aug 16 07:12:13 +0000 2026",
+                                "display_text_range": [15, 40],
+                                "entities": {
+                                  "media": [
+                                    {
+                                      "allow_download_status": {
+                                        "allow_download": true
+                                      },
+                                      "display_url": "pic.x.com/I5ZTYT17mW",
+                                      "expanded_url": "https://x.com/unname5331/status/2088886533206282540/photo/1",
+                                      "ext_media_availability": {
+                                        "status": "Available"
+                                      },
+                                      "features": {
+                                        "large": {
+                                          "faces": [
+                                            {
+                                              "h": 117,
+                                              "w": 117,
+                                              "x": 286,
+                                              "y": 156
+                                            }
+                                          ]
+                                        },
+                                        "medium": {
+                                          "faces": [
+                                            {
+                                              "h": 117,
+                                              "w": 117,
+                                              "x": 286,
+                                              "y": 156
+                                            }
+                                          ]
+                                        },
+                                        "orig": {
+                                          "faces": [
+                                            {
+                                              "h": 117,
+                                              "w": 117,
+                                              "x": 286,
+                                              "y": 156
+                                            }
+                                          ]
+                                        },
+                                        "small": {
+                                          "faces": [
+                                            {
+                                              "h": 81,
+                                              "w": 81,
+                                              "x": 198,
+                                              "y": 108
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "id_str": "2088886362170851328",
+                                      "indices": [41, 64],
+                                      "media_key": "3_2088886362170851328",
+                                      "media_results": {
+                                        "result": {
+                                          "media_key": "3_2088886362170851328"
+                                        }
+                                      },
+                                      "media_url_https": "https://pbs.twimg.com/media/HP03FDlaAAAu4PY.jpg",
+                                      "original_info": {
+                                        "focus_rects": [
+                                          {
+                                            "h": 432,
+                                            "w": 772,
+                                            "x": 0,
+                                            "y": 345
+                                          },
+                                          {
+                                            "h": 772,
+                                            "w": 772,
+                                            "x": 0,
+                                            "y": 175
+                                          },
+                                          {
+                                            "h": 880,
+                                            "w": 772,
+                                            "x": 0,
+                                            "y": 97
+                                          },
+                                          {
+                                            "h": 977,
+                                            "w": 489,
+                                            "x": 122,
+                                            "y": 0
+                                          },
+                                          {
+                                            "h": 977,
+                                            "w": 772,
+                                            "x": 0,
+                                            "y": 0
+                                          }
+                                        ],
+                                        "height": 977,
+                                        "width": 772
+                                      },
+                                      "sizes": {
+                                        "large": {
+                                          "h": 977,
+                                          "resize": "fit",
+                                          "w": 772
+                                        },
+                                        "medium": {
+                                          "h": 977,
+                                          "resize": "fit",
+                                          "w": 772
+                                        },
+                                        "small": {
+                                          "h": 680,
+                                          "resize": "fit",
+                                          "w": 537
+                                        },
+                                        "thumb": {
+                                          "h": 150,
+                                          "resize": "crop",
+                                          "w": 150
+                                        }
+                                      },
+                                      "type": "photo",
+                                      "url": "https://t.co/I5ZTYT17mW"
+                                    }
+                                  ],
+                                  "user_mentions": [
+                                    {
+                                      "id_str": "1072404907230060544",
+                                      "indices": [0, 14],
+                                      "name": "Genshin Impact",
+                                      "screen_name": "GenshinImpact"
+                                    }
+                                  ]
+                                },
+                                "extended_entities": {
+                                  "media": [
+                                    {
+                                      "allow_download_status": {
+                                        "allow_download": true
+                                      },
+                                      "display_url": "pic.x.com/I5ZTYT17mW",
+                                      "expanded_url": "https://x.com/unname5331/status/2088886533206282540/photo/1",
+                                      "ext_media_availability": {
+                                        "status": "Available"
+                                      },
+                                      "features": {
+                                        "large": {
+                                          "faces": [
+                                            {
+                                              "h": 117,
+                                              "w": 117,
+                                              "x": 286,
+                                              "y": 156
+                                            }
+                                          ]
+                                        },
+                                        "medium": {
+                                          "faces": [
+                                            {
+                                              "h": 117,
+                                              "w": 117,
+                                              "x": 286,
+                                              "y": 156
+                                            }
+                                          ]
+                                        },
+                                        "orig": {
+                                          "faces": [
+                                            {
+                                              "h": 117,
+                                              "w": 117,
+                                              "x": 286,
+                                              "y": 156
+                                            }
+                                          ]
+                                        },
+                                        "small": {
+                                          "faces": [
+                                            {
+                                              "h": 81,
+                                              "w": 81,
+                                              "x": 198,
+                                              "y": 108
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "id_str": "2088886362170851328",
+                                      "indices": [41, 64],
+                                      "media_key": "3_2088886362170851328",
+                                      "media_results": {
+                                        "result": {
+                                          "media_key": "3_2088886362170851328"
+                                        }
+                                      },
+                                      "media_url_https": "https://pbs.twimg.com/media/HP03FDlaAAAu4PY.jpg",
+                                      "original_info": {
+                                        "focus_rects": [
+                                          {
+                                            "h": 432,
+                                            "w": 772,
+                                            "x": 0,
+                                            "y": 345
+                                          },
+                                          {
+                                            "h": 772,
+                                            "w": 772,
+                                            "x": 0,
+                                            "y": 175
+                                          },
+                                          {
+                                            "h": 880,
+                                            "w": 772,
+                                            "x": 0,
+                                            "y": 97
+                                          },
+                                          {
+                                            "h": 977,
+                                            "w": 489,
+                                            "x": 122,
+                                            "y": 0
+                                          },
+                                          {
+                                            "h": 977,
+                                            "w": 772,
+                                            "x": 0,
+                                            "y": 0
+                                          }
+                                        ],
+                                        "height": 977,
+                                        "width": 772
+                                      },
+                                      "sizes": {
+                                        "large": {
+                                          "h": 977,
+                                          "resize": "fit",
+                                          "w": 772
+                                        },
+                                        "medium": {
+                                          "h": 977,
+                                          "resize": "fit",
+                                          "w": 772
+                                        },
+                                        "small": {
+                                          "h": 680,
+                                          "resize": "fit",
+                                          "w": 537
+                                        },
+                                        "thumb": {
+                                          "h": 150,
+                                          "resize": "crop",
+                                          "w": 150
+                                        }
+                                      },
+                                      "type": "photo",
+                                      "url": "https://t.co/I5ZTYT17mW"
+                                    }
+                                  ]
+                                },
+                                "favorite_count": 0,
+                                "favorited": false,
+                                "full_text": "@GenshinImpact UID:802066020\nServer:Asia https://t.co/I5ZTYT17mW",
+                                "id_str": "2088886533206282540",
+                                "in_reply_to_screen_name": "GenshinImpact",
+                                "in_reply_to_status_id_str": "2087720798702498234",
+                                "in_reply_to_user_id_str": "1072404907230060544",
+                                "is_quote_status": false,
+                                "lang": "et",
+                                "possibly_sensitive": false,
+                                "possibly_sensitive_editable": true,
+                                "quote_count": 0,
+                                "reply_count": 0,
+                                "retweet_count": 0,
+                                "retweeted": false,
+                                "user_id_str": "1244107928572850176"
+                              },
+                              "quick_promote_eligibility": {
+                                "eligibility": "IneligibleNotVerified"
+                              },
+                              "rest_id": "2088886533206282540",
+                              "source": "<a href=\"https://mobile.twitter.com\" rel=\"nofollow\">Twitter Web App</a>",
+                              "unmention_data": {},
+                              "views": {
+                                "count": "73",
+                                "state": "EnabledWithCount"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  ],
+                  "metadata": {
+                    "conversationMetadata": {
+                      "allTweetIds": ["2088886533206282540"],
+                      "enableDeduplication": true
+                    }
+                  }
+                },
+                "entryId": "conversationthread-2088886533206282540",
+                "sortIndex": "2088929116056190806"
+              },
+              {
+                "content": {
+                  "__typename": "TimelineTimelineModule",
+                  "clientEventInfo": {
+                    "component": "tweet",
+                    "details": {
+                      "conversationDetails": {
+                        "conversationSection": "HighQuality"
+                      },
+                      "timelinesDetails": {
+                        "controllerData": "DAACDAAEDAABCgABAAAAAAAAAAEKAAIAAAAAAAAAAAoAAwAAAaAKBN5LAAAAAA=="
+                      }
+                    }
+                  },
+                  "displayType": "VerticalConversation",
+                  "entryType": "TimelineTimelineModule",
+                  "items": [
+                    {
+                      "entryId": "conversationthread-2088718487405367650-tweet-2088718487405367650",
+                      "item": {
+                        "clientEventInfo": {
+                          "component": "tweet",
+                          "details": {
+                            "conversationDetails": {
+                              "conversationSection": "HighQuality"
+                            },
+                            "timelinesDetails": {
+                              "controllerData": "DAACDAAEDAABCgABAAAAAAAAAAEKAAIAAAAAAAAAAAoAAwAAAaAKBN5LAAAAAA=="
+                            }
+                          },
+                          "element": "tweet"
+                        },
+                        "itemContent": {
+                          "__typename": "TimelineTweet",
+                          "itemType": "TimelineTweet",
+                          "tweetDisplayType": "Tweet",
+                          "tweet_results": {
+                            "result": {
+                              "__typename": "Tweet",
+                              "core": {
+                                "user_results": {
+                                  "result": {
+                                    "__typename": "User",
+                                    "affiliates_highlighted_label": {},
+                                    "avatar": {
+                                      "image_url": "https://pbs.twimg.com/profile_images/1813392514709168128/FYufgu-k_normal.jpg"
+                                    },
+                                    "core": {
+                                      "created_at": "Wed Oct 31 00:45:50 +0000 2018",
+                                      "name": "Sydney Robert",
+                                      "screen_name": "SydneyRobert10"
+                                    },
+                                    "dm_permissions": {
+                                      "can_dm": false
+                                    },
+                                    "follow_request_sent": false,
+                                    "has_graduated_access": true,
+                                    "id": "VXNlcjoxMDU3NDMzNDI4MzMxNzY5ODU3",
+                                    "is_blue_verified": false,
+                                    "legacy": {
+                                      "default_profile": true,
+                                      "default_profile_image": false,
+                                      "description": "",
+                                      "entities": {
+                                        "description": {}
+                                      },
+                                      "fast_followers_count": 0,
+                                      "favourites_count": 325,
+                                      "follow_request_sent": false,
+                                      "followers_count": 8,
+                                      "friends_count": 23,
+                                      "has_custom_timelines": false,
+                                      "is_translator": false,
+                                      "listed_count": 0,
+                                      "media_count": 10,
+                                      "needs_phone_verification": false,
+                                      "normal_followers_count": 8,
+                                      "notifications": false,
+                                      "possibly_sensitive": false,
+                                      "profile_banner_url": "https://pbs.twimg.com/profile_banners/1057433428331769857/1721181443",
+                                      "profile_interstitial_type": "",
+                                      "statuses_count": 319,
+                                      "time_zone": "",
+                                      "translator_type": "none",
+                                      "url": "",
+                                      "utc_offset": 0,
+                                      "want_retweets": false,
+                                      "withheld_description": "",
+                                      "withheld_scope": ""
+                                    },
+                                    "location": {
+                                      "location": ""
+                                    },
+                                    "media_permissions": {
+                                      "can_media_tag": true
+                                    },
+                                    "parody_commentary_fan_label": "None",
+                                    "privacy": {
+                                      "protected": false
+                                    },
+                                    "profile_bio": {
+                                      "description": ""
+                                    },
+                                    "profile_description_language": "und",
+                                    "profile_image_shape": "Circle",
+                                    "relationship_perspectives": {
+                                      "blocked_by": false,
+                                      "blocking": false,
+                                      "followed_by": false,
+                                      "following": false,
+                                      "muting": false
+                                    },
+                                    "rest_id": "1057433428331769857",
+                                    "super_follow_eligible": false,
+                                    "super_followed_by": false,
+                                    "super_following": false,
+                                    "verification": {
+                                      "verified": false
+                                    }
+                                  }
+                                }
+                              },
+                              "edit_control": {
+                                "edit_tweet_ids": ["2088718487405367650"],
+                                "editable_until_msecs": "1786827868000",
+                                "edits_remaining": "5",
+                                "is_edit_eligible": false
+                              },
+                              "grok_analysis_button": true,
+                              "grok_annotations": {},
+                              "has_birdwatch_notes": false,
+                              "is_translatable": false,
+                              "legacy": {
+                                "bookmark_count": 0,
+                                "bookmarked": false,
+                                "conversation_id_str": "2087720798702498234",
+                                "created_at": "Sat Aug 15 20:04:28 +0000 2026",
+                                "display_text_range": [15, 45],
+                                "entities": {
+                                  "user_mentions": [
+                                    {
+                                      "id_str": "1072404907230060544",
+                                      "indices": [0, 14],
+                                      "name": "Genshin Impact",
+                                      "screen_name": "GenshinImpact"
+                                    }
+                                  ]
+                                },
+                                "favorite_count": 0,
+                                "favorited": false,
+                                "full_text": "@GenshinImpact Is this on hoyolab? Or just X?",
+                                "id_str": "2088718487405367650",
+                                "in_reply_to_screen_name": "GenshinImpact",
+                                "in_reply_to_status_id_str": "2087720798702498234",
+                                "in_reply_to_user_id_str": "1072404907230060544",
+                                "is_quote_status": false,
+                                "lang": "en",
+                                "quote_count": 0,
+                                "reply_count": 0,
+                                "retweet_count": 0,
+                                "retweeted": false,
+                                "user_id_str": "1057433428331769857"
+                              },
+                              "quick_promote_eligibility": {
+                                "eligibility": "IneligibleNotVerified"
+                              },
+                              "rest_id": "2088718487405367650",
+                              "source": "<a href=\"http://twitter.com/download/android\" rel=\"nofollow\">Twitter for Android</a>",
+                              "unmention_data": {},
+                              "views": {
+                                "count": "182",
+                                "state": "EnabledWithCount"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  ],
+                  "metadata": {
+                    "conversationMetadata": {
+                      "allTweetIds": ["2088718487405367650"],
+                      "enableDeduplication": true
+                    }
+                  }
+                },
+                "entryId": "conversationthread-2088718487405367650",
+                "sortIndex": "2088929116056190796"
+              },
+              {
+                "content": {
+                  "__typename": "TimelineTimelineModule",
+                  "clientEventInfo": {
+                    "component": "tweet",
+                    "details": {
+                      "conversationDetails": {
+                        "conversationSection": "HighQuality"
+                      },
+                      "timelinesDetails": {
+                        "controllerData": "DAACDAAEDAABCgABAAAAAAAAAAEKAAIAAAAAAAAAAAoAAwAAAaAKBN5LAAAAAA=="
+                      }
+                    }
+                  },
+                  "displayType": "VerticalConversation",
+                  "entryType": "TimelineTimelineModule",
+                  "items": [
+                    {
+                      "entryId": "conversationthread-2088386018030260706-tweet-2088386018030260706",
+                      "item": {
+                        "clientEventInfo": {
+                          "component": "tweet",
+                          "details": {
+                            "conversationDetails": {
+                              "conversationSection": "HighQuality"
+                            },
+                            "timelinesDetails": {
+                              "controllerData": "DAACDAAEDAABCgABAAAAAAAAAAEKAAIAAAAAAAAAAAoAAwAAAaAKBN5LAAAAAA=="
+                            }
+                          },
+                          "element": "tweet"
+                        },
+                        "itemContent": {
+                          "__typename": "TimelineTweet",
+                          "itemType": "TimelineTweet",
+                          "tweetDisplayType": "Tweet",
+                          "tweet_results": {
+                            "result": {
+                              "__typename": "Tweet",
+                              "core": {
+                                "user_results": {
+                                  "result": {
+                                    "__typename": "User",
+                                    "affiliates_highlighted_label": {},
+                                    "avatar": {
+                                      "image_url": "https://pbs.twimg.com/profile_images/2027954601329098753/cJwlkVqR_normal.jpg"
+                                    },
+                                    "core": {
+                                      "created_at": "Sat Jul 09 19:03:11 +0000 2022",
+                                      "name": "Winnie꒰ᐢ. .ᐢ꒱🔪",
+                                      "screen_name": "ms_rori3"
+                                    },
+                                    "dm_permissions": {
+                                      "can_dm": true
+                                    },
+                                    "follow_request_sent": false,
+                                    "has_graduated_access": true,
+                                    "id": "VXNlcjoxNTQ1ODQ1OTg2MTUyNTcwODgw",
+                                    "is_blue_verified": false,
+                                    "legacy": {
+                                      "default_profile": true,
+                                      "default_profile_image": false,
+                                      "description": "📜🪶; https://t.co/IwiXXG19ql; sume_luv Genshin UID: 658989248",
+                                      "entities": {
+                                        "description": {
+                                          "urls": [
+                                            {
+                                              "display_url": "discord.gg/6AXEhs4W",
+                                              "expanded_url": "https://discord.gg/6AXEhs4W",
+                                              "indices": [4, 27],
+                                              "url": "https://t.co/IwiXXG19ql"
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "fast_followers_count": 0,
+                                      "favourites_count": 248,
+                                      "follow_request_sent": false,
+                                      "followers_count": 52,
+                                      "friends_count": 110,
+                                      "has_custom_timelines": false,
+                                      "is_translator": false,
+                                      "listed_count": 0,
+                                      "media_count": 36,
+                                      "needs_phone_verification": false,
+                                      "normal_followers_count": 52,
+                                      "notifications": false,
+                                      "pinned_tweet_ids_str": [
+                                        "2015677495723376901"
+                                      ],
+                                      "possibly_sensitive": false,
+                                      "profile_banner_url": "https://pbs.twimg.com/profile_banners/1545845986152570880/1769476023",
+                                      "profile_interstitial_type": "",
+                                      "statuses_count": 211,
+                                      "time_zone": "",
+                                      "translator_type": "none",
+                                      "url": "",
+                                      "utc_offset": 0,
+                                      "want_retweets": false,
+                                      "withheld_description": "",
+                                      "withheld_scope": ""
+                                    },
+                                    "location": {
+                                      "location": ""
+                                    },
+                                    "media_permissions": {
+                                      "can_media_tag": true
+                                    },
+                                    "parody_commentary_fan_label": "None",
+                                    "privacy": {
+                                      "protected": false
+                                    },
+                                    "profile_bio": {
+                                      "description": "📜🪶; https://t.co/IwiXXG19ql; sume_luv Genshin UID: 658989248"
+                                    },
+                                    "profile_image_shape": "Circle",
+                                    "relationship_perspectives": {
+                                      "blocked_by": false,
+                                      "blocking": false,
+                                      "followed_by": false,
+                                      "following": false,
+                                      "muting": false
+                                    },
+                                    "rest_id": "1545845986152570880",
+                                    "super_follow_eligible": false,
+                                    "super_followed_by": false,
+                                    "super_following": false,
+                                    "verification": {
+                                      "verified": false
+                                    }
+                                  }
+                                }
+                              },
+                              "edit_control": {
+                                "edit_tweet_ids": ["2088386018030260706"],
+                                "editable_until_msecs": "1786748601000",
+                                "edits_remaining": "5",
+                                "is_edit_eligible": false
+                              },
+                              "grok_analysis_button": true,
+                              "grok_annotations": {},
+                              "has_birdwatch_notes": false,
+                              "is_translatable": false,
+                              "legacy": {
+                                "bookmark_count": 1,
+                                "bookmarked": false,
+                                "conversation_id_str": "2087720798702498234",
+                                "created_at": "Fri Aug 14 22:03:21 +0000 2026",
+                                "display_text_range": [15, 46],
+                                "entities": {
+                                  "media": [
+                                    {
+                                      "display_url": "pic.x.com/xqQxFQayan",
+                                      "expanded_url": "https://x.com/ms_rori3/status/2088386018030260706/photo/1",
+                                      "ext_media_availability": {
+                                        "status": "Available"
+                                      },
+                                      "features": {
+                                        "large": {
+                                          "faces": []
+                                        },
+                                        "medium": {
+                                          "faces": []
+                                        },
+                                        "orig": {
+                                          "faces": []
+                                        },
+                                        "small": {
+                                          "faces": []
+                                        }
+                                      },
+                                      "id_str": "2088386014880452609",
+                                      "indices": [47, 70],
+                                      "media_key": "3_2088386014880452609",
+                                      "media_results": {
+                                        "result": {
+                                          "media_key": "3_2088386014880452609"
+                                        }
+                                      },
+                                      "media_url_https": "https://pbs.twimg.com/media/HPtwBArX0AEHizc.jpg",
+                                      "original_info": {
+                                        "focus_rects": [
+                                          {
+                                            "h": 675,
+                                            "w": 1206,
+                                            "x": 0,
+                                            "y": 615
+                                          },
+                                          {
+                                            "h": 1206,
+                                            "w": 1206,
+                                            "x": 0,
+                                            "y": 84
+                                          },
+                                          {
+                                            "h": 1290,
+                                            "w": 1132,
+                                            "x": 0,
+                                            "y": 0
+                                          },
+                                          {
+                                            "h": 1290,
+                                            "w": 645,
+                                            "x": 97,
+                                            "y": 0
+                                          },
+                                          {
+                                            "h": 1290,
+                                            "w": 1206,
+                                            "x": 0,
+                                            "y": 0
+                                          }
+                                        ],
+                                        "height": 1290,
+                                        "width": 1206
+                                      },
+                                      "sizes": {
+                                        "large": {
+                                          "h": 1290,
+                                          "resize": "fit",
+                                          "w": 1206
+                                        },
+                                        "medium": {
+                                          "h": 1200,
+                                          "resize": "fit",
+                                          "w": 1122
+                                        },
+                                        "small": {
+                                          "h": 680,
+                                          "resize": "fit",
+                                          "w": 636
+                                        },
+                                        "thumb": {
+                                          "h": 150,
+                                          "resize": "crop",
+                                          "w": 150
+                                        }
+                                      },
+                                      "type": "photo",
+                                      "url": "https://t.co/xqQxFQayan"
+                                    }
+                                  ],
+                                  "user_mentions": [
+                                    {
+                                      "id_str": "1072404907230060544",
+                                      "indices": [0, 14],
+                                      "name": "Genshin Impact",
+                                      "screen_name": "GenshinImpact"
+                                    }
+                                  ]
+                                },
+                                "extended_entities": {
+                                  "media": [
+                                    {
+                                      "display_url": "pic.x.com/xqQxFQayan",
+                                      "expanded_url": "https://x.com/ms_rori3/status/2088386018030260706/photo/1",
+                                      "ext_media_availability": {
+                                        "status": "Available"
+                                      },
+                                      "features": {
+                                        "large": {
+                                          "faces": []
+                                        },
+                                        "medium": {
+                                          "faces": []
+                                        },
+                                        "orig": {
+                                          "faces": []
+                                        },
+                                        "small": {
+                                          "faces": []
+                                        }
+                                      },
+                                      "id_str": "2088386014880452609",
+                                      "indices": [47, 70],
+                                      "media_key": "3_2088386014880452609",
+                                      "media_results": {
+                                        "result": {
+                                          "media_key": "3_2088386014880452609"
+                                        }
+                                      },
+                                      "media_url_https": "https://pbs.twimg.com/media/HPtwBArX0AEHizc.jpg",
+                                      "original_info": {
+                                        "focus_rects": [
+                                          {
+                                            "h": 675,
+                                            "w": 1206,
+                                            "x": 0,
+                                            "y": 615
+                                          },
+                                          {
+                                            "h": 1206,
+                                            "w": 1206,
+                                            "x": 0,
+                                            "y": 84
+                                          },
+                                          {
+                                            "h": 1290,
+                                            "w": 1132,
+                                            "x": 0,
+                                            "y": 0
+                                          },
+                                          {
+                                            "h": 1290,
+                                            "w": 645,
+                                            "x": 97,
+                                            "y": 0
+                                          },
+                                          {
+                                            "h": 1290,
+                                            "w": 1206,
+                                            "x": 0,
+                                            "y": 0
+                                          }
+                                        ],
+                                        "height": 1290,
+                                        "width": 1206
+                                      },
+                                      "sizes": {
+                                        "large": {
+                                          "h": 1290,
+                                          "resize": "fit",
+                                          "w": 1206
+                                        },
+                                        "medium": {
+                                          "h": 1200,
+                                          "resize": "fit",
+                                          "w": 1122
+                                        },
+                                        "small": {
+                                          "h": 680,
+                                          "resize": "fit",
+                                          "w": 636
+                                        },
+                                        "thumb": {
+                                          "h": 150,
+                                          "resize": "crop",
+                                          "w": 150
+                                        }
+                                      },
+                                      "type": "photo",
+                                      "url": "https://t.co/xqQxFQayan"
+                                    }
+                                  ]
+                                },
+                                "favorite_count": 0,
+                                "favorited": false,
+                                "full_text": "@GenshinImpact Server: American\nUID: 658989248 https://t.co/xqQxFQayan",
+                                "id_str": "2088386018030260706",
+                                "in_reply_to_screen_name": "GenshinImpact",
+                                "in_reply_to_status_id_str": "2087720798702498234",
+                                "in_reply_to_user_id_str": "1072404907230060544",
+                                "is_quote_status": false,
+                                "lang": "ca",
+                                "possibly_sensitive": false,
+                                "possibly_sensitive_editable": true,
+                                "quote_count": 0,
+                                "reply_count": 0,
+                                "retweet_count": 0,
+                                "retweeted": false,
+                                "user_id_str": "1545845986152570880"
+                              },
+                              "quick_promote_eligibility": {
+                                "eligibility": "IneligibleNotVerified"
+                              },
+                              "rest_id": "2088386018030260706",
+                              "source": "<a href=\"http://twitter.com/download/iphone\" rel=\"nofollow\">Twitter for iPhone</a>",
+                              "unmention_data": {},
+                              "views": {
+                                "count": "461",
+                                "state": "EnabledWithCount"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  ],
+                  "metadata": {
+                    "conversationMetadata": {
+                      "allTweetIds": ["2088386018030260706"],
+                      "enableDeduplication": true
+                    }
+                  }
+                },
+                "entryId": "conversationthread-2088386018030260706",
+                "sortIndex": "2088929116056190786"
+              },
+              {
+                "content": {
+                  "__typename": "TimelineTimelineModule",
+                  "clientEventInfo": {
+                    "component": "tweet",
+                    "details": {
+                      "conversationDetails": {
+                        "conversationSection": "HighQuality"
+                      },
+                      "timelinesDetails": {
+                        "controllerData": "DAACDAAEDAABCgABAAAAAAAAAAEKAAIAAAAAAAAAAAoAAwAAAaAKBN5LAAAAAA=="
+                      }
+                    }
+                  },
+                  "displayType": "VerticalConversation",
+                  "entryType": "TimelineTimelineModule",
+                  "items": [
+                    {
+                      "entryId": "conversationthread-2088386301485871132-tweet-2088386301485871132",
+                      "item": {
+                        "clientEventInfo": {
+                          "component": "tweet",
+                          "details": {
+                            "conversationDetails": {
+                              "conversationSection": "HighQuality"
+                            },
+                            "timelinesDetails": {
+                              "controllerData": "DAACDAAEDAABCgABAAAAAAAAAAEKAAIAAAAAAAAAAAoAAwAAAaAKBN5LAAAAAA=="
+                            }
+                          },
+                          "element": "tweet"
+                        },
+                        "itemContent": {
+                          "__typename": "TimelineTweet",
+                          "itemType": "TimelineTweet",
+                          "tweetDisplayType": "Tweet",
+                          "tweet_results": {
+                            "result": {
+                              "__typename": "Tweet",
+                              "core": {
+                                "user_results": {
+                                  "result": {
+                                    "__typename": "User",
+                                    "affiliates_highlighted_label": {},
+                                    "avatar": {
+                                      "image_url": "https://pbs.twimg.com/profile_images/2006498407419105280/RIUI-X-2_normal.jpg"
+                                    },
+                                    "core": {
+                                      "created_at": "Sat Jan 11 21:40:44 +0000 2025",
+                                      "name": "𝐼𝓇𝒾𝓈.",
+                                      "screen_name": "kim1rix"
+                                    },
+                                    "dm_permissions": {
+                                      "can_dm": false
+                                    },
+                                    "follow_request_sent": false,
+                                    "has_graduated_access": true,
+                                    "id": "VXNlcjoxODc4MTk1MDY0MTM0MDgyNTYw",
+                                    "is_blue_verified": false,
+                                    "legacy": {
+                                      "default_profile": true,
+                                      "default_profile_image": false,
+                                      "description": "( ꜆🥛꜀ ) . . ୨୧",
+                                      "entities": {
+                                        "description": {},
+                                        "url": {
+                                          "urls": [
+                                            {
+                                              "display_url": "cinnamqncapriccio.carrd.co",
+                                              "expanded_url": "https://cinnamqncapriccio.carrd.co/",
+                                              "indices": [0, 23],
+                                              "url": "https://t.co/3SFxI4mVO2"
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "fast_followers_count": 0,
+                                      "favourites_count": 1,
+                                      "follow_request_sent": false,
+                                      "followers_count": 4,
+                                      "friends_count": 13,
+                                      "has_custom_timelines": false,
+                                      "is_translator": false,
+                                      "listed_count": 0,
+                                      "media_count": 1,
+                                      "needs_phone_verification": false,
+                                      "normal_followers_count": 4,
+                                      "notifications": false,
+                                      "possibly_sensitive": false,
+                                      "profile_banner_url": "https://pbs.twimg.com/profile_banners/1878195064134082560/1767221485",
+                                      "profile_interstitial_type": "",
+                                      "statuses_count": 3,
+                                      "time_zone": "",
+                                      "translator_type": "none",
+                                      "url": "https://t.co/3SFxI4mVO2",
+                                      "utc_offset": 0,
+                                      "want_retweets": false,
+                                      "withheld_description": "",
+                                      "withheld_scope": ""
+                                    },
+                                    "location": {
+                                      "location": "epiphany."
+                                    },
+                                    "media_permissions": {
+                                      "can_media_tag": false
+                                    },
+                                    "parody_commentary_fan_label": "None",
+                                    "privacy": {
+                                      "protected": false
+                                    },
+                                    "profile_bio": {
+                                      "description": "( ꜆🥛꜀ ) . . ୨୧"
+                                    },
+                                    "profile_image_shape": "Circle",
+                                    "relationship_perspectives": {
+                                      "blocked_by": false,
+                                      "blocking": false,
+                                      "followed_by": false,
+                                      "following": false,
+                                      "muting": false
+                                    },
+                                    "rest_id": "1878195064134082560",
+                                    "super_follow_eligible": false,
+                                    "super_followed_by": false,
+                                    "super_following": false,
+                                    "verification": {
+                                      "verified": false
+                                    }
+                                  }
+                                }
+                              },
+                              "edit_control": {
+                                "edit_tweet_ids": ["2088386301485871132"],
+                                "editable_until_msecs": "1786748669000",
+                                "edits_remaining": "5",
+                                "is_edit_eligible": false
+                              },
+                              "grok_analysis_button": true,
+                              "grok_annotations": {},
+                              "has_birdwatch_notes": false,
+                              "is_translatable": false,
+                              "legacy": {
+                                "bookmark_count": 0,
+                                "bookmarked": false,
+                                "conversation_id_str": "2087720798702498234",
+                                "created_at": "Fri Aug 14 22:04:29 +0000 2026",
+                                "display_text_range": [15, 42],
+                                "entities": {
+                                  "media": [
+                                    {
+                                      "allow_download_status": {
+                                        "allow_download": true
+                                      },
+                                      "display_url": "pic.x.com/aQoveKhslZ",
+                                      "expanded_url": "https://x.com/kim1rix/status/2088386301485871132/photo/1",
+                                      "ext_media_availability": {
+                                        "status": "Available"
+                                      },
+                                      "features": {
+                                        "large": {
+                                          "faces": [
+                                            {
+                                              "h": 35,
+                                              "w": 35,
+                                              "x": 999,
+                                              "y": 419
+                                            },
+                                            {
+                                              "h": 41,
+                                              "w": 41,
+                                              "x": 5,
+                                              "y": 176
+                                            },
+                                            {
+                                              "h": 82,
+                                              "w": 82,
+                                              "x": 744,
+                                              "y": 646
+                                            }
+                                          ]
+                                        },
+                                        "medium": {
+                                          "faces": [
+                                            {
+                                              "h": 35,
+                                              "w": 35,
+                                              "x": 999,
+                                              "y": 419
+                                            },
+                                            {
+                                              "h": 41,
+                                              "w": 41,
+                                              "x": 5,
+                                              "y": 176
+                                            },
+                                            {
+                                              "h": 82,
+                                              "w": 82,
+                                              "x": 744,
+                                              "y": 646
+                                            }
+                                          ]
+                                        },
+                                        "orig": {
+                                          "faces": [
+                                            {
+                                              "h": 35,
+                                              "w": 35,
+                                              "x": 999,
+                                              "y": 419
+                                            },
+                                            {
+                                              "h": 41,
+                                              "w": 41,
+                                              "x": 5,
+                                              "y": 176
+                                            },
+                                            {
+                                              "h": 82,
+                                              "w": 82,
+                                              "x": 744,
+                                              "y": 646
+                                            }
+                                          ]
+                                        },
+                                        "small": {
+                                          "faces": [
+                                            {
+                                              "h": 22,
+                                              "w": 22,
+                                              "x": 629,
+                                              "y": 263
+                                            },
+                                            {
+                                              "h": 25,
+                                              "w": 25,
+                                              "x": 3,
+                                              "y": 110
+                                            },
+                                            {
+                                              "h": 51,
+                                              "w": 51,
+                                              "x": 468,
+                                              "y": 406
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "id_str": "2088386294988873728",
+                                      "indices": [43, 66],
+                                      "media_key": "3_2088386294988873728",
+                                      "media_results": {
+                                        "result": {
+                                          "media_key": "3_2088386294988873728"
+                                        }
+                                      },
+                                      "media_url_https": "https://pbs.twimg.com/media/HPtwRUKbIAAbRKb.jpg",
+                                      "original_info": {
+                                        "focus_rects": [
+                                          {
+                                            "h": 605,
+                                            "w": 1080,
+                                            "x": 0,
+                                            "y": 475
+                                          },
+                                          {
+                                            "h": 1080,
+                                            "w": 1080,
+                                            "x": 0,
+                                            "y": 0
+                                          },
+                                          {
+                                            "h": 1080,
+                                            "w": 947,
+                                            "x": 133,
+                                            "y": 0
+                                          },
+                                          {
+                                            "h": 1080,
+                                            "w": 540,
+                                            "x": 540,
+                                            "y": 0
+                                          },
+                                          {
+                                            "h": 1080,
+                                            "w": 1080,
+                                            "x": 0,
+                                            "y": 0
+                                          }
+                                        ],
+                                        "height": 1080,
+                                        "width": 1080
+                                      },
+                                      "sizes": {
+                                        "large": {
+                                          "h": 1080,
+                                          "resize": "fit",
+                                          "w": 1080
+                                        },
+                                        "medium": {
+                                          "h": 1080,
+                                          "resize": "fit",
+                                          "w": 1080
+                                        },
+                                        "small": {
+                                          "h": 680,
+                                          "resize": "fit",
+                                          "w": 680
+                                        },
+                                        "thumb": {
+                                          "h": 150,
+                                          "resize": "crop",
+                                          "w": 150
+                                        }
+                                      },
+                                      "type": "photo",
+                                      "url": "https://t.co/aQoveKhslZ"
+                                    }
+                                  ],
+                                  "user_mentions": [
+                                    {
+                                      "id_str": "1072404907230060544",
+                                      "indices": [0, 14],
+                                      "name": "Genshin Impact",
+                                      "screen_name": "GenshinImpact"
+                                    }
+                                  ]
+                                },
+                                "extended_entities": {
+                                  "media": [
+                                    {
+                                      "allow_download_status": {
+                                        "allow_download": true
+                                      },
+                                      "display_url": "pic.x.com/aQoveKhslZ",
+                                      "expanded_url": "https://x.com/kim1rix/status/2088386301485871132/photo/1",
+                                      "ext_media_availability": {
+                                        "status": "Available"
+                                      },
+                                      "features": {
+                                        "large": {
+                                          "faces": [
+                                            {
+                                              "h": 35,
+                                              "w": 35,
+                                              "x": 999,
+                                              "y": 419
+                                            },
+                                            {
+                                              "h": 41,
+                                              "w": 41,
+                                              "x": 5,
+                                              "y": 176
+                                            },
+                                            {
+                                              "h": 82,
+                                              "w": 82,
+                                              "x": 744,
+                                              "y": 646
+                                            }
+                                          ]
+                                        },
+                                        "medium": {
+                                          "faces": [
+                                            {
+                                              "h": 35,
+                                              "w": 35,
+                                              "x": 999,
+                                              "y": 419
+                                            },
+                                            {
+                                              "h": 41,
+                                              "w": 41,
+                                              "x": 5,
+                                              "y": 176
+                                            },
+                                            {
+                                              "h": 82,
+                                              "w": 82,
+                                              "x": 744,
+                                              "y": 646
+                                            }
+                                          ]
+                                        },
+                                        "orig": {
+                                          "faces": [
+                                            {
+                                              "h": 35,
+                                              "w": 35,
+                                              "x": 999,
+                                              "y": 419
+                                            },
+                                            {
+                                              "h": 41,
+                                              "w": 41,
+                                              "x": 5,
+                                              "y": 176
+                                            },
+                                            {
+                                              "h": 82,
+                                              "w": 82,
+                                              "x": 744,
+                                              "y": 646
+                                            }
+                                          ]
+                                        },
+                                        "small": {
+                                          "faces": [
+                                            {
+                                              "h": 22,
+                                              "w": 22,
+                                              "x": 629,
+                                              "y": 263
+                                            },
+                                            {
+                                              "h": 25,
+                                              "w": 25,
+                                              "x": 3,
+                                              "y": 110
+                                            },
+                                            {
+                                              "h": 51,
+                                              "w": 51,
+                                              "x": 468,
+                                              "y": 406
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "id_str": "2088386294988873728",
+                                      "indices": [43, 66],
+                                      "media_key": "3_2088386294988873728",
+                                      "media_results": {
+                                        "result": {
+                                          "media_key": "3_2088386294988873728"
+                                        }
+                                      },
+                                      "media_url_https": "https://pbs.twimg.com/media/HPtwRUKbIAAbRKb.jpg",
+                                      "original_info": {
+                                        "focus_rects": [
+                                          {
+                                            "h": 605,
+                                            "w": 1080,
+                                            "x": 0,
+                                            "y": 475
+                                          },
+                                          {
+                                            "h": 1080,
+                                            "w": 1080,
+                                            "x": 0,
+                                            "y": 0
+                                          },
+                                          {
+                                            "h": 1080,
+                                            "w": 947,
+                                            "x": 133,
+                                            "y": 0
+                                          },
+                                          {
+                                            "h": 1080,
+                                            "w": 540,
+                                            "x": 540,
+                                            "y": 0
+                                          },
+                                          {
+                                            "h": 1080,
+                                            "w": 1080,
+                                            "x": 0,
+                                            "y": 0
+                                          }
+                                        ],
+                                        "height": 1080,
+                                        "width": 1080
+                                      },
+                                      "sizes": {
+                                        "large": {
+                                          "h": 1080,
+                                          "resize": "fit",
+                                          "w": 1080
+                                        },
+                                        "medium": {
+                                          "h": 1080,
+                                          "resize": "fit",
+                                          "w": 1080
+                                        },
+                                        "small": {
+                                          "h": 680,
+                                          "resize": "fit",
+                                          "w": 680
+                                        },
+                                        "thumb": {
+                                          "h": 150,
+                                          "resize": "crop",
+                                          "w": 150
+                                        }
+                                      },
+                                      "type": "photo",
+                                      "url": "https://t.co/aQoveKhslZ"
+                                    }
+                                  ]
+                                },
+                                "favorite_count": 0,
+                                "favorited": false,
+                                "full_text": "@GenshinImpact Server: Asia\nUID: 836456779 https://t.co/aQoveKhslZ",
+                                "id_str": "2088386301485871132",
+                                "in_reply_to_screen_name": "GenshinImpact",
+                                "in_reply_to_status_id_str": "2087720798702498234",
+                                "in_reply_to_user_id_str": "1072404907230060544",
+                                "is_quote_status": false,
+                                "lang": "in",
+                                "possibly_sensitive": false,
+                                "possibly_sensitive_editable": true,
+                                "quote_count": 0,
+                                "reply_count": 0,
+                                "retweet_count": 0,
+                                "retweeted": false,
+                                "user_id_str": "1878195064134082560"
+                              },
+                              "quick_promote_eligibility": {
+                                "eligibility": "IneligibleNotVerified"
+                              },
+                              "rest_id": "2088386301485871132",
+                              "source": "<a href=\"http://twitter.com/download/iphone\" rel=\"nofollow\">Twitter for iPhone</a>",
+                              "unmention_data": {},
+                              "views": {
+                                "count": "244",
+                                "state": "EnabledWithCount"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  ],
+                  "metadata": {
+                    "conversationMetadata": {
+                      "allTweetIds": ["2088386301485871132"],
+                      "enableDeduplication": true
+                    }
+                  }
+                },
+                "entryId": "conversationthread-2088386301485871132",
+                "sortIndex": "2088929116056190776"
+              },
+              {
+                "content": {
+                  "__typename": "TimelineTimelineModule",
+                  "clientEventInfo": {
+                    "component": "tweet",
+                    "details": {
+                      "conversationDetails": {
+                        "conversationSection": "HighQuality"
+                      },
+                      "timelinesDetails": {
+                        "controllerData": "DAACDAAEDAABCgABAAAAAAAAAAEKAAIAAAAAAAAAAAoAAwAAAaAKBN5LAAAAAA=="
+                      }
+                    }
+                  },
+                  "displayType": "VerticalConversation",
+                  "entryType": "TimelineTimelineModule",
+                  "items": [
+                    {
+                      "entryId": "conversationthread-2088138297960718356-tweet-2088138297960718356",
+                      "item": {
+                        "clientEventInfo": {
+                          "component": "tweet",
+                          "details": {
+                            "conversationDetails": {
+                              "conversationSection": "HighQuality"
+                            },
+                            "timelinesDetails": {
+                              "controllerData": "DAACDAAEDAABCgABAAAAAAAAAAEKAAIAAAAAAAAAAAoAAwAAAaAKBN5LAAAAAA=="
+                            }
+                          },
+                          "element": "tweet"
+                        },
+                        "itemContent": {
+                          "__typename": "TimelineTweet",
+                          "itemType": "TimelineTweet",
+                          "tweetDisplayType": "Tweet",
+                          "tweet_results": {
+                            "result": {
+                              "__typename": "Tweet",
+                              "core": {
+                                "user_results": {
+                                  "result": {
+                                    "__typename": "User",
+                                    "affiliates_highlighted_label": {},
+                                    "avatar": {
+                                      "image_url": "https://pbs.twimg.com/profile_images/1560797145468440576/w-Z-F9ib_normal.jpg"
+                                    },
+                                    "core": {
+                                      "created_at": "Thu Sep 09 23:39:25 +0000 2021",
+                                      "name": "Soup",
+                                      "screen_name": "OrdonSoup"
+                                    },
+                                    "dm_permissions": {
+                                      "can_dm": false
+                                    },
+                                    "follow_request_sent": false,
+                                    "has_graduated_access": true,
+                                    "id": "VXNlcjoxNDM2MTExOTM1NDUyNDU0OTE2",
+                                    "is_blue_verified": false,
+                                    "legacy": {
+                                      "default_profile": true,
+                                      "default_profile_image": false,
+                                      "description": "",
+                                      "entities": {
+                                        "description": {}
+                                      },
+                                      "fast_followers_count": 0,
+                                      "favourites_count": 10401,
+                                      "follow_request_sent": false,
+                                      "followers_count": 1,
+                                      "friends_count": 78,
+                                      "has_custom_timelines": true,
+                                      "is_translator": false,
+                                      "listed_count": 0,
+                                      "media_count": 2,
+                                      "needs_phone_verification": false,
+                                      "normal_followers_count": 1,
+                                      "notifications": false,
+                                      "possibly_sensitive": false,
+                                      "profile_banner_url": "https://pbs.twimg.com/profile_banners/1436111935452454916/1654629876",
+                                      "profile_interstitial_type": "",
+                                      "statuses_count": 3,
+                                      "time_zone": "",
+                                      "translator_type": "none",
+                                      "url": "",
+                                      "utc_offset": 0,
+                                      "want_retweets": false,
+                                      "withheld_description": "",
+                                      "withheld_scope": ""
+                                    },
+                                    "location": {
+                                      "location": ""
+                                    },
+                                    "media_permissions": {
+                                      "can_media_tag": true
+                                    },
+                                    "parody_commentary_fan_label": "None",
+                                    "privacy": {
+                                      "protected": false
+                                    },
+                                    "profile_bio": {
+                                      "description": ""
+                                    },
+                                    "profile_image_shape": "Circle",
+                                    "relationship_perspectives": {
+                                      "blocked_by": false,
+                                      "blocking": false,
+                                      "followed_by": false,
+                                      "following": false,
+                                      "muting": false
+                                    },
+                                    "rest_id": "1436111935452454916",
+                                    "super_follow_eligible": false,
+                                    "super_followed_by": false,
+                                    "super_following": false,
+                                    "verification": {
+                                      "verified": false
+                                    }
+                                  }
+                                }
+                              },
+                              "edit_control": {
+                                "edit_tweet_ids": ["2088138297960718356"],
+                                "editable_until_msecs": "1786689540000",
+                                "edits_remaining": "5",
+                                "is_edit_eligible": false
+                              },
+                              "grok_analysis_button": true,
+                              "grok_annotations": {},
+                              "has_birdwatch_notes": false,
+                              "is_translatable": false,
+                              "legacy": {
+                                "bookmark_count": 0,
+                                "bookmarked": false,
+                                "conversation_id_str": "2087720798702498234",
+                                "created_at": "Fri Aug 14 05:39:00 +0000 2026",
+                                "display_text_range": [14, 14],
+                                "entities": {
+                                  "media": [
+                                    {
+                                      "allow_download_status": {
+                                        "allow_download": true
+                                      },
+                                      "display_url": "pic.x.com/mYqPFGuZnZ",
+                                      "expanded_url": "https://x.com/OrdonSoup/status/2088138297960718356/photo/1",
+                                      "ext_media_availability": {
+                                        "status": "Available"
+                                      },
+                                      "features": {
+                                        "large": {
+                                          "faces": []
+                                        },
+                                        "medium": {
+                                          "faces": []
+                                        },
+                                        "orig": {
+                                          "faces": []
+                                        },
+                                        "small": {
+                                          "faces": []
+                                        }
+                                      },
+                                      "id_str": "2088138293934170113",
+                                      "indices": [15, 38],
+                                      "media_key": "3_2088138293934170113",
+                                      "media_results": {
+                                        "result": {
+                                          "media_key": "3_2088138293934170113"
+                                        }
+                                      },
+                                      "media_url_https": "https://pbs.twimg.com/media/HPqOtwPWIAEjTBk.jpg",
+                                      "original_info": {
+                                        "focus_rects": [
+                                          {
+                                            "h": 529,
+                                            "w": 945,
+                                            "x": 0,
+                                            "y": 1013
+                                          },
+                                          {
+                                            "h": 945,
+                                            "w": 945,
+                                            "x": 0,
+                                            "y": 805
+                                          },
+                                          {
+                                            "h": 1077,
+                                            "w": 945,
+                                            "x": 0,
+                                            "y": 739
+                                          },
+                                          {
+                                            "h": 1890,
+                                            "w": 945,
+                                            "x": 0,
+                                            "y": 158
+                                          },
+                                          {
+                                            "h": 2048,
+                                            "w": 945,
+                                            "x": 0,
+                                            "y": 0
+                                          }
+                                        ],
+                                        "height": 2048,
+                                        "width": 945
+                                      },
+                                      "sizes": {
+                                        "large": {
+                                          "h": 2048,
+                                          "resize": "fit",
+                                          "w": 945
+                                        },
+                                        "medium": {
+                                          "h": 1200,
+                                          "resize": "fit",
+                                          "w": 554
+                                        },
+                                        "small": {
+                                          "h": 680,
+                                          "resize": "fit",
+                                          "w": 314
+                                        },
+                                        "thumb": {
+                                          "h": 150,
+                                          "resize": "crop",
+                                          "w": 150
+                                        }
+                                      },
+                                      "type": "photo",
+                                      "url": "https://t.co/mYqPFGuZnZ"
+                                    }
+                                  ],
+                                  "user_mentions": [
+                                    {
+                                      "id_str": "1072404907230060544",
+                                      "indices": [0, 14],
+                                      "name": "Genshin Impact",
+                                      "screen_name": "GenshinImpact"
+                                    }
+                                  ]
+                                },
+                                "extended_entities": {
+                                  "media": [
+                                    {
+                                      "allow_download_status": {
+                                        "allow_download": true
+                                      },
+                                      "display_url": "pic.x.com/mYqPFGuZnZ",
+                                      "expanded_url": "https://x.com/OrdonSoup/status/2088138297960718356/photo/1",
+                                      "ext_media_availability": {
+                                        "status": "Available"
+                                      },
+                                      "features": {
+                                        "large": {
+                                          "faces": []
+                                        },
+                                        "medium": {
+                                          "faces": []
+                                        },
+                                        "orig": {
+                                          "faces": []
+                                        },
+                                        "small": {
+                                          "faces": []
+                                        }
+                                      },
+                                      "id_str": "2088138293934170113",
+                                      "indices": [15, 38],
+                                      "media_key": "3_2088138293934170113",
+                                      "media_results": {
+                                        "result": {
+                                          "media_key": "3_2088138293934170113"
+                                        }
+                                      },
+                                      "media_url_https": "https://pbs.twimg.com/media/HPqOtwPWIAEjTBk.jpg",
+                                      "original_info": {
+                                        "focus_rects": [
+                                          {
+                                            "h": 529,
+                                            "w": 945,
+                                            "x": 0,
+                                            "y": 1013
+                                          },
+                                          {
+                                            "h": 945,
+                                            "w": 945,
+                                            "x": 0,
+                                            "y": 805
+                                          },
+                                          {
+                                            "h": 1077,
+                                            "w": 945,
+                                            "x": 0,
+                                            "y": 739
+                                          },
+                                          {
+                                            "h": 1890,
+                                            "w": 945,
+                                            "x": 0,
+                                            "y": 158
+                                          },
+                                          {
+                                            "h": 2048,
+                                            "w": 945,
+                                            "x": 0,
+                                            "y": 0
+                                          }
+                                        ],
+                                        "height": 2048,
+                                        "width": 945
+                                      },
+                                      "sizes": {
+                                        "large": {
+                                          "h": 2048,
+                                          "resize": "fit",
+                                          "w": 945
+                                        },
+                                        "medium": {
+                                          "h": 1200,
+                                          "resize": "fit",
+                                          "w": 554
+                                        },
+                                        "small": {
+                                          "h": 680,
+                                          "resize": "fit",
+                                          "w": 314
+                                        },
+                                        "thumb": {
+                                          "h": 150,
+                                          "resize": "crop",
+                                          "w": 150
+                                        }
+                                      },
+                                      "type": "photo",
+                                      "url": "https://t.co/mYqPFGuZnZ"
+                                    }
+                                  ]
+                                },
+                                "favorite_count": 0,
+                                "favorited": false,
+                                "full_text": "@GenshinImpact https://t.co/mYqPFGuZnZ",
+                                "id_str": "2088138297960718356",
+                                "in_reply_to_screen_name": "GenshinImpact",
+                                "in_reply_to_status_id_str": "2087720798702498234",
+                                "in_reply_to_user_id_str": "1072404907230060544",
+                                "is_quote_status": false,
+                                "lang": "qme",
+                                "possibly_sensitive": false,
+                                "possibly_sensitive_editable": true,
+                                "quote_count": 0,
+                                "reply_count": 0,
+                                "retweet_count": 0,
+                                "retweeted": false,
+                                "user_id_str": "1436111935452454916"
+                              },
+                              "quick_promote_eligibility": {
+                                "eligibility": "IneligibleNotVerified"
+                              },
+                              "rest_id": "2088138297960718356",
+                              "source": "<a href=\"http://twitter.com/download/iphone\" rel=\"nofollow\">Twitter for iPhone</a>",
+                              "unmention_data": {},
+                              "views": {
+                                "count": "252",
+                                "state": "EnabledWithCount"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  ],
+                  "metadata": {
+                    "conversationMetadata": {
+                      "allTweetIds": ["2088138297960718356"],
+                      "enableDeduplication": true
+                    }
+                  }
+                },
+                "entryId": "conversationthread-2088138297960718356",
+                "sortIndex": "2088929116056190766"
+              },
+              {
+                "content": {
+                  "__typename": "TimelineTimelineModule",
+                  "clientEventInfo": {
+                    "component": "tweet",
+                    "details": {
+                      "conversationDetails": {
+                        "conversationSection": "HighQuality"
+                      },
+                      "timelinesDetails": {
+                        "controllerData": "DAACDAAEDAABCgABAAAAAAAAAAEKAAIAAAAAAAAAAAoAAwAAAaAKBN5LAAAAAA=="
+                      }
+                    }
+                  },
+                  "displayType": "VerticalConversation",
+                  "entryType": "TimelineTimelineModule",
+                  "items": [
+                    {
+                      "entryId": "conversationthread-2088121539296362882-tweet-2088121539296362882",
+                      "item": {
+                        "clientEventInfo": {
+                          "component": "tweet",
+                          "details": {
+                            "conversationDetails": {
+                              "conversationSection": "HighQuality"
+                            },
+                            "timelinesDetails": {
+                              "controllerData": "DAACDAAEDAABCgABAAAAAAAAAAEKAAIAAAAAAAAAAAoAAwAAAaAKBN5LAAAAAA=="
+                            }
+                          },
+                          "element": "tweet"
+                        },
+                        "itemContent": {
+                          "__typename": "TimelineTweet",
+                          "itemType": "TimelineTweet",
+                          "tweetDisplayType": "Tweet",
+                          "tweet_results": {
+                            "result": {
+                              "__typename": "Tweet",
+                              "core": {
+                                "user_results": {
+                                  "result": {
+                                    "__typename": "User",
+                                    "affiliates_highlighted_label": {},
+                                    "avatar": {
+                                      "image_url": "https://pbs.twimg.com/profile_images/2052478047849426944/p58uUNrw_normal.jpg"
+                                    },
+                                    "core": {
+                                      "created_at": "Fri Dec 06 06:18:50 +0000 2019",
+                                      "name": "𐙚 m",
+                                      "screen_name": "sinfulfooI"
+                                    },
+                                    "dm_permissions": {
+                                      "can_dm": true
+                                    },
+                                    "follow_request_sent": false,
+                                    "has_graduated_access": true,
+                                    "id": "VXNlcjoxMjAyODM0Njg4NDY2Nzk2NTQ0",
+                                    "is_blue_verified": false,
+                                    "legacy": {
+                                      "default_profile": true,
+                                      "default_profile_image": false,
+                                      "description": "can i waste all your time here on the sidewalk ?",
+                                      "entities": {
+                                        "description": {},
+                                        "url": {
+                                          "urls": [
+                                            {
+                                              "display_url": "open.spotify.com/user/bbkrkrxbf…",
+                                              "expanded_url": "https://open.spotify.com/user/bbkrkrxbfo40vx15nfim1ly2e?si=ohwoilG6QTWAcZ7DOodVdg",
+                                              "indices": [0, 23],
+                                              "url": "https://t.co/nYDCnMwS3R"
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "fast_followers_count": 0,
+                                      "favourites_count": 10188,
+                                      "follow_request_sent": false,
+                                      "followers_count": 36,
+                                      "friends_count": 39,
+                                      "has_custom_timelines": true,
+                                      "is_translator": false,
+                                      "listed_count": 0,
+                                      "media_count": 220,
+                                      "needs_phone_verification": false,
+                                      "normal_followers_count": 36,
+                                      "notifications": false,
+                                      "possibly_sensitive": false,
+                                      "profile_banner_url": "https://pbs.twimg.com/profile_banners/1202834688466796544/1756913747",
+                                      "profile_interstitial_type": "",
+                                      "statuses_count": 3696,
+                                      "time_zone": "",
+                                      "translator_type": "none",
+                                      "url": "https://t.co/nYDCnMwS3R",
+                                      "utc_offset": 0,
+                                      "want_retweets": false,
+                                      "withheld_description": "",
+                                      "withheld_scope": ""
+                                    },
+                                    "location": {
+                                      "location": "she her"
+                                    },
+                                    "media_permissions": {
+                                      "can_media_tag": false
+                                    },
+                                    "parody_commentary_fan_label": "None",
+                                    "privacy": {
+                                      "protected": false
+                                    },
+                                    "profile_bio": {
+                                      "description": "can i waste all your time here on the sidewalk ?"
+                                    },
+                                    "profile_description_language": "en",
+                                    "profile_image_shape": "Circle",
+                                    "relationship_perspectives": {
+                                      "blocked_by": false,
+                                      "blocking": false,
+                                      "followed_by": false,
+                                      "following": false,
+                                      "muting": false
+                                    },
+                                    "rest_id": "1202834688466796544",
+                                    "super_follow_eligible": false,
+                                    "super_followed_by": false,
+                                    "super_following": false,
+                                    "verification": {
+                                      "verified": false
+                                    }
+                                  }
+                                }
+                              },
+                              "edit_control": {
+                                "edit_tweet_ids": ["2088121539296362882"],
+                                "editable_until_msecs": "1786685545000",
+                                "edits_remaining": "5",
+                                "is_edit_eligible": false
+                              },
+                              "grok_analysis_button": true,
+                              "grok_annotations": {},
+                              "has_birdwatch_notes": false,
+                              "is_translatable": false,
+                              "legacy": {
+                                "bookmark_count": 0,
+                                "bookmarked": false,
+                                "conversation_id_str": "2087720798702498234",
+                                "created_at": "Fri Aug 14 04:32:25 +0000 2026",
+                                "display_text_range": [15, 24],
+                                "entities": {
+                                  "media": [
+                                    {
+                                      "display_url": "pic.x.com/4ThQfxPe2h",
+                                      "expanded_url": "https://x.com/sinfulfooI/status/2088121539296362882/photo/1",
+                                      "ext_media_availability": {
+                                        "status": "Available"
+                                      },
+                                      "features": {
+                                        "large": {
+                                          "faces": []
+                                        },
+                                        "medium": {
+                                          "faces": []
+                                        },
+                                        "orig": {
+                                          "faces": []
+                                        },
+                                        "small": {
+                                          "faces": []
+                                        }
+                                      },
+                                      "id_str": "2088121533013413888",
+                                      "indices": [25, 48],
+                                      "media_key": "3_2088121533013413888",
+                                      "media_results": {
+                                        "result": {
+                                          "media_key": "3_2088121533013413888"
+                                        }
+                                      },
+                                      "media_url_https": "https://pbs.twimg.com/media/HPp_eI8b0AAjVJO.jpg",
+                                      "original_info": {
+                                        "focus_rects": [
+                                          {
+                                            "h": 605,
+                                            "w": 1080,
+                                            "x": 0,
+                                            "y": 252
+                                          },
+                                          {
+                                            "h": 857,
+                                            "w": 857,
+                                            "x": 0,
+                                            "y": 0
+                                          },
+                                          {
+                                            "h": 857,
+                                            "w": 752,
+                                            "x": 28,
+                                            "y": 0
+                                          },
+                                          {
+                                            "h": 857,
+                                            "w": 429,
+                                            "x": 190,
+                                            "y": 0
+                                          },
+                                          {
+                                            "h": 857,
+                                            "w": 1080,
+                                            "x": 0,
+                                            "y": 0
+                                          }
+                                        ],
+                                        "height": 857,
+                                        "width": 1080
+                                      },
+                                      "sizes": {
+                                        "large": {
+                                          "h": 857,
+                                          "resize": "fit",
+                                          "w": 1080
+                                        },
+                                        "medium": {
+                                          "h": 857,
+                                          "resize": "fit",
+                                          "w": 1080
+                                        },
+                                        "small": {
+                                          "h": 540,
+                                          "resize": "fit",
+                                          "w": 680
+                                        },
+                                        "thumb": {
+                                          "h": 150,
+                                          "resize": "crop",
+                                          "w": 150
+                                        }
+                                      },
+                                      "type": "photo",
+                                      "url": "https://t.co/4ThQfxPe2h"
+                                    }
+                                  ],
+                                  "user_mentions": [
+                                    {
+                                      "id_str": "1072404907230060544",
+                                      "indices": [0, 14],
+                                      "name": "Genshin Impact",
+                                      "screen_name": "GenshinImpact"
+                                    }
+                                  ]
+                                },
+                                "extended_entities": {
+                                  "media": [
+                                    {
+                                      "display_url": "pic.x.com/4ThQfxPe2h",
+                                      "expanded_url": "https://x.com/sinfulfooI/status/2088121539296362882/photo/1",
+                                      "ext_media_availability": {
+                                        "status": "Available"
+                                      },
+                                      "features": {
+                                        "large": {
+                                          "faces": []
+                                        },
+                                        "medium": {
+                                          "faces": []
+                                        },
+                                        "orig": {
+                                          "faces": []
+                                        },
+                                        "small": {
+                                          "faces": []
+                                        }
+                                      },
+                                      "id_str": "2088121533013413888",
+                                      "indices": [25, 48],
+                                      "media_key": "3_2088121533013413888",
+                                      "media_results": {
+                                        "result": {
+                                          "media_key": "3_2088121533013413888"
+                                        }
+                                      },
+                                      "media_url_https": "https://pbs.twimg.com/media/HPp_eI8b0AAjVJO.jpg",
+                                      "original_info": {
+                                        "focus_rects": [
+                                          {
+                                            "h": 605,
+                                            "w": 1080,
+                                            "x": 0,
+                                            "y": 252
+                                          },
+                                          {
+                                            "h": 857,
+                                            "w": 857,
+                                            "x": 0,
+                                            "y": 0
+                                          },
+                                          {
+                                            "h": 857,
+                                            "w": 752,
+                                            "x": 28,
+                                            "y": 0
+                                          },
+                                          {
+                                            "h": 857,
+                                            "w": 429,
+                                            "x": 190,
+                                            "y": 0
+                                          },
+                                          {
+                                            "h": 857,
+                                            "w": 1080,
+                                            "x": 0,
+                                            "y": 0
+                                          }
+                                        ],
+                                        "height": 857,
+                                        "width": 1080
+                                      },
+                                      "sizes": {
+                                        "large": {
+                                          "h": 857,
+                                          "resize": "fit",
+                                          "w": 1080
+                                        },
+                                        "medium": {
+                                          "h": 857,
+                                          "resize": "fit",
+                                          "w": 1080
+                                        },
+                                        "small": {
+                                          "h": 540,
+                                          "resize": "fit",
+                                          "w": 680
+                                        },
+                                        "thumb": {
+                                          "h": 150,
+                                          "resize": "crop",
+                                          "w": 150
+                                        }
+                                      },
+                                      "type": "photo",
+                                      "url": "https://t.co/4ThQfxPe2h"
+                                    }
+                                  ]
+                                },
+                                "favorite_count": 0,
+                                "favorited": false,
+                                "full_text": "@GenshinImpact mora mora https://t.co/4ThQfxPe2h",
+                                "id_str": "2088121539296362882",
+                                "in_reply_to_screen_name": "GenshinImpact",
+                                "in_reply_to_status_id_str": "2087720798702498234",
+                                "in_reply_to_user_id_str": "1072404907230060544",
+                                "is_quote_status": false,
+                                "lang": "pt",
+                                "possibly_sensitive": false,
+                                "possibly_sensitive_editable": true,
+                                "quote_count": 0,
+                                "reply_count": 0,
+                                "retweet_count": 0,
+                                "retweeted": false,
+                                "user_id_str": "1202834688466796544"
+                              },
+                              "quick_promote_eligibility": {
+                                "eligibility": "IneligibleNotVerified"
+                              },
+                              "rest_id": "2088121539296362882",
+                              "source": "<a href=\"http://twitter.com/download/android\" rel=\"nofollow\">Twitter for Android</a>",
+                              "unmention_data": {},
+                              "views": {
+                                "count": "117",
+                                "state": "EnabledWithCount"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  ],
+                  "metadata": {
+                    "conversationMetadata": {
+                      "allTweetIds": ["2088121539296362882"],
+                      "enableDeduplication": true
+                    }
+                  }
+                },
+                "entryId": "conversationthread-2088121539296362882",
+                "sortIndex": "2088929116056190756"
+              },
+              {
+                "content": {
+                  "__typename": "TimelineTimelineModule",
+                  "clientEventInfo": {
+                    "component": "tweet",
+                    "details": {
+                      "conversationDetails": {
+                        "conversationSection": "HighQuality"
+                      },
+                      "timelinesDetails": {
+                        "controllerData": "DAACDAAEDAABCgABAAAAAAAAAAEKAAIAAAAAAAAAAAoAAwAAAaAKBN5LAAAAAA=="
+                      }
+                    }
+                  },
+                  "displayType": "VerticalConversation",
+                  "entryType": "TimelineTimelineModule",
+                  "items": [
+                    {
+                      "entryId": "conversationthread-2088730946887426311-tweet-2088730946887426311",
+                      "item": {
+                        "clientEventInfo": {
+                          "component": "tweet",
+                          "details": {
+                            "conversationDetails": {
+                              "conversationSection": "HighQuality"
+                            },
+                            "timelinesDetails": {
+                              "controllerData": "DAACDAAEDAABCgABAAAAAAAAAAEKAAIAAAAAAAAAAAoAAwAAAaAKBN5LAAAAAA=="
+                            }
+                          },
+                          "element": "tweet"
+                        },
+                        "itemContent": {
+                          "__typename": "TimelineTweet",
+                          "itemType": "TimelineTweet",
+                          "tweetDisplayType": "Tweet",
+                          "tweet_results": {
+                            "result": {
+                              "__typename": "Tweet",
+                              "core": {
+                                "user_results": {
+                                  "result": {
+                                    "__typename": "User",
+                                    "affiliates_highlighted_label": {},
+                                    "avatar": {
+                                      "image_url": "https://pbs.twimg.com/profile_images/1884831032156852225/EEXZWseH_normal.jpg"
+                                    },
+                                    "core": {
+                                      "created_at": "Thu Apr 08 19:14:33 +0000 2021",
+                                      "name": "Dead on the inside",
+                                      "screen_name": "officialktmint"
+                                    },
+                                    "dm_permissions": {
+                                      "can_dm": false
+                                    },
+                                    "follow_request_sent": false,
+                                    "has_graduated_access": true,
+                                    "id": "VXNlcjoxMzgwMjM3NTkwMTYzNTYyNTA0",
+                                    "is_blue_verified": false,
+                                    "legacy": {
+                                      "default_profile": true,
+                                      "default_profile_image": false,
+                                      "description": ".・゜-: ✧ :-　　₁₇ ₛₕₑ/ₕₑᵣ-: ✧ :-゜・．\n\nᴳᵉⁿˢʰᶦⁿ/ᴴˢᴿ/ᵂᵁᵂᴬ ᵃᵈᵈᶦᶜᵗ ˡᵐᵃᵒ\n\nᵇᵉᵉⁿ ᵃ ˢᵗᵃʸ ˢᶦⁿᶜᵉ ᴬᵘᵍ ²⁰²²\n\nᴮᵃᵇʸ ᶜᵃʳᵃᵗ",
+                                      "entities": {
+                                        "description": {}
+                                      },
+                                      "fast_followers_count": 0,
+                                      "favourites_count": 25719,
+                                      "follow_request_sent": false,
+                                      "followers_count": 116,
+                                      "friends_count": 879,
+                                      "has_custom_timelines": true,
+                                      "is_translator": false,
+                                      "listed_count": 1,
+                                      "media_count": 125,
+                                      "needs_phone_verification": false,
+                                      "normal_followers_count": 116,
+                                      "notifications": false,
+                                      "pinned_tweet_ids_str": [
+                                        "1852061242782859533"
+                                      ],
+                                      "possibly_sensitive": false,
+                                      "profile_banner_url": "https://pbs.twimg.com/profile_banners/1380237590163562504/1738213756",
+                                      "profile_interstitial_type": "",
+                                      "statuses_count": 5273,
+                                      "time_zone": "",
+                                      "translator_type": "none",
+                                      "url": "",
+                                      "utc_offset": 0,
+                                      "want_retweets": false,
+                                      "withheld_description": "",
+                                      "withheld_scope": ""
+                                    },
+                                    "location": {
+                                      "location": "ᵢₙ ₑₙₕᵧₚₑₙ ₐₙ𝒹 ₛᵥₜ ₑᵣₐ"
+                                    },
+                                    "media_permissions": {
+                                      "can_media_tag": true
+                                    },
+                                    "parody_commentary_fan_label": "None",
+                                    "privacy": {
+                                      "protected": false
+                                    },
+                                    "profile_bio": {
+                                      "description": ".・゜-: ✧ :-　　₁₇ ₛₕₑ/ₕₑᵣ-: ✧ :-゜・．\n\nᴳᵉⁿˢʰᶦⁿ/ᴴˢᴿ/ᵂᵁᵂᴬ ᵃᵈᵈᶦᶜᵗ ˡᵐᵃᵒ\n\nᵇᵉᵉⁿ ᵃ ˢᵗᵃʸ ˢᶦⁿᶜᵉ ᴬᵘᵍ ²⁰²²\n\nᴮᵃᵇʸ ᶜᵃʳᵃᵗ"
+                                    },
+                                    "profile_image_shape": "Circle",
+                                    "relationship_perspectives": {
+                                      "blocked_by": false,
+                                      "blocking": false,
+                                      "followed_by": false,
+                                      "following": false,
+                                      "muting": false
+                                    },
+                                    "rest_id": "1380237590163562504",
+                                    "super_follow_eligible": false,
+                                    "super_followed_by": false,
+                                    "super_following": false,
+                                    "verification": {
+                                      "verified": false
+                                    }
+                                  }
+                                }
+                              },
+                              "edit_control": {
+                                "edit_tweet_ids": ["2088730946887426311"],
+                                "editable_until_msecs": "1786830839000",
+                                "edits_remaining": "5",
+                                "is_edit_eligible": false
+                              },
+                              "grok_analysis_button": true,
+                              "grok_annotations": {},
+                              "has_birdwatch_notes": false,
+                              "is_translatable": false,
+                              "legacy": {
+                                "bookmark_count": 0,
+                                "bookmarked": false,
+                                "conversation_id_str": "2087720798702498234",
+                                "created_at": "Sat Aug 15 20:53:59 +0000 2026",
+                                "display_text_range": [15, 20],
+                                "entities": {
+                                  "media": [
+                                    {
+                                      "display_url": "pic.x.com/176FNwadx3",
+                                      "expanded_url": "https://x.com/officialktmint/status/2088730946887426311/photo/1",
+                                      "ext_media_availability": {
+                                        "status": "Available"
+                                      },
+                                      "features": {
+                                        "large": {
+                                          "faces": [
+                                            {
+                                              "h": 41,
+                                              "w": 41,
+                                              "x": 1000,
+                                              "y": 568
+                                            },
+                                            {
+                                              "h": 52,
+                                              "w": 52,
+                                              "x": 547,
+                                              "y": 442
+                                            }
+                                          ]
+                                        },
+                                        "medium": {
+                                          "faces": [
+                                            {
+                                              "h": 41,
+                                              "w": 41,
+                                              "x": 1000,
+                                              "y": 568
+                                            },
+                                            {
+                                              "h": 52,
+                                              "w": 52,
+                                              "x": 547,
+                                              "y": 442
+                                            }
+                                          ]
+                                        },
+                                        "orig": {
+                                          "faces": [
+                                            {
+                                              "h": 41,
+                                              "w": 41,
+                                              "x": 1000,
+                                              "y": 568
+                                            },
+                                            {
+                                              "h": 52,
+                                              "w": 52,
+                                              "x": 547,
+                                              "y": 442
+                                            }
+                                          ]
+                                        },
+                                        "small": {
+                                          "faces": [
+                                            {
+                                              "h": 25,
+                                              "w": 25,
+                                              "x": 629,
+                                              "y": 357
+                                            },
+                                            {
+                                              "h": 32,
+                                              "w": 32,
+                                              "x": 344,
+                                              "y": 278
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "id_str": "2088730943213203456",
+                                      "indices": [21, 44],
+                                      "media_key": "3_2088730943213203456",
+                                      "media_results": {
+                                        "result": {
+                                          "media_key": "3_2088730943213203456"
+                                        }
+                                      },
+                                      "media_url_https": "https://pbs.twimg.com/media/HPypue2W8AA9bDj.jpg",
+                                      "original_info": {
+                                        "focus_rects": [
+                                          {
+                                            "h": 605,
+                                            "w": 1080,
+                                            "x": 0,
+                                            "y": 475
+                                          },
+                                          {
+                                            "h": 1080,
+                                            "w": 1080,
+                                            "x": 0,
+                                            "y": 0
+                                          },
+                                          {
+                                            "h": 1080,
+                                            "w": 947,
+                                            "x": 0,
+                                            "y": 0
+                                          },
+                                          {
+                                            "h": 1080,
+                                            "w": 540,
+                                            "x": 0,
+                                            "y": 0
+                                          },
+                                          {
+                                            "h": 1080,
+                                            "w": 1080,
+                                            "x": 0,
+                                            "y": 0
+                                          }
+                                        ],
+                                        "height": 1080,
+                                        "width": 1080
+                                      },
+                                      "sizes": {
+                                        "large": {
+                                          "h": 1080,
+                                          "resize": "fit",
+                                          "w": 1080
+                                        },
+                                        "medium": {
+                                          "h": 1080,
+                                          "resize": "fit",
+                                          "w": 1080
+                                        },
+                                        "small": {
+                                          "h": 680,
+                                          "resize": "fit",
+                                          "w": 680
+                                        },
+                                        "thumb": {
+                                          "h": 150,
+                                          "resize": "crop",
+                                          "w": 150
+                                        }
+                                      },
+                                      "type": "photo",
+                                      "url": "https://t.co/176FNwadx3"
+                                    }
+                                  ],
+                                  "user_mentions": [
+                                    {
+                                      "id_str": "1072404907230060544",
+                                      "indices": [0, 14],
+                                      "name": "Genshin Impact",
+                                      "screen_name": "GenshinImpact"
+                                    }
+                                  ]
+                                },
+                                "extended_entities": {
+                                  "media": [
+                                    {
+                                      "display_url": "pic.x.com/176FNwadx3",
+                                      "expanded_url": "https://x.com/officialktmint/status/2088730946887426311/photo/1",
+                                      "ext_media_availability": {
+                                        "status": "Available"
+                                      },
+                                      "features": {
+                                        "large": {
+                                          "faces": [
+                                            {
+                                              "h": 41,
+                                              "w": 41,
+                                              "x": 1000,
+                                              "y": 568
+                                            },
+                                            {
+                                              "h": 52,
+                                              "w": 52,
+                                              "x": 547,
+                                              "y": 442
+                                            }
+                                          ]
+                                        },
+                                        "medium": {
+                                          "faces": [
+                                            {
+                                              "h": 41,
+                                              "w": 41,
+                                              "x": 1000,
+                                              "y": 568
+                                            },
+                                            {
+                                              "h": 52,
+                                              "w": 52,
+                                              "x": 547,
+                                              "y": 442
+                                            }
+                                          ]
+                                        },
+                                        "orig": {
+                                          "faces": [
+                                            {
+                                              "h": 41,
+                                              "w": 41,
+                                              "x": 1000,
+                                              "y": 568
+                                            },
+                                            {
+                                              "h": 52,
+                                              "w": 52,
+                                              "x": 547,
+                                              "y": 442
+                                            }
+                                          ]
+                                        },
+                                        "small": {
+                                          "faces": [
+                                            {
+                                              "h": 25,
+                                              "w": 25,
+                                              "x": 629,
+                                              "y": 357
+                                            },
+                                            {
+                                              "h": 32,
+                                              "w": 32,
+                                              "x": 344,
+                                              "y": 278
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "id_str": "2088730943213203456",
+                                      "indices": [21, 44],
+                                      "media_key": "3_2088730943213203456",
+                                      "media_results": {
+                                        "result": {
+                                          "media_key": "3_2088730943213203456"
+                                        }
+                                      },
+                                      "media_url_https": "https://pbs.twimg.com/media/HPypue2W8AA9bDj.jpg",
+                                      "original_info": {
+                                        "focus_rects": [
+                                          {
+                                            "h": 605,
+                                            "w": 1080,
+                                            "x": 0,
+                                            "y": 475
+                                          },
+                                          {
+                                            "h": 1080,
+                                            "w": 1080,
+                                            "x": 0,
+                                            "y": 0
+                                          },
+                                          {
+                                            "h": 1080,
+                                            "w": 947,
+                                            "x": 0,
+                                            "y": 0
+                                          },
+                                          {
+                                            "h": 1080,
+                                            "w": 540,
+                                            "x": 0,
+                                            "y": 0
+                                          },
+                                          {
+                                            "h": 1080,
+                                            "w": 1080,
+                                            "x": 0,
+                                            "y": 0
+                                          }
+                                        ],
+                                        "height": 1080,
+                                        "width": 1080
+                                      },
+                                      "sizes": {
+                                        "large": {
+                                          "h": 1080,
+                                          "resize": "fit",
+                                          "w": 1080
+                                        },
+                                        "medium": {
+                                          "h": 1080,
+                                          "resize": "fit",
+                                          "w": 1080
+                                        },
+                                        "small": {
+                                          "h": 680,
+                                          "resize": "fit",
+                                          "w": 680
+                                        },
+                                        "thumb": {
+                                          "h": 150,
+                                          "resize": "crop",
+                                          "w": 150
+                                        }
+                                      },
+                                      "type": "photo",
+                                      "url": "https://t.co/176FNwadx3"
+                                    }
+                                  ]
+                                },
+                                "favorite_count": 0,
+                                "favorited": false,
+                                "full_text": "@GenshinImpact Ok ig https://t.co/176FNwadx3",
+                                "id_str": "2088730946887426311",
+                                "in_reply_to_screen_name": "GenshinImpact",
+                                "in_reply_to_status_id_str": "2087720798702498234",
+                                "in_reply_to_user_id_str": "1072404907230060544",
+                                "is_quote_status": false,
+                                "lang": "sv",
+                                "possibly_sensitive": false,
+                                "possibly_sensitive_editable": true,
+                                "quote_count": 0,
+                                "reply_count": 0,
+                                "retweet_count": 0,
+                                "retweeted": false,
+                                "user_id_str": "1380237590163562504"
+                              },
+                              "quick_promote_eligibility": {
+                                "eligibility": "IneligibleNotVerified"
+                              },
+                              "rest_id": "2088730946887426311",
+                              "source": "<a href=\"http://twitter.com/download/android\" rel=\"nofollow\">Twitter for Android</a>",
+                              "unmention_data": {},
+                              "views": {
+                                "count": "203",
+                                "state": "EnabledWithCount"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  ],
+                  "metadata": {
+                    "conversationMetadata": {
+                      "allTweetIds": ["2088730946887426311"],
+                      "enableDeduplication": true
+                    }
+                  }
+                },
+                "entryId": "conversationthread-2088730946887426311",
+                "sortIndex": "2088929116056190746"
+              },
+              {
+                "content": {
+                  "__typename": "TimelineTimelineModule",
+                  "clientEventInfo": {
+                    "component": "tweet",
+                    "details": {
+                      "conversationDetails": {
+                        "conversationSection": "HighQuality"
+                      },
+                      "timelinesDetails": {
+                        "controllerData": "DAACDAAEDAABCgABAAAAAAAAAAEKAAIAAAAAAAAAAAoAAwAAAaAKBN5LAAAAAA=="
+                      }
+                    }
+                  },
+                  "displayType": "VerticalConversation",
+                  "entryType": "TimelineTimelineModule",
+                  "items": [
+                    {
+                      "entryId": "conversationthread-2088027993008726212-tweet-2088027993008726212",
+                      "item": {
+                        "clientEventInfo": {
+                          "component": "tweet",
+                          "details": {
+                            "conversationDetails": {
+                              "conversationSection": "HighQuality"
+                            },
+                            "timelinesDetails": {
+                              "controllerData": "DAACDAAEDAABCgABAAAAAAAAAAEKAAIAAAAAAAAAAAoAAwAAAaAKBN5LAAAAAA=="
+                            }
+                          },
+                          "element": "tweet"
+                        },
+                        "itemContent": {
+                          "__typename": "TimelineTweet",
+                          "itemType": "TimelineTweet",
+                          "tweetDisplayType": "Tweet",
+                          "tweet_results": {
+                            "result": {
+                              "__typename": "Tweet",
+                              "core": {
+                                "user_results": {
+                                  "result": {
+                                    "__typename": "User",
+                                    "affiliates_highlighted_label": {},
+                                    "avatar": {
+                                      "image_url": "https://pbs.twimg.com/profile_images/2057651156344844289/GAqKQpm2_normal.jpg"
+                                    },
+                                    "core": {
+                                      "created_at": "Wed Aug 11 20:16:25 +0000 2021",
+                                      "name": "SylviStarlet",
+                                      "screen_name": "SylviStarlet"
+                                    },
+                                    "dm_permissions": {
+                                      "can_dm": true
+                                    },
+                                    "follow_request_sent": false,
+                                    "has_graduated_access": true,
+                                    "id": "VXNlcjoxNDI1NTUxNjQ0OTE0MjI1MTYy",
+                                    "is_blue_verified": false,
+                                    "legacy": {
+                                      "default_profile": true,
+                                      "default_profile_image": false,
+                                      "description": "Hello.\nNice to meet you.\nMy name is SylviStarlet.\nI am Korean.\nI want many many BEAUTIFUL SWEET SWEET LOVELY GUMI SINGING SONGS.\nThank you.\n\nYT@SylviStarlet",
+                                      "entities": {
+                                        "description": {},
+                                        "url": {
+                                          "urls": [
+                                            {
+                                              "display_url": "youtube.com/@sylvistarlet?…",
+                                              "expanded_url": "https://youtube.com/@sylvistarlet?si=433eyxjTTTZOptUV",
+                                              "indices": [0, 23],
+                                              "url": "https://t.co/Milbg7DYgY"
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "fast_followers_count": 0,
+                                      "favourites_count": 390,
+                                      "follow_request_sent": false,
+                                      "followers_count": 18,
+                                      "friends_count": 97,
+                                      "has_custom_timelines": false,
+                                      "is_translator": false,
+                                      "listed_count": 1,
+                                      "media_count": 10,
+                                      "needs_phone_verification": false,
+                                      "normal_followers_count": 18,
+                                      "notifications": false,
+                                      "pinned_tweet_ids_str": [
+                                        "2037641917077577960"
+                                      ],
+                                      "possibly_sensitive": false,
+                                      "profile_banner_url": "https://pbs.twimg.com/profile_banners/1425551644914225162/1785989346",
+                                      "profile_interstitial_type": "",
+                                      "statuses_count": 254,
+                                      "time_zone": "",
+                                      "translator_type": "none",
+                                      "url": "https://t.co/Milbg7DYgY",
+                                      "utc_offset": 0,
+                                      "want_retweets": false,
+                                      "withheld_description": "",
+                                      "withheld_scope": ""
+                                    },
+                                    "location": {
+                                      "location": ""
+                                    },
+                                    "media_permissions": {
+                                      "can_media_tag": false
+                                    },
+                                    "parody_commentary_fan_label": "None",
+                                    "privacy": {
+                                      "protected": false
+                                    },
+                                    "profile_bio": {
+                                      "description": "Hello.\nNice to meet you.\nMy name is SylviStarlet.\nI am Korean.\nI want many many BEAUTIFUL SWEET SWEET LOVELY GUMI SINGING SONGS.\nThank you.\n\nYT@SylviStarlet"
+                                    },
+                                    "profile_description_language": "en",
+                                    "profile_image_shape": "Circle",
+                                    "relationship_perspectives": {
+                                      "blocked_by": false,
+                                      "blocking": false,
+                                      "followed_by": false,
+                                      "following": false,
+                                      "muting": false
+                                    },
+                                    "rest_id": "1425551644914225162",
+                                    "super_follow_eligible": false,
+                                    "super_followed_by": false,
+                                    "super_following": false,
+                                    "verification": {
+                                      "verified": false
+                                    }
+                                  }
+                                }
+                              },
+                              "edit_control": {
+                                "edit_tweet_ids": ["2088027993008726212"],
+                                "editable_until_msecs": "1786663241000",
+                                "edits_remaining": "5",
+                                "is_edit_eligible": false
+                              },
+                              "grok_analysis_button": true,
+                              "grok_annotations": {},
+                              "has_birdwatch_notes": false,
+                              "is_translatable": false,
+                              "legacy": {
+                                "bookmark_count": 0,
+                                "bookmarked": false,
+                                "conversation_id_str": "2087720798702498234",
+                                "created_at": "Thu Aug 13 22:20:41 +0000 2026",
+                                "display_text_range": [15, 37],
+                                "entities": {
+                                  "media": [
+                                    {
+                                      "allow_download_status": {
+                                        "allow_download": true
+                                      },
+                                      "display_url": "pic.x.com/beGhHM8yNi",
+                                      "expanded_url": "https://x.com/SylviStarlet/status/2088027993008726212/photo/1",
+                                      "ext_media_availability": {
+                                        "status": "Available"
+                                      },
+                                      "features": {
+                                        "large": {
+                                          "faces": [
+                                            {
+                                              "h": 135,
+                                              "w": 135,
+                                              "x": 580,
+                                              "y": 286
+                                            }
+                                          ]
+                                        },
+                                        "medium": {
+                                          "faces": [
+                                            {
+                                              "h": 135,
+                                              "w": 135,
+                                              "x": 580,
+                                              "y": 286
+                                            }
+                                          ]
+                                        },
+                                        "orig": {
+                                          "faces": [
+                                            {
+                                              "h": 135,
+                                              "w": 135,
+                                              "x": 580,
+                                              "y": 286
+                                            }
+                                          ]
+                                        },
+                                        "small": {
+                                          "faces": [
+                                            {
+                                              "h": 94,
+                                              "w": 94,
+                                              "x": 406,
+                                              "y": 200
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "id_str": "2088027892777439232",
+                                      "indices": [38, 61],
+                                      "media_key": "3_2088027892777439232",
+                                      "media_results": {
+                                        "result": {
+                                          "media_key": "3_2088027892777439232"
+                                        }
+                                      },
+                                      "media_url_https": "https://pbs.twimg.com/media/HPoqTj4bUAAFz1N.jpg",
+                                      "original_info": {
+                                        "focus_rects": [
+                                          {
+                                            "h": 467,
+                                            "w": 834,
+                                            "x": 0,
+                                            "y": 502
+                                          },
+                                          {
+                                            "h": 834,
+                                            "w": 834,
+                                            "x": 0,
+                                            "y": 135
+                                          },
+                                          {
+                                            "h": 951,
+                                            "w": 834,
+                                            "x": 0,
+                                            "y": 18
+                                          },
+                                          {
+                                            "h": 969,
+                                            "w": 485,
+                                            "x": 0,
+                                            "y": 0
+                                          },
+                                          {
+                                            "h": 969,
+                                            "w": 834,
+                                            "x": 0,
+                                            "y": 0
+                                          }
+                                        ],
+                                        "height": 969,
+                                        "width": 834
+                                      },
+                                      "sizes": {
+                                        "large": {
+                                          "h": 969,
+                                          "resize": "fit",
+                                          "w": 834
+                                        },
+                                        "medium": {
+                                          "h": 969,
+                                          "resize": "fit",
+                                          "w": 834
+                                        },
+                                        "small": {
+                                          "h": 680,
+                                          "resize": "fit",
+                                          "w": 585
+                                        },
+                                        "thumb": {
+                                          "h": 150,
+                                          "resize": "crop",
+                                          "w": 150
+                                        }
+                                      },
+                                      "type": "photo",
+                                      "url": "https://t.co/beGhHM8yNi"
+                                    }
+                                  ],
+                                  "user_mentions": [
+                                    {
+                                      "id_str": "1072404907230060544",
+                                      "indices": [0, 14],
+                                      "name": "Genshin Impact",
+                                      "screen_name": "GenshinImpact"
+                                    }
+                                  ]
+                                },
+                                "extended_entities": {
+                                  "media": [
+                                    {
+                                      "allow_download_status": {
+                                        "allow_download": true
+                                      },
+                                      "display_url": "pic.x.com/beGhHM8yNi",
+                                      "expanded_url": "https://x.com/SylviStarlet/status/2088027993008726212/photo/1",
+                                      "ext_media_availability": {
+                                        "status": "Available"
+                                      },
+                                      "features": {
+                                        "large": {
+                                          "faces": [
+                                            {
+                                              "h": 135,
+                                              "w": 135,
+                                              "x": 580,
+                                              "y": 286
+                                            }
+                                          ]
+                                        },
+                                        "medium": {
+                                          "faces": [
+                                            {
+                                              "h": 135,
+                                              "w": 135,
+                                              "x": 580,
+                                              "y": 286
+                                            }
+                                          ]
+                                        },
+                                        "orig": {
+                                          "faces": [
+                                            {
+                                              "h": 135,
+                                              "w": 135,
+                                              "x": 580,
+                                              "y": 286
+                                            }
+                                          ]
+                                        },
+                                        "small": {
+                                          "faces": [
+                                            {
+                                              "h": 94,
+                                              "w": 94,
+                                              "x": 406,
+                                              "y": 200
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "id_str": "2088027892777439232",
+                                      "indices": [38, 61],
+                                      "media_key": "3_2088027892777439232",
+                                      "media_results": {
+                                        "result": {
+                                          "media_key": "3_2088027892777439232"
+                                        }
+                                      },
+                                      "media_url_https": "https://pbs.twimg.com/media/HPoqTj4bUAAFz1N.jpg",
+                                      "original_info": {
+                                        "focus_rects": [
+                                          {
+                                            "h": 467,
+                                            "w": 834,
+                                            "x": 0,
+                                            "y": 502
+                                          },
+                                          {
+                                            "h": 834,
+                                            "w": 834,
+                                            "x": 0,
+                                            "y": 135
+                                          },
+                                          {
+                                            "h": 951,
+                                            "w": 834,
+                                            "x": 0,
+                                            "y": 18
+                                          },
+                                          {
+                                            "h": 969,
+                                            "w": 485,
+                                            "x": 0,
+                                            "y": 0
+                                          },
+                                          {
+                                            "h": 969,
+                                            "w": 834,
+                                            "x": 0,
+                                            "y": 0
+                                          }
+                                        ],
+                                        "height": 969,
+                                        "width": 834
+                                      },
+                                      "sizes": {
+                                        "large": {
+                                          "h": 969,
+                                          "resize": "fit",
+                                          "w": 834
+                                        },
+                                        "medium": {
+                                          "h": 969,
+                                          "resize": "fit",
+                                          "w": 834
+                                        },
+                                        "small": {
+                                          "h": 680,
+                                          "resize": "fit",
+                                          "w": 585
+                                        },
+                                        "thumb": {
+                                          "h": 150,
+                                          "resize": "crop",
+                                          "w": 150
+                                        }
+                                      },
+                                      "type": "photo",
+                                      "url": "https://t.co/beGhHM8yNi"
+                                    }
+                                  ]
+                                },
+                                "favorite_count": 0,
+                                "favorited": false,
+                                "full_text": "@GenshinImpact America, UID 600300993 https://t.co/beGhHM8yNi",
+                                "id_str": "2088027993008726212",
+                                "in_reply_to_screen_name": "GenshinImpact",
+                                "in_reply_to_status_id_str": "2087720798702498234",
+                                "in_reply_to_user_id_str": "1072404907230060544",
+                                "is_quote_status": false,
+                                "lang": "nl",
+                                "possibly_sensitive": false,
+                                "possibly_sensitive_editable": true,
+                                "quote_count": 0,
+                                "reply_count": 0,
+                                "retweet_count": 0,
+                                "retweeted": false,
+                                "user_id_str": "1425551644914225162"
+                              },
+                              "quick_promote_eligibility": {
+                                "eligibility": "IneligibleNotVerified"
+                              },
+                              "rest_id": "2088027993008726212",
+                              "source": "<a href=\"https://mobile.twitter.com\" rel=\"nofollow\">Twitter Web App</a>",
+                              "unmention_data": {},
+                              "views": {
+                                "count": "384",
+                                "state": "EnabledWithCount"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  ],
+                  "metadata": {
+                    "conversationMetadata": {
+                      "allTweetIds": ["2088027993008726212"],
+                      "enableDeduplication": true
+                    }
+                  }
+                },
+                "entryId": "conversationthread-2088027993008726212",
+                "sortIndex": "2088929116056190736"
+              },
+              {
+                "content": {
+                  "__typename": "TimelineTimelineModule",
+                  "clientEventInfo": {
+                    "component": "tweet",
+                    "details": {
+                      "conversationDetails": {
+                        "conversationSection": "HighQuality"
+                      },
+                      "timelinesDetails": {
+                        "controllerData": "DAACDAAEDAABCgABAAAAAAAAAAEKAAIAAAAAAAAAAAoAAwAAAaAKBN5LAAAAAA=="
+                      }
+                    }
+                  },
+                  "displayType": "VerticalConversation",
+                  "entryType": "TimelineTimelineModule",
+                  "items": [
+                    {
+                      "entryId": "conversationthread-2088560864114712779-tweet-2088560864114712779",
+                      "item": {
+                        "clientEventInfo": {
+                          "component": "tweet",
+                          "details": {
+                            "conversationDetails": {
+                              "conversationSection": "HighQuality"
+                            },
+                            "timelinesDetails": {
+                              "controllerData": "DAACDAAEDAABCgABAAAAAAAAAAEKAAIAAAAAAAAAAAoAAwAAAaAKBN5LAAAAAA=="
+                            }
+                          },
+                          "element": "tweet"
+                        },
+                        "itemContent": {
+                          "__typename": "TimelineTweet",
+                          "itemType": "TimelineTweet",
+                          "tweetDisplayType": "Tweet",
+                          "tweet_results": {
+                            "result": {
+                              "__typename": "Tweet",
+                              "core": {
+                                "user_results": {
+                                  "result": {
+                                    "__typename": "User",
+                                    "affiliates_highlighted_label": {},
+                                    "avatar": {
+                                      "image_url": "https://pbs.twimg.com/profile_images/1619067902673428510/EjsD8Ptq_normal.jpg"
+                                    },
+                                    "core": {
+                                      "created_at": "Tue Jun 30 21:22:39 +0000 2015",
+                                      "name": "OnestarKai",
+                                      "screen_name": "Onestarkai"
+                                    },
+                                    "dm_permissions": {
+                                      "can_dm": false
+                                    },
+                                    "follow_request_sent": false,
+                                    "has_graduated_access": true,
+                                    "id": "VXNlcjozMzUyMzYwMzM1",
+                                    "is_blue_verified": false,
+                                    "legacy": {
+                                      "default_profile": true,
+                                      "default_profile_image": false,
+                                      "description": "Not much happens on this account. used to personally keep track of stuff.",
+                                      "entities": {
+                                        "description": {}
+                                      },
+                                      "fast_followers_count": 0,
+                                      "favourites_count": 7681,
+                                      "follow_request_sent": false,
+                                      "followers_count": 3,
+                                      "friends_count": 527,
+                                      "has_custom_timelines": true,
+                                      "is_translator": false,
+                                      "listed_count": 0,
+                                      "media_count": 5,
+                                      "needs_phone_verification": false,
+                                      "normal_followers_count": 3,
+                                      "notifications": false,
+                                      "possibly_sensitive": false,
+                                      "profile_banner_url": "https://pbs.twimg.com/profile_banners/3352360335/1741287848",
+                                      "profile_interstitial_type": "",
+                                      "statuses_count": 162,
+                                      "time_zone": "",
+                                      "translator_type": "none",
+                                      "url": "",
+                                      "utc_offset": 0,
+                                      "want_retweets": false,
+                                      "withheld_description": "",
+                                      "withheld_scope": ""
+                                    },
+                                    "location": {
+                                      "location": ""
+                                    },
+                                    "media_permissions": {
+                                      "can_media_tag": false
+                                    },
+                                    "parody_commentary_fan_label": "None",
+                                    "privacy": {
+                                      "protected": false
+                                    },
+                                    "profile_bio": {
+                                      "description": "Not much happens on this account. used to personally keep track of stuff."
+                                    },
+                                    "profile_description_language": "en",
+                                    "profile_image_shape": "Circle",
+                                    "relationship_perspectives": {
+                                      "blocked_by": false,
+                                      "blocking": false,
+                                      "followed_by": false,
+                                      "following": false,
+                                      "muting": false
+                                    },
+                                    "rest_id": "3352360335",
+                                    "super_follow_eligible": false,
+                                    "super_followed_by": false,
+                                    "super_following": false,
+                                    "verification": {
+                                      "verified": false
+                                    }
+                                  }
+                                }
+                              },
+                              "edit_control": {
+                                "edit_tweet_ids": ["2088560864114712779"],
+                                "editable_until_msecs": "1786790288000",
+                                "edits_remaining": "5",
+                                "is_edit_eligible": false
+                              },
+                              "grok_analysis_button": true,
+                              "grok_annotations": {},
+                              "has_birdwatch_notes": false,
+                              "is_translatable": false,
+                              "legacy": {
+                                "bookmark_count": 0,
+                                "bookmarked": false,
+                                "conversation_id_str": "2087720798702498234",
+                                "created_at": "Sat Aug 15 09:38:08 +0000 2026",
+                                "display_text_range": [15, 38],
+                                "entities": {
+                                  "media": [
+                                    {
+                                      "display_url": "pic.x.com/GYif5AhByz",
+                                      "expanded_url": "https://x.com/Onestarkai/status/2088560864114712779/photo/1",
+                                      "ext_media_availability": {
+                                        "status": "Available"
+                                      },
+                                      "features": {
+                                        "large": {
+                                          "faces": []
+                                        },
+                                        "medium": {
+                                          "faces": []
+                                        },
+                                        "orig": {
+                                          "faces": []
+                                        },
+                                        "small": {
+                                          "faces": []
+                                        }
+                                      },
+                                      "id_str": "2088560861459652608",
+                                      "indices": [39, 62],
+                                      "media_key": "3_2088560861459652608",
+                                      "media_results": {
+                                        "result": {
+                                          "media_key": "3_2088560861459652608"
+                                        }
+                                      },
+                                      "media_url_https": "https://pbs.twimg.com/media/HPwPCa8WIAA38D-.jpg",
+                                      "original_info": {
+                                        "focus_rects": [
+                                          {
+                                            "h": 605,
+                                            "w": 1080,
+                                            "x": 0,
+                                            "y": 850
+                                          },
+                                          {
+                                            "h": 1080,
+                                            "w": 1080,
+                                            "x": 0,
+                                            "y": 407
+                                          },
+                                          {
+                                            "h": 1231,
+                                            "w": 1080,
+                                            "x": 0,
+                                            "y": 256
+                                          },
+                                          {
+                                            "h": 1487,
+                                            "w": 744,
+                                            "x": 185,
+                                            "y": 0
+                                          },
+                                          {
+                                            "h": 1487,
+                                            "w": 1080,
+                                            "x": 0,
+                                            "y": 0
+                                          }
+                                        ],
+                                        "height": 1487,
+                                        "width": 1080
+                                      },
+                                      "sizes": {
+                                        "large": {
+                                          "h": 1487,
+                                          "resize": "fit",
+                                          "w": 1080
+                                        },
+                                        "medium": {
+                                          "h": 1200,
+                                          "resize": "fit",
+                                          "w": 872
+                                        },
+                                        "small": {
+                                          "h": 680,
+                                          "resize": "fit",
+                                          "w": 494
+                                        },
+                                        "thumb": {
+                                          "h": 150,
+                                          "resize": "crop",
+                                          "w": 150
+                                        }
+                                      },
+                                      "type": "photo",
+                                      "url": "https://t.co/GYif5AhByz"
+                                    }
+                                  ],
+                                  "user_mentions": [
+                                    {
+                                      "id_str": "1072404907230060544",
+                                      "indices": [0, 14],
+                                      "name": "Genshin Impact",
+                                      "screen_name": "GenshinImpact"
+                                    }
+                                  ]
+                                },
+                                "extended_entities": {
+                                  "media": [
+                                    {
+                                      "display_url": "pic.x.com/GYif5AhByz",
+                                      "expanded_url": "https://x.com/Onestarkai/status/2088560864114712779/photo/1",
+                                      "ext_media_availability": {
+                                        "status": "Available"
+                                      },
+                                      "features": {
+                                        "large": {
+                                          "faces": []
+                                        },
+                                        "medium": {
+                                          "faces": []
+                                        },
+                                        "orig": {
+                                          "faces": []
+                                        },
+                                        "small": {
+                                          "faces": []
+                                        }
+                                      },
+                                      "id_str": "2088560861459652608",
+                                      "indices": [39, 62],
+                                      "media_key": "3_2088560861459652608",
+                                      "media_results": {
+                                        "result": {
+                                          "media_key": "3_2088560861459652608"
+                                        }
+                                      },
+                                      "media_url_https": "https://pbs.twimg.com/media/HPwPCa8WIAA38D-.jpg",
+                                      "original_info": {
+                                        "focus_rects": [
+                                          {
+                                            "h": 605,
+                                            "w": 1080,
+                                            "x": 0,
+                                            "y": 850
+                                          },
+                                          {
+                                            "h": 1080,
+                                            "w": 1080,
+                                            "x": 0,
+                                            "y": 407
+                                          },
+                                          {
+                                            "h": 1231,
+                                            "w": 1080,
+                                            "x": 0,
+                                            "y": 256
+                                          },
+                                          {
+                                            "h": 1487,
+                                            "w": 744,
+                                            "x": 185,
+                                            "y": 0
+                                          },
+                                          {
+                                            "h": 1487,
+                                            "w": 1080,
+                                            "x": 0,
+                                            "y": 0
+                                          }
+                                        ],
+                                        "height": 1487,
+                                        "width": 1080
+                                      },
+                                      "sizes": {
+                                        "large": {
+                                          "h": 1487,
+                                          "resize": "fit",
+                                          "w": 1080
+                                        },
+                                        "medium": {
+                                          "h": 1200,
+                                          "resize": "fit",
+                                          "w": 872
+                                        },
+                                        "small": {
+                                          "h": 680,
+                                          "resize": "fit",
+                                          "w": 494
+                                        },
+                                        "thumb": {
+                                          "h": 150,
+                                          "resize": "crop",
+                                          "w": 150
+                                        }
+                                      },
+                                      "type": "photo",
+                                      "url": "https://t.co/GYif5AhByz"
+                                    }
+                                  ]
+                                },
+                                "favorite_count": 0,
+                                "favorited": false,
+                                "full_text": "@GenshinImpact UID 688148879\nNA Server https://t.co/GYif5AhByz",
+                                "id_str": "2088560864114712779",
+                                "in_reply_to_screen_name": "GenshinImpact",
+                                "in_reply_to_status_id_str": "2087720798702498234",
+                                "in_reply_to_user_id_str": "1072404907230060544",
+                                "is_quote_status": false,
+                                "lang": "tl",
+                                "possibly_sensitive": false,
+                                "possibly_sensitive_editable": true,
+                                "quote_count": 0,
+                                "reply_count": 0,
+                                "retweet_count": 0,
+                                "retweeted": false,
+                                "user_id_str": "3352360335"
+                              },
+                              "quick_promote_eligibility": {
+                                "eligibility": "IneligibleNotVerified"
+                              },
+                              "rest_id": "2088560864114712779",
+                              "source": "<a href=\"http://twitter.com/download/android\" rel=\"nofollow\">Twitter for Android</a>",
+                              "unmention_data": {},
+                              "views": {
+                                "count": "439",
+                                "state": "EnabledWithCount"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  ],
+                  "metadata": {
+                    "conversationMetadata": {
+                      "allTweetIds": ["2088560864114712779"],
+                      "enableDeduplication": true
+                    }
+                  }
+                },
+                "entryId": "conversationthread-2088560864114712779",
+                "sortIndex": "2088929116056190726"
+              },
+              {
+                "content": {
+                  "__typename": "TimelineTimelineModule",
+                  "clientEventInfo": {
+                    "component": "tweet",
+                    "details": {
+                      "conversationDetails": {
+                        "conversationSection": "HighQuality"
+                      },
+                      "timelinesDetails": {
+                        "controllerData": "DAACDAAEDAABCgABAAAAAAAAAAEKAAIAAAAAAAAAAAoAAwAAAaAKBN5LAAAAAA=="
+                      }
+                    }
+                  },
+                  "displayType": "VerticalConversation",
+                  "entryType": "TimelineTimelineModule",
+                  "items": [
+                    {
+                      "entryId": "conversationthread-2088901705178198385-tweet-2088901705178198385",
+                      "item": {
+                        "clientEventInfo": {
+                          "component": "tweet",
+                          "details": {
+                            "conversationDetails": {
+                              "conversationSection": "HighQuality"
+                            },
+                            "timelinesDetails": {
+                              "controllerData": "DAACDAAEDAABCgABAAAAAAAAAAEKAAIAAAAAAAAAAAoAAwAAAaAKBN5LAAAAAA=="
+                            }
+                          },
+                          "element": "tweet"
+                        },
+                        "itemContent": {
+                          "__typename": "TimelineTweet",
+                          "itemType": "TimelineTweet",
+                          "tweetDisplayType": "Tweet",
+                          "tweet_results": {
+                            "result": {
+                              "__typename": "Tweet",
+                              "core": {
+                                "user_results": {
+                                  "result": {
+                                    "__typename": "User",
+                                    "affiliates_highlighted_label": {},
+                                    "avatar": {
+                                      "image_url": "https://pbs.twimg.com/profile_images/2044328154949644288/qhKTJyw5_normal.jpg"
+                                    },
+                                    "core": {
+                                      "created_at": "Wed Apr 15 08:12:07 +0000 2026",
+                                      "name": "JILUS",
+                                      "screen_name": "JILUS130262"
+                                    },
+                                    "dm_permissions": {
+                                      "can_dm": false
+                                    },
+                                    "follow_request_sent": false,
+                                    "has_graduated_access": true,
+                                    "id": "VXNlcjoyMDQ0MzI3NzgxODg3MDA4NzY5",
+                                    "is_blue_verified": false,
+                                    "legacy": {
+                                      "default_profile": true,
+                                      "default_profile_image": false,
+                                      "description": "",
+                                      "entities": {
+                                        "description": {}
+                                      },
+                                      "fast_followers_count": 0,
+                                      "favourites_count": 3026,
+                                      "follow_request_sent": false,
+                                      "followers_count": 1,
+                                      "friends_count": 21,
+                                      "has_custom_timelines": false,
+                                      "is_translator": false,
+                                      "listed_count": 0,
+                                      "media_count": 1,
+                                      "needs_phone_verification": false,
+                                      "normal_followers_count": 1,
+                                      "notifications": false,
+                                      "possibly_sensitive": false,
+                                      "profile_banner_url": "",
+                                      "profile_interstitial_type": "",
+                                      "statuses_count": 1,
+                                      "time_zone": "",
+                                      "translator_type": "none",
+                                      "url": "",
+                                      "utc_offset": 0,
+                                      "want_retweets": false,
+                                      "withheld_description": "",
+                                      "withheld_scope": ""
+                                    },
+                                    "location": {
+                                      "location": ""
+                                    },
+                                    "media_permissions": {
+                                      "can_media_tag": true
+                                    },
+                                    "parody_commentary_fan_label": "None",
+                                    "privacy": {
+                                      "protected": false
+                                    },
+                                    "profile_bio": {
+                                      "description": ""
+                                    },
+                                    "profile_image_shape": "Circle",
+                                    "relationship_perspectives": {
+                                      "blocked_by": false,
+                                      "blocking": false,
+                                      "followed_by": false,
+                                      "following": false,
+                                      "muting": false
+                                    },
+                                    "rest_id": "2044327781887008769",
+                                    "super_follow_eligible": false,
+                                    "super_followed_by": false,
+                                    "super_following": false,
+                                    "verification": {
+                                      "verified": false
+                                    }
+                                  }
+                                }
+                              },
+                              "edit_control": {
+                                "edit_tweet_ids": ["2088901705178198385"],
+                                "editable_until_msecs": "1786871551000",
+                                "edits_remaining": "5",
+                                "is_edit_eligible": false
+                              },
+                              "grok_analysis_button": true,
+                              "grok_annotations": {},
+                              "has_birdwatch_notes": false,
+                              "is_translatable": false,
+                              "legacy": {
+                                "bookmark_count": 0,
+                                "bookmarked": false,
+                                "conversation_id_str": "2087720798702498234",
+                                "created_at": "Sun Aug 16 08:12:31 +0000 2026",
+                                "display_text_range": [15, 39],
+                                "entities": {
+                                  "media": [
+                                    {
+                                      "display_url": "pic.x.com/SrkTDXHroV",
+                                      "expanded_url": "https://x.com/JILUS130262/status/2088901705178198385/photo/1",
+                                      "ext_media_availability": {
+                                        "status": "Available"
+                                      },
+                                      "features": {
+                                        "large": {
+                                          "faces": []
+                                        },
+                                        "medium": {
+                                          "faces": []
+                                        },
+                                        "orig": {
+                                          "faces": []
+                                        },
+                                        "small": {
+                                          "faces": []
+                                        }
+                                      },
+                                      "id_str": "2088901697414578176",
+                                      "indices": [40, 63],
+                                      "media_key": "3_2088901697414578176",
+                                      "media_results": {
+                                        "result": {
+                                          "media_key": "3_2088901697414578176"
+                                        }
+                                      },
+                                      "media_url_https": "https://pbs.twimg.com/media/HP1FBr0bQAAEJEt.jpg",
+                                      "original_info": {
+                                        "focus_rects": [
+                                          {
+                                            "h": 323,
+                                            "w": 577,
+                                            "x": 0,
+                                            "y": 241
+                                          },
+                                          {
+                                            "h": 564,
+                                            "w": 564,
+                                            "x": 0,
+                                            "y": 0
+                                          },
+                                          {
+                                            "h": 564,
+                                            "w": 495,
+                                            "x": 0,
+                                            "y": 0
+                                          },
+                                          {
+                                            "h": 564,
+                                            "w": 282,
+                                            "x": 17,
+                                            "y": 0
+                                          },
+                                          {
+                                            "h": 564,
+                                            "w": 577,
+                                            "x": 0,
+                                            "y": 0
+                                          }
+                                        ],
+                                        "height": 564,
+                                        "width": 577
+                                      },
+                                      "sizes": {
+                                        "large": {
+                                          "h": 564,
+                                          "resize": "fit",
+                                          "w": 577
+                                        },
+                                        "medium": {
+                                          "h": 564,
+                                          "resize": "fit",
+                                          "w": 577
+                                        },
+                                        "small": {
+                                          "h": 564,
+                                          "resize": "fit",
+                                          "w": 577
+                                        },
+                                        "thumb": {
+                                          "h": 150,
+                                          "resize": "crop",
+                                          "w": 150
+                                        }
+                                      },
+                                      "type": "photo",
+                                      "url": "https://t.co/SrkTDXHroV"
+                                    }
+                                  ],
+                                  "user_mentions": [
+                                    {
+                                      "id_str": "1072404907230060544",
+                                      "indices": [0, 14],
+                                      "name": "Genshin Impact",
+                                      "screen_name": "GenshinImpact"
+                                    }
+                                  ]
+                                },
+                                "extended_entities": {
+                                  "media": [
+                                    {
+                                      "display_url": "pic.x.com/SrkTDXHroV",
+                                      "expanded_url": "https://x.com/JILUS130262/status/2088901705178198385/photo/1",
+                                      "ext_media_availability": {
+                                        "status": "Available"
+                                      },
+                                      "features": {
+                                        "large": {
+                                          "faces": []
+                                        },
+                                        "medium": {
+                                          "faces": []
+                                        },
+                                        "orig": {
+                                          "faces": []
+                                        },
+                                        "small": {
+                                          "faces": []
+                                        }
+                                      },
+                                      "id_str": "2088901697414578176",
+                                      "indices": [40, 63],
+                                      "media_key": "3_2088901697414578176",
+                                      "media_results": {
+                                        "result": {
+                                          "media_key": "3_2088901697414578176"
+                                        }
+                                      },
+                                      "media_url_https": "https://pbs.twimg.com/media/HP1FBr0bQAAEJEt.jpg",
+                                      "original_info": {
+                                        "focus_rects": [
+                                          {
+                                            "h": 323,
+                                            "w": 577,
+                                            "x": 0,
+                                            "y": 241
+                                          },
+                                          {
+                                            "h": 564,
+                                            "w": 564,
+                                            "x": 0,
+                                            "y": 0
+                                          },
+                                          {
+                                            "h": 564,
+                                            "w": 495,
+                                            "x": 0,
+                                            "y": 0
+                                          },
+                                          {
+                                            "h": 564,
+                                            "w": 282,
+                                            "x": 17,
+                                            "y": 0
+                                          },
+                                          {
+                                            "h": 564,
+                                            "w": 577,
+                                            "x": 0,
+                                            "y": 0
+                                          }
+                                        ],
+                                        "height": 564,
+                                        "width": 577
+                                      },
+                                      "sizes": {
+                                        "large": {
+                                          "h": 564,
+                                          "resize": "fit",
+                                          "w": 577
+                                        },
+                                        "medium": {
+                                          "h": 564,
+                                          "resize": "fit",
+                                          "w": 577
+                                        },
+                                        "small": {
+                                          "h": 564,
+                                          "resize": "fit",
+                                          "w": 577
+                                        },
+                                        "thumb": {
+                                          "h": 150,
+                                          "resize": "crop",
+                                          "w": 150
+                                        }
+                                      },
+                                      "type": "photo",
+                                      "url": "https://t.co/SrkTDXHroV"
+                                    }
+                                  ]
+                                },
+                                "favorite_count": 0,
+                                "favorited": false,
+                                "full_text": "@GenshinImpact 1813313416 (asia server) https://t.co/SrkTDXHroV",
+                                "id_str": "2088901705178198385",
+                                "in_reply_to_screen_name": "GenshinImpact",
+                                "in_reply_to_status_id_str": "2087720798702498234",
+                                "in_reply_to_user_id_str": "1072404907230060544",
+                                "is_quote_status": false,
+                                "lang": "in",
+                                "possibly_sensitive": false,
+                                "possibly_sensitive_editable": true,
+                                "quote_count": 0,
+                                "reply_count": 0,
+                                "retweet_count": 0,
+                                "retweeted": false,
+                                "user_id_str": "2044327781887008769"
+                              },
+                              "quick_promote_eligibility": {
+                                "eligibility": "IneligibleNotVerified"
+                              },
+                              "rest_id": "2088901705178198385",
+                              "source": "<a href=\"http://twitter.com/download/android\" rel=\"nofollow\">Twitter for Android</a>",
+                              "unmention_data": {},
+                              "views": {
+                                "count": "19",
+                                "state": "EnabledWithCount"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  ],
+                  "metadata": {
+                    "conversationMetadata": {
+                      "allTweetIds": ["2088901705178198385"],
+                      "enableDeduplication": true
+                    }
+                  }
+                },
+                "entryId": "conversationthread-2088901705178198385",
+                "sortIndex": "2088929116056190716"
+              },
+              {
+                "content": {
+                  "__typename": "TimelineTimelineModule",
+                  "clientEventInfo": {
+                    "component": "tweet",
+                    "details": {
+                      "conversationDetails": {
+                        "conversationSection": "HighQuality"
+                      },
+                      "timelinesDetails": {
+                        "controllerData": "DAACDAAEDAABCgABAAAAAAAAAAEKAAIAAAAAAAAAAAoAAwAAAaAKBN5LAAAAAA=="
+                      }
+                    }
+                  },
+                  "displayType": "VerticalConversation",
+                  "entryType": "TimelineTimelineModule",
+                  "items": [
+                    {
+                      "entryId": "conversationthread-2088088489636290969-tweet-2088088489636290969",
+                      "item": {
+                        "clientEventInfo": {
+                          "component": "tweet",
+                          "details": {
+                            "conversationDetails": {
+                              "conversationSection": "HighQuality"
+                            },
+                            "timelinesDetails": {
+                              "controllerData": "DAACDAAEDAABCgABAAAAAAAAAAEKAAIAAAAAAAAAAAoAAwAAAaAKBN5LAAAAAA=="
+                            }
+                          },
+                          "element": "tweet"
+                        },
+                        "itemContent": {
+                          "__typename": "TimelineTweet",
+                          "itemType": "TimelineTweet",
+                          "tweetDisplayType": "Tweet",
+                          "tweet_results": {
+                            "result": {
+                              "__typename": "Tweet",
+                              "core": {
+                                "user_results": {
+                                  "result": {
+                                    "__typename": "User",
+                                    "affiliates_highlighted_label": {},
+                                    "avatar": {
+                                      "image_url": "https://abs.twimg.com/sticky/default_profile_images/default_profile_normal.png"
+                                    },
+                                    "core": {
+                                      "created_at": "Tue Jun 30 18:11:06 +0000 2026",
+                                      "name": "shio",
+                                      "screen_name": "shiozsa"
+                                    },
+                                    "dm_permissions": {
+                                      "can_dm": false
+                                    },
+                                    "follow_request_sent": false,
+                                    "has_graduated_access": true,
+                                    "id": "VXNlcjoyMDcyMDE5OTkyMjQ2NDE1MzYw",
+                                    "is_blue_verified": false,
+                                    "legacy": {
+                                      "default_profile": true,
+                                      "default_profile_image": true,
+                                      "description": "",
+                                      "entities": {
+                                        "description": {}
+                                      },
+                                      "fast_followers_count": 0,
+                                      "favourites_count": 195,
+                                      "follow_request_sent": false,
+                                      "followers_count": 0,
+                                      "friends_count": 12,
+                                      "has_custom_timelines": false,
+                                      "is_translator": false,
+                                      "listed_count": 0,
+                                      "media_count": 1,
+                                      "needs_phone_verification": false,
+                                      "normal_followers_count": 0,
+                                      "notifications": false,
+                                      "possibly_sensitive": false,
+                                      "profile_banner_url": "",
+                                      "profile_interstitial_type": "",
+                                      "statuses_count": 1,
+                                      "time_zone": "",
+                                      "translator_type": "none",
+                                      "url": "",
+                                      "utc_offset": 0,
+                                      "want_retweets": false,
+                                      "withheld_description": "",
+                                      "withheld_scope": ""
+                                    },
+                                    "location": {
+                                      "location": ""
+                                    },
+                                    "media_permissions": {
+                                      "can_media_tag": true
+                                    },
+                                    "parody_commentary_fan_label": "None",
+                                    "privacy": {
+                                      "protected": false
+                                    },
+                                    "profile_bio": {
+                                      "description": ""
+                                    },
+                                    "profile_image_shape": "Circle",
+                                    "relationship_perspectives": {
+                                      "blocked_by": false,
+                                      "blocking": false,
+                                      "followed_by": false,
+                                      "following": false,
+                                      "muting": false
+                                    },
+                                    "rest_id": "2072019992246415360",
+                                    "super_follow_eligible": false,
+                                    "super_followed_by": false,
+                                    "super_following": false,
+                                    "verification": {
+                                      "verified": false
+                                    }
+                                  }
+                                }
+                              },
+                              "edit_control": {
+                                "edit_tweet_ids": ["2088088489636290969"],
+                                "editable_until_msecs": "1786677665000",
+                                "edits_remaining": "5",
+                                "is_edit_eligible": false
+                              },
+                              "grok_analysis_button": true,
+                              "grok_annotations": {},
+                              "has_birdwatch_notes": false,
+                              "is_translatable": false,
+                              "legacy": {
+                                "bookmark_count": 0,
+                                "bookmarked": false,
+                                "conversation_id_str": "2087720798702498234",
+                                "created_at": "Fri Aug 14 02:21:05 +0000 2026",
+                                "display_text_range": [15, 33],
+                                "entities": {
+                                  "media": [
+                                    {
+                                      "display_url": "pic.x.com/HQny3MdNcG",
+                                      "expanded_url": "https://x.com/shiozsa/status/2088088489636290969/photo/1",
+                                      "ext_media_availability": {
+                                        "status": "Available"
+                                      },
+                                      "features": {
+                                        "large": {
+                                          "faces": []
+                                        },
+                                        "medium": {
+                                          "faces": []
+                                        },
+                                        "orig": {
+                                          "faces": []
+                                        },
+                                        "small": {
+                                          "faces": []
+                                        }
+                                      },
+                                      "id_str": "2088088482086633472",
+                                      "indices": [34, 57],
+                                      "media_key": "3_2088088482086633472",
+                                      "media_results": {
+                                        "result": {
+                                          "media_key": "3_2088088482086633472"
+                                        }
+                                      },
+                                      "media_url_https": "https://pbs.twimg.com/media/HPphaUpbwAAYjbc.jpg",
+                                      "original_info": {
+                                        "focus_rects": [
+                                          {
+                                            "h": 602,
+                                            "w": 1075,
+                                            "x": 0,
+                                            "y": 564
+                                          },
+                                          {
+                                            "h": 1075,
+                                            "w": 1075,
+                                            "x": 0,
+                                            "y": 91
+                                          },
+                                          {
+                                            "h": 1166,
+                                            "w": 1023,
+                                            "x": 0,
+                                            "y": 0
+                                          },
+                                          {
+                                            "h": 1166,
+                                            "w": 583,
+                                            "x": 0,
+                                            "y": 0
+                                          },
+                                          {
+                                            "h": 1166,
+                                            "w": 1075,
+                                            "x": 0,
+                                            "y": 0
+                                          }
+                                        ],
+                                        "height": 1166,
+                                        "width": 1075
+                                      },
+                                      "sizes": {
+                                        "large": {
+                                          "h": 1166,
+                                          "resize": "fit",
+                                          "w": 1075
+                                        },
+                                        "medium": {
+                                          "h": 1166,
+                                          "resize": "fit",
+                                          "w": 1075
+                                        },
+                                        "small": {
+                                          "h": 680,
+                                          "resize": "fit",
+                                          "w": 627
+                                        },
+                                        "thumb": {
+                                          "h": 150,
+                                          "resize": "crop",
+                                          "w": 150
+                                        }
+                                      },
+                                      "type": "photo",
+                                      "url": "https://t.co/HQny3MdNcG"
+                                    }
+                                  ],
+                                  "user_mentions": [
+                                    {
+                                      "id_str": "1072404907230060544",
+                                      "indices": [0, 14],
+                                      "name": "Genshin Impact",
+                                      "screen_name": "GenshinImpact"
+                                    }
+                                  ]
+                                },
+                                "extended_entities": {
+                                  "media": [
+                                    {
+                                      "display_url": "pic.x.com/HQny3MdNcG",
+                                      "expanded_url": "https://x.com/shiozsa/status/2088088489636290969/photo/1",
+                                      "ext_media_availability": {
+                                        "status": "Available"
+                                      },
+                                      "features": {
+                                        "large": {
+                                          "faces": []
+                                        },
+                                        "medium": {
+                                          "faces": []
+                                        },
+                                        "orig": {
+                                          "faces": []
+                                        },
+                                        "small": {
+                                          "faces": []
+                                        }
+                                      },
+                                      "id_str": "2088088482086633472",
+                                      "indices": [34, 57],
+                                      "media_key": "3_2088088482086633472",
+                                      "media_results": {
+                                        "result": {
+                                          "media_key": "3_2088088482086633472"
+                                        }
+                                      },
+                                      "media_url_https": "https://pbs.twimg.com/media/HPphaUpbwAAYjbc.jpg",
+                                      "original_info": {
+                                        "focus_rects": [
+                                          {
+                                            "h": 602,
+                                            "w": 1075,
+                                            "x": 0,
+                                            "y": 564
+                                          },
+                                          {
+                                            "h": 1075,
+                                            "w": 1075,
+                                            "x": 0,
+                                            "y": 91
+                                          },
+                                          {
+                                            "h": 1166,
+                                            "w": 1023,
+                                            "x": 0,
+                                            "y": 0
+                                          },
+                                          {
+                                            "h": 1166,
+                                            "w": 583,
+                                            "x": 0,
+                                            "y": 0
+                                          },
+                                          {
+                                            "h": 1166,
+                                            "w": 1075,
+                                            "x": 0,
+                                            "y": 0
+                                          }
+                                        ],
+                                        "height": 1166,
+                                        "width": 1075
+                                      },
+                                      "sizes": {
+                                        "large": {
+                                          "h": 1166,
+                                          "resize": "fit",
+                                          "w": 1075
+                                        },
+                                        "medium": {
+                                          "h": 1166,
+                                          "resize": "fit",
+                                          "w": 1075
+                                        },
+                                        "small": {
+                                          "h": 680,
+                                          "resize": "fit",
+                                          "w": 627
+                                        },
+                                        "thumb": {
+                                          "h": 150,
+                                          "resize": "crop",
+                                          "w": 150
+                                        }
+                                      },
+                                      "type": "photo",
+                                      "url": "https://t.co/HQny3MdNcG"
+                                    }
+                                  ]
+                                },
+                                "favorite_count": 1,
+                                "favorited": false,
+                                "full_text": "@GenshinImpact Asia\nid: 877919555 https://t.co/HQny3MdNcG",
+                                "id_str": "2088088489636290969",
+                                "in_reply_to_screen_name": "GenshinImpact",
+                                "in_reply_to_status_id_str": "2087720798702498234",
+                                "in_reply_to_user_id_str": "1072404907230060544",
+                                "is_quote_status": false,
+                                "lang": "in",
+                                "possibly_sensitive": false,
+                                "possibly_sensitive_editable": true,
+                                "quote_count": 0,
+                                "reply_count": 0,
+                                "retweet_count": 0,
+                                "retweeted": false,
+                                "user_id_str": "2072019992246415360"
+                              },
+                              "quick_promote_eligibility": {
+                                "eligibility": "IneligibleNotVerified"
+                              },
+                              "rest_id": "2088088489636290969",
+                              "source": "<a href=\"http://twitter.com/download/android\" rel=\"nofollow\">Twitter for Android</a>",
+                              "unmention_data": {},
+                              "views": {
+                                "count": "245",
+                                "state": "EnabledWithCount"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  ],
+                  "metadata": {
+                    "conversationMetadata": {
+                      "allTweetIds": ["2088088489636290969"],
+                      "enableDeduplication": true
+                    }
+                  }
+                },
+                "entryId": "conversationthread-2088088489636290969",
+                "sortIndex": "2088929116056190706"
+              },
+              {
+                "content": {
+                  "__typename": "TimelineTimelineModule",
+                  "clientEventInfo": {
+                    "component": "tweet",
+                    "details": {
+                      "conversationDetails": {
+                        "conversationSection": "HighQuality"
+                      },
+                      "timelinesDetails": {
+                        "controllerData": "DAACDAAEDAABCgABAAAAAAAAAAEKAAIAAAAAAAAAAAoAAwAAAaAKBN5LAAAAAA=="
+                      }
+                    }
+                  },
+                  "displayType": "VerticalConversation",
+                  "entryType": "TimelineTimelineModule",
+                  "items": [
+                    {
+                      "entryId": "conversationthread-2088089094123401298-tweet-2088089094123401298",
+                      "item": {
+                        "clientEventInfo": {
+                          "component": "tweet",
+                          "details": {
+                            "conversationDetails": {
+                              "conversationSection": "HighQuality"
+                            },
+                            "timelinesDetails": {
+                              "controllerData": "DAACDAAEDAABCgABAAAAAAAAAAEKAAIAAAAAAAAAAAoAAwAAAaAKBN5LAAAAAA=="
+                            }
+                          },
+                          "element": "tweet"
+                        },
+                        "itemContent": {
+                          "__typename": "TimelineTweet",
+                          "itemType": "TimelineTweet",
+                          "tweetDisplayType": "Tweet",
+                          "tweet_results": {
+                            "result": {
+                              "__typename": "Tweet",
+                              "core": {
+                                "user_results": {
+                                  "result": {
+                                    "__typename": "User",
+                                    "affiliates_highlighted_label": {},
+                                    "avatar": {
+                                      "image_url": "https://pbs.twimg.com/profile_images/2060180462048280579/o2n01oXG_normal.jpg"
+                                    },
+                                    "core": {
+                                      "created_at": "Tue May 24 16:50:44 +0000 2022",
+                                      "name": "Mittens",
+                                      "screen_name": "Mittens08354481"
+                                    },
+                                    "dm_permissions": {
+                                      "can_dm": false
+                                    },
+                                    "follow_request_sent": false,
+                                    "has_graduated_access": true,
+                                    "id": "VXNlcjoxNTI5MTQyNjc0NzYyMTI5NDEx",
+                                    "is_blue_verified": false,
+                                    "legacy": {
+                                      "default_profile": true,
+                                      "default_profile_image": false,
+                                      "description": "",
+                                      "entities": {
+                                        "description": {}
+                                      },
+                                      "fast_followers_count": 0,
+                                      "favourites_count": 280,
+                                      "follow_request_sent": false,
+                                      "followers_count": 0,
+                                      "friends_count": 24,
+                                      "has_custom_timelines": false,
+                                      "is_translator": false,
+                                      "listed_count": 0,
+                                      "media_count": 7,
+                                      "needs_phone_verification": false,
+                                      "normal_followers_count": 0,
+                                      "notifications": false,
+                                      "possibly_sensitive": false,
+                                      "profile_banner_url": "https://pbs.twimg.com/profile_banners/1529142674762129411/1780020273",
+                                      "profile_interstitial_type": "",
+                                      "statuses_count": 24,
+                                      "time_zone": "",
+                                      "translator_type": "none",
+                                      "url": "",
+                                      "utc_offset": 0,
+                                      "want_retweets": false,
+                                      "withheld_description": "",
+                                      "withheld_scope": ""
+                                    },
+                                    "location": {
+                                      "location": ""
+                                    },
+                                    "media_permissions": {
+                                      "can_media_tag": true
+                                    },
+                                    "parody_commentary_fan_label": "None",
+                                    "privacy": {
+                                      "protected": false
+                                    },
+                                    "profile_bio": {
+                                      "description": ""
+                                    },
+                                    "profile_image_shape": "Circle",
+                                    "relationship_perspectives": {
+                                      "blocked_by": false,
+                                      "blocking": false,
+                                      "followed_by": false,
+                                      "following": false,
+                                      "muting": false
+                                    },
+                                    "rest_id": "1529142674762129411",
+                                    "super_follow_eligible": false,
+                                    "super_followed_by": false,
+                                    "super_following": false,
+                                    "verification": {
+                                      "verified": false
+                                    }
+                                  }
+                                }
+                              },
+                              "edit_control": {
+                                "edit_tweet_ids": ["2088089094123401298"],
+                                "editable_until_msecs": "1786677809000",
+                                "edits_remaining": "5",
+                                "is_edit_eligible": false
+                              },
+                              "grok_analysis_button": true,
+                              "grok_annotations": {},
+                              "has_birdwatch_notes": false,
+                              "is_translatable": false,
+                              "legacy": {
+                                "bookmark_count": 0,
+                                "bookmarked": false,
+                                "conversation_id_str": "2087720798702498234",
+                                "created_at": "Fri Aug 14 02:23:29 +0000 2026",
+                                "display_text_range": [15, 71],
+                                "entities": {
+                                  "media": [
+                                    {
+                                      "display_url": "pic.x.com/xAfXkfCB1G",
+                                      "expanded_url": "https://x.com/Mittens08354481/status/2088089094123401298/photo/1",
+                                      "ext_media_availability": {
+                                        "status": "Available"
+                                      },
+                                      "features": {
+                                        "large": {
+                                          "faces": [
+                                            {
+                                              "h": 41,
+                                              "w": 41,
+                                              "x": 1000,
+                                              "y": 568
+                                            },
+                                            {
+                                              "h": 52,
+                                              "w": 52,
+                                              "x": 547,
+                                              "y": 442
+                                            }
+                                          ]
+                                        },
+                                        "medium": {
+                                          "faces": [
+                                            {
+                                              "h": 41,
+                                              "w": 41,
+                                              "x": 1000,
+                                              "y": 568
+                                            },
+                                            {
+                                              "h": 52,
+                                              "w": 52,
+                                              "x": 547,
+                                              "y": 442
+                                            }
+                                          ]
+                                        },
+                                        "orig": {
+                                          "faces": [
+                                            {
+                                              "h": 41,
+                                              "w": 41,
+                                              "x": 1000,
+                                              "y": 568
+                                            },
+                                            {
+                                              "h": 52,
+                                              "w": 52,
+                                              "x": 547,
+                                              "y": 442
+                                            }
+                                          ]
+                                        },
+                                        "small": {
+                                          "faces": [
+                                            {
+                                              "h": 25,
+                                              "w": 25,
+                                              "x": 629,
+                                              "y": 357
+                                            },
+                                            {
+                                              "h": 32,
+                                              "w": 32,
+                                              "x": 344,
+                                              "y": 278
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "id_str": "2088089085915107328",
+                                      "indices": [72, 95],
+                                      "media_key": "3_2088089085915107328",
+                                      "media_results": {
+                                        "result": {
+                                          "media_key": "3_2088089085915107328"
+                                        }
+                                      },
+                                      "media_url_https": "https://pbs.twimg.com/media/HPph9eFXEAA4Fkf.jpg",
+                                      "original_info": {
+                                        "focus_rects": [
+                                          {
+                                            "h": 605,
+                                            "w": 1080,
+                                            "x": 0,
+                                            "y": 475
+                                          },
+                                          {
+                                            "h": 1080,
+                                            "w": 1080,
+                                            "x": 0,
+                                            "y": 0
+                                          },
+                                          {
+                                            "h": 1080,
+                                            "w": 947,
+                                            "x": 0,
+                                            "y": 0
+                                          },
+                                          {
+                                            "h": 1080,
+                                            "w": 540,
+                                            "x": 0,
+                                            "y": 0
+                                          },
+                                          {
+                                            "h": 1080,
+                                            "w": 1080,
+                                            "x": 0,
+                                            "y": 0
+                                          }
+                                        ],
+                                        "height": 1080,
+                                        "width": 1080
+                                      },
+                                      "sizes": {
+                                        "large": {
+                                          "h": 1080,
+                                          "resize": "fit",
+                                          "w": 1080
+                                        },
+                                        "medium": {
+                                          "h": 1080,
+                                          "resize": "fit",
+                                          "w": 1080
+                                        },
+                                        "small": {
+                                          "h": 680,
+                                          "resize": "fit",
+                                          "w": 680
+                                        },
+                                        "thumb": {
+                                          "h": 150,
+                                          "resize": "crop",
+                                          "w": 150
+                                        }
+                                      },
+                                      "type": "photo",
+                                      "url": "https://t.co/xAfXkfCB1G"
+                                    }
+                                  ],
+                                  "user_mentions": [
+                                    {
+                                      "id_str": "1072404907230060544",
+                                      "indices": [0, 14],
+                                      "name": "Genshin Impact",
+                                      "screen_name": "GenshinImpact"
+                                    }
+                                  ]
+                                },
+                                "extended_entities": {
+                                  "media": [
+                                    {
+                                      "display_url": "pic.x.com/xAfXkfCB1G",
+                                      "expanded_url": "https://x.com/Mittens08354481/status/2088089094123401298/photo/1",
+                                      "ext_media_availability": {
+                                        "status": "Available"
+                                      },
+                                      "features": {
+                                        "large": {
+                                          "faces": [
+                                            {
+                                              "h": 41,
+                                              "w": 41,
+                                              "x": 1000,
+                                              "y": 568
+                                            },
+                                            {
+                                              "h": 52,
+                                              "w": 52,
+                                              "x": 547,
+                                              "y": 442
+                                            }
+                                          ]
+                                        },
+                                        "medium": {
+                                          "faces": [
+                                            {
+                                              "h": 41,
+                                              "w": 41,
+                                              "x": 1000,
+                                              "y": 568
+                                            },
+                                            {
+                                              "h": 52,
+                                              "w": 52,
+                                              "x": 547,
+                                              "y": 442
+                                            }
+                                          ]
+                                        },
+                                        "orig": {
+                                          "faces": [
+                                            {
+                                              "h": 41,
+                                              "w": 41,
+                                              "x": 1000,
+                                              "y": 568
+                                            },
+                                            {
+                                              "h": 52,
+                                              "w": 52,
+                                              "x": 547,
+                                              "y": 442
+                                            }
+                                          ]
+                                        },
+                                        "small": {
+                                          "faces": [
+                                            {
+                                              "h": 25,
+                                              "w": 25,
+                                              "x": 629,
+                                              "y": 357
+                                            },
+                                            {
+                                              "h": 32,
+                                              "w": 32,
+                                              "x": 344,
+                                              "y": 278
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "id_str": "2088089085915107328",
+                                      "indices": [72, 95],
+                                      "media_key": "3_2088089085915107328",
+                                      "media_results": {
+                                        "result": {
+                                          "media_key": "3_2088089085915107328"
+                                        }
+                                      },
+                                      "media_url_https": "https://pbs.twimg.com/media/HPph9eFXEAA4Fkf.jpg",
+                                      "original_info": {
+                                        "focus_rects": [
+                                          {
+                                            "h": 605,
+                                            "w": 1080,
+                                            "x": 0,
+                                            "y": 475
+                                          },
+                                          {
+                                            "h": 1080,
+                                            "w": 1080,
+                                            "x": 0,
+                                            "y": 0
+                                          },
+                                          {
+                                            "h": 1080,
+                                            "w": 947,
+                                            "x": 0,
+                                            "y": 0
+                                          },
+                                          {
+                                            "h": 1080,
+                                            "w": 540,
+                                            "x": 0,
+                                            "y": 0
+                                          },
+                                          {
+                                            "h": 1080,
+                                            "w": 1080,
+                                            "x": 0,
+                                            "y": 0
+                                          }
+                                        ],
+                                        "height": 1080,
+                                        "width": 1080
+                                      },
+                                      "sizes": {
+                                        "large": {
+                                          "h": 1080,
+                                          "resize": "fit",
+                                          "w": 1080
+                                        },
+                                        "medium": {
+                                          "h": 1080,
+                                          "resize": "fit",
+                                          "w": 1080
+                                        },
+                                        "small": {
+                                          "h": 680,
+                                          "resize": "fit",
+                                          "w": 680
+                                        },
+                                        "thumb": {
+                                          "h": 150,
+                                          "resize": "crop",
+                                          "w": 150
+                                        }
+                                      },
+                                      "type": "photo",
+                                      "url": "https://t.co/xAfXkfCB1G"
+                                    }
+                                  ]
+                                },
+                                "favorite_count": 1,
+                                "favorited": false,
+                                "full_text": "@GenshinImpact Well, ykw.. sure, I'll take it \nUID: 651640174 (America) https://t.co/xAfXkfCB1G",
+                                "id_str": "2088089094123401298",
+                                "in_reply_to_screen_name": "GenshinImpact",
+                                "in_reply_to_status_id_str": "2087720798702498234",
+                                "in_reply_to_user_id_str": "1072404907230060544",
+                                "is_quote_status": false,
+                                "lang": "en",
+                                "possibly_sensitive": false,
+                                "possibly_sensitive_editable": true,
+                                "quote_count": 0,
+                                "reply_count": 0,
+                                "retweet_count": 0,
+                                "retweeted": false,
+                                "user_id_str": "1529142674762129411"
+                              },
+                              "quick_promote_eligibility": {
+                                "eligibility": "IneligibleNotVerified"
+                              },
+                              "rest_id": "2088089094123401298",
+                              "source": "<a href=\"http://twitter.com/download/android\" rel=\"nofollow\">Twitter for Android</a>",
+                              "unmention_data": {},
+                              "views": {
+                                "count": "705",
+                                "state": "EnabledWithCount"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  ],
+                  "metadata": {
+                    "conversationMetadata": {
+                      "allTweetIds": ["2088089094123401298"],
+                      "enableDeduplication": true
+                    }
+                  }
+                },
+                "entryId": "conversationthread-2088089094123401298",
+                "sortIndex": "2088929116056190696"
+              },
+              {
+                "content": {
+                  "__typename": "TimelineTimelineModule",
+                  "clientEventInfo": {
+                    "component": "tweet",
+                    "details": {
+                      "conversationDetails": {
+                        "conversationSection": "HighQuality"
+                      },
+                      "timelinesDetails": {
+                        "controllerData": "DAACDAAEDAABCgABAAAAAAAAAAEKAAIAAAAAAAAAAAoAAwAAAaAKBN5LAAAAAA=="
+                      }
+                    }
+                  },
+                  "displayType": "VerticalConversation",
+                  "entryType": "TimelineTimelineModule",
+                  "items": [
+                    {
+                      "entryId": "conversationthread-2088809989691367795-tweet-2088809989691367795",
+                      "item": {
+                        "clientEventInfo": {
+                          "component": "tweet",
+                          "details": {
+                            "conversationDetails": {
+                              "conversationSection": "HighQuality"
+                            },
+                            "timelinesDetails": {
+                              "controllerData": "DAACDAAEDAABCgABAAAAAAAAAAEKAAIAAAAAAAAAAAoAAwAAAaAKBN5LAAAAAA=="
+                            }
+                          },
+                          "element": "tweet"
+                        },
+                        "itemContent": {
+                          "__typename": "TimelineTweet",
+                          "itemType": "TimelineTweet",
+                          "tweetDisplayType": "Tweet",
+                          "tweet_results": {
+                            "result": {
+                              "__typename": "Tweet",
+                              "card": {
+                                "legacy": {
+                                  "binding_values": [
+                                    {
+                                      "key": "photo_image_full_size_large",
+                                      "value": {
+                                        "image_value": {
+                                          "alt": "",
+                                          "height": 419,
+                                          "url": "https://pbs.twimg.com/card_img/2087720991036248064/KH6-leHO?format=jpg&name=800x419",
+                                          "width": 800
+                                        },
+                                        "type": "IMAGE"
+                                      }
+                                    },
+                                    {
+                                      "key": "thumbnail_image",
+                                      "value": {
+                                        "image_value": {
+                                          "alt": "",
+                                          "height": 147,
+                                          "url": "https://pbs.twimg.com/card_img/2087720991036248064/KH6-leHO?format=jpg&name=280x150",
+                                          "width": 280
+                                        },
+                                        "type": "IMAGE"
+                                      }
+                                    },
+                                    {
+                                      "key": "domain",
+                                      "value": {
+                                        "string_value": "snezhnayacareertest-en.belugacpn.jp",
+                                        "type": "STRING"
+                                      }
+                                    },
+                                    {
+                                      "key": "thumbnail_image_large",
+                                      "value": {
+                                        "image_value": {
+                                          "alt": "",
+                                          "height": 314,
+                                          "url": "https://pbs.twimg.com/card_img/2087720991036248064/KH6-leHO?format=jpg&name=600x600",
+                                          "width": 600
+                                        },
+                                        "type": "IMAGE"
+                                      }
+                                    },
+                                    {
+                                      "key": "summary_photo_image_small",
+                                      "value": {
+                                        "image_value": {
+                                          "alt": "",
+                                          "height": 202,
+                                          "url": "https://pbs.twimg.com/card_img/2087720991036248064/KH6-leHO?format=jpg&name=386x202",
+                                          "width": 386
+                                        },
+                                        "type": "IMAGE"
+                                      }
+                                    },
+                                    {
+                                      "key": "thumbnail_image_original",
+                                      "value": {
+                                        "image_value": {
+                                          "alt": "",
+                                          "height": 628,
+                                          "url": "https://pbs.twimg.com/card_img/2087720991036248064/KH6-leHO?format=jpg&name=orig",
+                                          "width": 1200
+                                        },
+                                        "type": "IMAGE"
+                                      }
+                                    },
+                                    {
+                                      "key": "photo_image_full_size_small",
+                                      "value": {
+                                        "image_value": {
+                                          "alt": "",
+                                          "height": 202,
+                                          "url": "https://pbs.twimg.com/card_img/2087720991036248064/KH6-leHO?format=jpg&name=386x202",
+                                          "width": 386
+                                        },
+                                        "type": "IMAGE"
+                                      }
+                                    },
+                                    {
+                                      "key": "summary_photo_image_large",
+                                      "value": {
+                                        "image_value": {
+                                          "alt": "",
+                                          "height": 419,
+                                          "url": "https://pbs.twimg.com/card_img/2087720991036248064/KH6-leHO?format=jpg&name=800x419",
+                                          "width": 800
+                                        },
+                                        "type": "IMAGE"
+                                      }
+                                    },
+                                    {
+                                      "key": "thumbnail_image_small",
+                                      "value": {
+                                        "image_value": {
+                                          "alt": "",
+                                          "height": 75,
+                                          "url": "https://pbs.twimg.com/card_img/2087720991036248064/KH6-leHO?format=jpg&name=144x144",
+                                          "width": 144
+                                        },
+                                        "type": "IMAGE"
+                                      }
+                                    },
+                                    {
+                                      "key": "thumbnail_image_x_large",
+                                      "value": {
+                                        "image_value": {
+                                          "alt": "",
+                                          "height": 628,
+                                          "url": "https://pbs.twimg.com/card_img/2087720991036248064/KH6-leHO?format=png&name=2048x2048_2_exp",
+                                          "width": 1200
+                                        },
+                                        "type": "IMAGE"
+                                      }
+                                    },
+                                    {
+                                      "key": "photo_image_full_size_original",
+                                      "value": {
+                                        "image_value": {
+                                          "alt": "",
+                                          "height": 628,
+                                          "url": "https://pbs.twimg.com/card_img/2087720991036248064/KH6-leHO?format=jpg&name=orig",
+                                          "width": 1200
+                                        },
+                                        "type": "IMAGE"
+                                      }
+                                    },
+                                    {
+                                      "key": "vanity_url",
+                                      "value": {
+                                        "scribe_key": "vanity_url",
+                                        "string_value": "snezhnayacareertest-en.belugacpn.jp",
+                                        "type": "STRING"
+                                      }
+                                    },
+                                    {
+                                      "key": "photo_image_full_size",
+                                      "value": {
+                                        "image_value": {
+                                          "alt": "",
+                                          "height": 314,
+                                          "url": "https://pbs.twimg.com/card_img/2087720991036248064/KH6-leHO?format=jpg&name=600x314",
+                                          "width": 600
+                                        },
+                                        "type": "IMAGE"
+                                      }
+                                    },
+                                    {
+                                      "key": "thumbnail_image_color",
+                                      "value": {
+                                        "image_color_value": {
+                                          "palette": [
+                                            {
+                                              "percentage": 46.79,
+                                              "rgb": {
+                                                "blue": 248,
+                                                "green": 239,
+                                                "red": 226
+                                              }
+                                            },
+                                            {
+                                              "percentage": 28.26,
+                                              "rgb": {
+                                                "blue": 235,
+                                                "green": 188,
+                                                "red": 119
+                                              }
+                                            },
+                                            {
+                                              "percentage": 8.65,
+                                              "rgb": {
+                                                "blue": 140,
+                                                "green": 66,
+                                                "red": 56
+                                              }
+                                            },
+                                            {
+                                              "percentage": 2.54,
+                                              "rgb": {
+                                                "blue": 156,
+                                                "green": 234,
+                                                "red": 250
+                                              }
+                                            },
+                                            {
+                                              "percentage": 2.29,
+                                              "rgb": {
+                                                "blue": 239,
+                                                "green": 172,
+                                                "red": 229
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        "type": "IMAGE_COLOR"
+                                      }
+                                    },
+                                    {
+                                      "key": "title",
+                                      "value": {
+                                        "string_value": "Click to start test",
+                                        "type": "STRING"
+                                      }
+                                    },
+                                    {
+                                      "key": "summary_photo_image_color",
+                                      "value": {
+                                        "image_color_value": {
+                                          "palette": [
+                                            {
+                                              "percentage": 46.79,
+                                              "rgb": {
+                                                "blue": 248,
+                                                "green": 239,
+                                                "red": 226
+                                              }
+                                            },
+                                            {
+                                              "percentage": 28.26,
+                                              "rgb": {
+                                                "blue": 235,
+                                                "green": 188,
+                                                "red": 119
+                                              }
+                                            },
+                                            {
+                                              "percentage": 8.65,
+                                              "rgb": {
+                                                "blue": 140,
+                                                "green": 66,
+                                                "red": 56
+                                              }
+                                            },
+                                            {
+                                              "percentage": 2.54,
+                                              "rgb": {
+                                                "blue": 156,
+                                                "green": 234,
+                                                "red": 250
+                                              }
+                                            },
+                                            {
+                                              "percentage": 2.29,
+                                              "rgb": {
+                                                "blue": 239,
+                                                "green": 172,
+                                                "red": 229
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        "type": "IMAGE_COLOR"
+                                      }
+                                    },
+                                    {
+                                      "key": "summary_photo_image_x_large",
+                                      "value": {
+                                        "image_value": {
+                                          "alt": "",
+                                          "height": 628,
+                                          "url": "https://pbs.twimg.com/card_img/2087720991036248064/KH6-leHO?format=png&name=2048x2048_2_exp",
+                                          "width": 1200
+                                        },
+                                        "type": "IMAGE"
+                                      }
+                                    },
+                                    {
+                                      "key": "summary_photo_image",
+                                      "value": {
+                                        "image_value": {
+                                          "alt": "",
+                                          "height": 314,
+                                          "url": "https://pbs.twimg.com/card_img/2087720991036248064/KH6-leHO?format=jpg&name=600x314",
+                                          "width": 600
+                                        },
+                                        "type": "IMAGE"
+                                      }
+                                    },
+                                    {
+                                      "key": "photo_image_full_size_color",
+                                      "value": {
+                                        "image_color_value": {
+                                          "palette": [
+                                            {
+                                              "percentage": 46.79,
+                                              "rgb": {
+                                                "blue": 248,
+                                                "green": 239,
+                                                "red": 226
+                                              }
+                                            },
+                                            {
+                                              "percentage": 28.26,
+                                              "rgb": {
+                                                "blue": 235,
+                                                "green": 188,
+                                                "red": 119
+                                              }
+                                            },
+                                            {
+                                              "percentage": 8.65,
+                                              "rgb": {
+                                                "blue": 140,
+                                                "green": 66,
+                                                "red": 56
+                                              }
+                                            },
+                                            {
+                                              "percentage": 2.54,
+                                              "rgb": {
+                                                "blue": 156,
+                                                "green": 234,
+                                                "red": 250
+                                              }
+                                            },
+                                            {
+                                              "percentage": 2.29,
+                                              "rgb": {
+                                                "blue": 239,
+                                                "green": 172,
+                                                "red": 229
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        "type": "IMAGE_COLOR"
+                                      }
+                                    },
+                                    {
+                                      "key": "photo_image_full_size_x_large",
+                                      "value": {
+                                        "image_value": {
+                                          "alt": "",
+                                          "height": 628,
+                                          "url": "https://pbs.twimg.com/card_img/2087720991036248064/KH6-leHO?format=png&name=2048x2048_2_exp",
+                                          "width": 1200
+                                        },
+                                        "type": "IMAGE"
+                                      }
+                                    },
+                                    {
+                                      "key": "card_url",
+                                      "value": {
+                                        "scribe_key": "card_url",
+                                        "string_value": "https://t.co/DHXlZMxG0F",
+                                        "type": "STRING"
+                                      }
+                                    },
+                                    {
+                                      "key": "summary_photo_image_original",
+                                      "value": {
+                                        "image_value": {
+                                          "alt": "",
+                                          "height": 628,
+                                          "url": "https://pbs.twimg.com/card_img/2087720991036248064/KH6-leHO?format=jpg&name=orig",
+                                          "width": 1200
+                                        },
+                                        "type": "IMAGE"
+                                      }
+                                    }
+                                  ],
+                                  "card_platform": {
+                                    "platform": {
+                                      "audience": {
+                                        "name": "production"
+                                      },
+                                      "device": {
+                                        "name": "Android",
+                                        "version": "12"
+                                      }
+                                    }
+                                  },
+                                  "name": "summary_large_image",
+                                  "url": "https://t.co/DHXlZMxG0F",
+                                  "user_refs_results": []
+                                },
+                                "rest_id": "https://t.co/DHXlZMxG0F"
+                              },
+                              "core": {
+                                "user_results": {
+                                  "result": {
+                                    "__typename": "User",
+                                    "affiliates_highlighted_label": {},
+                                    "avatar": {
+                                      "image_url": "https://pbs.twimg.com/profile_images/2080080544285544448/JTdBo1BL_normal.jpg"
+                                    },
+                                    "core": {
+                                      "created_at": "Tue Mar 31 18:34:17 +0000 2026",
+                                      "name": "keeky",
+                                      "screen_name": "hgirlhiiii4"
+                                    },
+                                    "dm_permissions": {
+                                      "can_dm": false
+                                    },
+                                    "follow_request_sent": false,
+                                    "has_graduated_access": true,
+                                    "id": "VXNlcjoyMDM5MDQ4NDI5MDA3OTQ5ODI0",
+                                    "is_blue_verified": false,
+                                    "legacy": {
+                                      "default_profile": true,
+                                      "default_profile_image": false,
+                                      "description": "i like plushies princesses and adopt me 💕",
+                                      "entities": {
+                                        "description": {},
+                                        "url": {
+                                          "urls": [
+                                            {
+                                              "display_url": "plushiedreadfuls.com",
+                                              "expanded_url": "http://plushiedreadfuls.com",
+                                              "indices": [0, 23],
+                                              "url": "https://t.co/E8wiRITCkC"
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "fast_followers_count": 0,
+                                      "favourites_count": 3001,
+                                      "follow_request_sent": false,
+                                      "followers_count": 38,
+                                      "friends_count": 113,
+                                      "has_custom_timelines": false,
+                                      "is_translator": false,
+                                      "listed_count": 0,
+                                      "media_count": 27,
+                                      "needs_phone_verification": false,
+                                      "normal_followers_count": 38,
+                                      "notifications": false,
+                                      "possibly_sensitive": false,
+                                      "profile_banner_url": "https://pbs.twimg.com/profile_banners/2039048429007949824/1784764833",
+                                      "profile_interstitial_type": "",
+                                      "statuses_count": 373,
+                                      "time_zone": "",
+                                      "translator_type": "none",
+                                      "url": "https://t.co/E8wiRITCkC",
+                                      "utc_offset": 0,
+                                      "want_retweets": false,
+                                      "withheld_description": "",
+                                      "withheld_scope": ""
+                                    },
+                                    "location": {
+                                      "location": "20!"
+                                    },
+                                    "media_permissions": {
+                                      "can_media_tag": true
+                                    },
+                                    "parody_commentary_fan_label": "None",
+                                    "privacy": {
+                                      "protected": false
+                                    },
+                                    "profile_bio": {
+                                      "description": "i like plushies princesses and adopt me 💕"
+                                    },
+                                    "profile_description_language": "en",
+                                    "profile_image_shape": "Circle",
+                                    "relationship_perspectives": {
+                                      "blocked_by": false,
+                                      "blocking": false,
+                                      "followed_by": false,
+                                      "following": false,
+                                      "muting": false
+                                    },
+                                    "rest_id": "2039048429007949824",
+                                    "super_follow_eligible": false,
+                                    "super_followed_by": false,
+                                    "super_following": false,
+                                    "verification": {
+                                      "verified": false
+                                    }
+                                  }
+                                }
+                              },
+                              "edit_control": {
+                                "edit_tweet_ids": ["2088809989691367795"],
+                                "editable_until_msecs": "1786849684000",
+                                "edits_remaining": "5",
+                                "is_edit_eligible": false
+                              },
+                              "grok_analysis_button": true,
+                              "grok_annotations": {},
+                              "has_birdwatch_notes": false,
+                              "is_translatable": false,
+                              "legacy": {
+                                "bookmark_count": 0,
+                                "bookmarked": false,
+                                "conversation_id_str": "2087720798702498234",
+                                "created_at": "Sun Aug 16 02:08:04 +0000 2026",
+                                "display_text_range": [15, 103],
+                                "entities": {
+                                  "hashtags": [
+                                    {
+                                      "indices": [44, 64],
+                                      "text": "SnezhnayaCareerTest"
+                                    }
+                                  ],
+                                  "urls": [
+                                    {
+                                      "display_url": "snezhnayacareertest-en.belugacpn.jp/983f5c51.html?…",
+                                      "expanded_url": "https://snezhnayacareertest-en.belugacpn.jp/983f5c51.html?q=l2A96AEbjn9LhIKMjo2WGrrLYGk_miJW-YWItRtQpsWb74j-QZN5JBxvDc3cZTeWCKlqlEGnhQW9Vwzeg-ZeV7Ffidsm_hGlE3tykF4SkHKjYtLfsCaqI6ztOSYNIwt93X4MIZtXowQrqhw3BuzErTElMOOzNvBrEDMQXFGO2K3fsAcnHLAQJw==",
+                                      "indices": [80, 103],
+                                      "url": "https://t.co/DHXlZMxG0F"
+                                    }
+                                  ],
+                                  "user_mentions": [
+                                    {
+                                      "id_str": "1072404907230060544",
+                                      "indices": [0, 14],
+                                      "name": "Genshin Impact",
+                                      "screen_name": "GenshinImpact"
+                                    },
+                                    {
+                                      "id_str": "1072404907230060544",
+                                      "indices": [65, 79],
+                                      "name": "Genshin Impact",
+                                      "screen_name": "GenshinImpact"
+                                    }
+                                  ]
+                                },
+                                "favorite_count": 0,
+                                "favorited": false,
+                                "full_text": "@GenshinImpact uid 612014748 america server #SnezhnayaCareerTest @GenshinImpact\nhttps://t.co/DHXlZMxG0F",
+                                "id_str": "2088809989691367795",
+                                "in_reply_to_screen_name": "GenshinImpact",
+                                "in_reply_to_status_id_str": "2087720798702498234",
+                                "in_reply_to_user_id_str": "1072404907230060544",
+                                "is_quote_status": false,
+                                "lang": "pt",
+                                "possibly_sensitive": false,
+                                "possibly_sensitive_editable": true,
+                                "quote_count": 0,
+                                "reply_count": 0,
+                                "retweet_count": 0,
+                                "retweeted": false,
+                                "user_id_str": "2039048429007949824"
+                              },
+                              "quick_promote_eligibility": {
+                                "eligibility": "IneligibleNotVerified"
+                              },
+                              "rest_id": "2088809989691367795",
+                              "source": "<a href=\"http://twitter.com/download/iphone\" rel=\"nofollow\">Twitter for iPhone</a>",
+                              "unmention_data": {},
+                              "views": {
+                                "count": "8",
+                                "state": "EnabledWithCount"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  ],
+                  "metadata": {
+                    "conversationMetadata": {
+                      "allTweetIds": ["2088809989691367795"],
+                      "enableDeduplication": true
+                    }
+                  }
+                },
+                "entryId": "conversationthread-2088809989691367795",
+                "sortIndex": "2088929116056190686"
+              },
+              {
+                "content": {
+                  "__typename": "TimelineTimelineModule",
+                  "clientEventInfo": {
+                    "component": "tweet",
+                    "details": {
+                      "conversationDetails": {
+                        "conversationSection": "HighQuality"
+                      },
+                      "timelinesDetails": {
+                        "controllerData": "DAACDAAEDAABCgABAAAAAAAAAAEKAAIAAAAAAAAAAAoAAwAAAaAKBN5LAAAAAA=="
+                      }
+                    }
+                  },
+                  "displayType": "VerticalConversation",
+                  "entryType": "TimelineTimelineModule",
+                  "items": [
+                    {
+                      "entryId": "conversationthread-2088316788874658085-tweet-2088316788874658085",
+                      "item": {
+                        "clientEventInfo": {
+                          "component": "tweet",
+                          "details": {
+                            "conversationDetails": {
+                              "conversationSection": "HighQuality"
+                            },
+                            "timelinesDetails": {
+                              "controllerData": "DAACDAAEDAABCgABAAAAAAAAAAEKAAIAAAAAAAAAAAoAAwAAAaAKBN5LAAAAAA=="
+                            }
+                          },
+                          "element": "tweet"
+                        },
+                        "itemContent": {
+                          "__typename": "TimelineTweet",
+                          "itemType": "TimelineTweet",
+                          "tweetDisplayType": "Tweet",
+                          "tweet_results": {
+                            "result": {
+                              "__typename": "Tweet",
+                              "core": {
+                                "user_results": {
+                                  "result": {
+                                    "__typename": "User",
+                                    "affiliates_highlighted_label": {},
+                                    "avatar": {
+                                      "image_url": "https://pbs.twimg.com/profile_images/904505528306458624/UpJqEDVt_normal.jpg"
+                                    },
+                                    "core": {
+                                      "created_at": "Thu Jun 08 16:24:58 +0000 2017",
+                                      "name": "ALREACHA GLACIES",
+                                      "screen_name": "AlreschaGlacies"
+                                    },
+                                    "dm_permissions": {
+                                      "can_dm": true
+                                    },
+                                    "follow_request_sent": false,
+                                    "has_graduated_access": true,
+                                    "id": "VXNlcjo4NzI4NTE5NTkzNDYzMzk4NDI=",
+                                    "is_blue_verified": false,
+                                    "legacy": {
+                                      "default_profile": true,
+                                      "default_profile_image": false,
+                                      "description": "",
+                                      "entities": {
+                                        "description": {}
+                                      },
+                                      "fast_followers_count": 0,
+                                      "favourites_count": 29698,
+                                      "follow_request_sent": false,
+                                      "followers_count": 16,
+                                      "friends_count": 691,
+                                      "has_custom_timelines": true,
+                                      "is_translator": false,
+                                      "listed_count": 2,
+                                      "media_count": 5,
+                                      "needs_phone_verification": false,
+                                      "normal_followers_count": 16,
+                                      "notifications": false,
+                                      "possibly_sensitive": false,
+                                      "profile_banner_url": "https://pbs.twimg.com/profile_banners/872851959346339842/1502541233",
+                                      "profile_interstitial_type": "",
+                                      "statuses_count": 23,
+                                      "time_zone": "",
+                                      "translator_type": "none",
+                                      "url": "",
+                                      "utc_offset": 0,
+                                      "want_retweets": false,
+                                      "withheld_description": "",
+                                      "withheld_scope": ""
+                                    },
+                                    "location": {
+                                      "location": ""
+                                    },
+                                    "media_permissions": {
+                                      "can_media_tag": true
+                                    },
+                                    "parody_commentary_fan_label": "None",
+                                    "privacy": {
+                                      "protected": false
+                                    },
+                                    "profile_bio": {
+                                      "description": ""
+                                    },
+                                    "profile_description_language": "und",
+                                    "profile_image_shape": "Circle",
+                                    "relationship_perspectives": {
+                                      "blocked_by": false,
+                                      "blocking": false,
+                                      "followed_by": false,
+                                      "following": false,
+                                      "muting": false
+                                    },
+                                    "rest_id": "872851959346339842",
+                                    "super_follow_eligible": false,
+                                    "super_followed_by": false,
+                                    "super_following": false,
+                                    "verification": {
+                                      "verified": false
+                                    }
+                                  }
+                                }
+                              },
+                              "edit_control": {
+                                "edit_tweet_ids": ["2088316788874658085"],
+                                "editable_until_msecs": "1786732096000",
+                                "edits_remaining": "5",
+                                "is_edit_eligible": false
+                              },
+                              "grok_analysis_button": true,
+                              "grok_annotations": {},
+                              "has_birdwatch_notes": false,
+                              "is_translatable": false,
+                              "legacy": {
+                                "bookmark_count": 0,
+                                "bookmarked": false,
+                                "conversation_id_str": "2087720798702498234",
+                                "created_at": "Fri Aug 14 17:28:16 +0000 2026",
+                                "display_text_range": [15, 130],
+                                "entities": {
+                                  "media": [
+                                    {
+                                      "display_url": "pic.x.com/wzdumEUOJQ",
+                                      "expanded_url": "https://x.com/AlreschaGlacies/status/2088316788874658085/photo/1",
+                                      "ext_media_availability": {
+                                        "status": "Available"
+                                      },
+                                      "features": {
+                                        "large": {
+                                          "faces": [
+                                            {
+                                              "h": 41,
+                                              "w": 41,
+                                              "x": 1000,
+                                              "y": 568
+                                            },
+                                            {
+                                              "h": 52,
+                                              "w": 52,
+                                              "x": 547,
+                                              "y": 442
+                                            }
+                                          ]
+                                        },
+                                        "medium": {
+                                          "faces": [
+                                            {
+                                              "h": 41,
+                                              "w": 41,
+                                              "x": 1000,
+                                              "y": 568
+                                            },
+                                            {
+                                              "h": 52,
+                                              "w": 52,
+                                              "x": 547,
+                                              "y": 442
+                                            }
+                                          ]
+                                        },
+                                        "orig": {
+                                          "faces": [
+                                            {
+                                              "h": 41,
+                                              "w": 41,
+                                              "x": 1000,
+                                              "y": 568
+                                            },
+                                            {
+                                              "h": 52,
+                                              "w": 52,
+                                              "x": 547,
+                                              "y": 442
+                                            }
+                                          ]
+                                        },
+                                        "small": {
+                                          "faces": [
+                                            {
+                                              "h": 25,
+                                              "w": 25,
+                                              "x": 629,
+                                              "y": 357
+                                            },
+                                            {
+                                              "h": 32,
+                                              "w": 32,
+                                              "x": 344,
+                                              "y": 278
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "id_str": "2088316782251773952",
+                                      "indices": [131, 154],
+                                      "media_key": "3_2088316782251773952",
+                                      "media_results": {
+                                        "result": {
+                                          "media_key": "3_2088316782251773952"
+                                        }
+                                      },
+                                      "media_url_https": "https://pbs.twimg.com/media/HPsxDJCakAALwVq.jpg",
+                                      "original_info": {
+                                        "focus_rects": [
+                                          {
+                                            "h": 605,
+                                            "w": 1080,
+                                            "x": 0,
+                                            "y": 475
+                                          },
+                                          {
+                                            "h": 1080,
+                                            "w": 1080,
+                                            "x": 0,
+                                            "y": 0
+                                          },
+                                          {
+                                            "h": 1080,
+                                            "w": 947,
+                                            "x": 0,
+                                            "y": 0
+                                          },
+                                          {
+                                            "h": 1080,
+                                            "w": 540,
+                                            "x": 0,
+                                            "y": 0
+                                          },
+                                          {
+                                            "h": 1080,
+                                            "w": 1080,
+                                            "x": 0,
+                                            "y": 0
+                                          }
+                                        ],
+                                        "height": 1080,
+                                        "width": 1080
+                                      },
+                                      "sizes": {
+                                        "large": {
+                                          "h": 1080,
+                                          "resize": "fit",
+                                          "w": 1080
+                                        },
+                                        "medium": {
+                                          "h": 1080,
+                                          "resize": "fit",
+                                          "w": 1080
+                                        },
+                                        "small": {
+                                          "h": 680,
+                                          "resize": "fit",
+                                          "w": 680
+                                        },
+                                        "thumb": {
+                                          "h": 150,
+                                          "resize": "crop",
+                                          "w": 150
+                                        }
+                                      },
+                                      "type": "photo",
+                                      "url": "https://t.co/wzdumEUOJQ"
+                                    }
+                                  ],
+                                  "user_mentions": [
+                                    {
+                                      "id_str": "1072404907230060544",
+                                      "indices": [0, 14],
+                                      "name": "Genshin Impact",
+                                      "screen_name": "GenshinImpact"
+                                    }
+                                  ]
+                                },
+                                "extended_entities": {
+                                  "media": [
+                                    {
+                                      "display_url": "pic.x.com/wzdumEUOJQ",
+                                      "expanded_url": "https://x.com/AlreschaGlacies/status/2088316788874658085/photo/1",
+                                      "ext_media_availability": {
+                                        "status": "Available"
+                                      },
+                                      "features": {
+                                        "large": {
+                                          "faces": [
+                                            {
+                                              "h": 41,
+                                              "w": 41,
+                                              "x": 1000,
+                                              "y": 568
+                                            },
+                                            {
+                                              "h": 52,
+                                              "w": 52,
+                                              "x": 547,
+                                              "y": 442
+                                            }
+                                          ]
+                                        },
+                                        "medium": {
+                                          "faces": [
+                                            {
+                                              "h": 41,
+                                              "w": 41,
+                                              "x": 1000,
+                                              "y": 568
+                                            },
+                                            {
+                                              "h": 52,
+                                              "w": 52,
+                                              "x": 547,
+                                              "y": 442
+                                            }
+                                          ]
+                                        },
+                                        "orig": {
+                                          "faces": [
+                                            {
+                                              "h": 41,
+                                              "w": 41,
+                                              "x": 1000,
+                                              "y": 568
+                                            },
+                                            {
+                                              "h": 52,
+                                              "w": 52,
+                                              "x": 547,
+                                              "y": 442
+                                            }
+                                          ]
+                                        },
+                                        "small": {
+                                          "faces": [
+                                            {
+                                              "h": 25,
+                                              "w": 25,
+                                              "x": 629,
+                                              "y": 357
+                                            },
+                                            {
+                                              "h": 32,
+                                              "w": 32,
+                                              "x": 344,
+                                              "y": 278
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "id_str": "2088316782251773952",
+                                      "indices": [131, 154],
+                                      "media_key": "3_2088316782251773952",
+                                      "media_results": {
+                                        "result": {
+                                          "media_key": "3_2088316782251773952"
+                                        }
+                                      },
+                                      "media_url_https": "https://pbs.twimg.com/media/HPsxDJCakAALwVq.jpg",
+                                      "original_info": {
+                                        "focus_rects": [
+                                          {
+                                            "h": 605,
+                                            "w": 1080,
+                                            "x": 0,
+                                            "y": 475
+                                          },
+                                          {
+                                            "h": 1080,
+                                            "w": 1080,
+                                            "x": 0,
+                                            "y": 0
+                                          },
+                                          {
+                                            "h": 1080,
+                                            "w": 947,
+                                            "x": 0,
+                                            "y": 0
+                                          },
+                                          {
+                                            "h": 1080,
+                                            "w": 540,
+                                            "x": 0,
+                                            "y": 0
+                                          },
+                                          {
+                                            "h": 1080,
+                                            "w": 1080,
+                                            "x": 0,
+                                            "y": 0
+                                          }
+                                        ],
+                                        "height": 1080,
+                                        "width": 1080
+                                      },
+                                      "sizes": {
+                                        "large": {
+                                          "h": 1080,
+                                          "resize": "fit",
+                                          "w": 1080
+                                        },
+                                        "medium": {
+                                          "h": 1080,
+                                          "resize": "fit",
+                                          "w": 1080
+                                        },
+                                        "small": {
+                                          "h": 680,
+                                          "resize": "fit",
+                                          "w": 680
+                                        },
+                                        "thumb": {
+                                          "h": 150,
+                                          "resize": "crop",
+                                          "w": 150
+                                        }
+                                      },
+                                      "type": "photo",
+                                      "url": "https://t.co/wzdumEUOJQ"
+                                    }
+                                  ]
+                                },
+                                "favorite_count": 0,
+                                "favorited": false,
+                                "full_text": "@GenshinImpact The most suitable career for Alreacha is Administrative Officer of the Zapolyarny Palace.\n\nUID：883135984\nSERVER：SEA https://t.co/wzdumEUOJQ",
+                                "id_str": "2088316788874658085",
+                                "in_reply_to_screen_name": "GenshinImpact",
+                                "in_reply_to_status_id_str": "2087720798702498234",
+                                "in_reply_to_user_id_str": "1072404907230060544",
+                                "is_quote_status": false,
+                                "lang": "en",
+                                "possibly_sensitive": false,
+                                "possibly_sensitive_editable": true,
+                                "quote_count": 0,
+                                "reply_count": 0,
+                                "retweet_count": 0,
+                                "retweeted": false,
+                                "user_id_str": "872851959346339842"
+                              },
+                              "quick_promote_eligibility": {
+                                "eligibility": "IneligibleNotVerified"
+                              },
+                              "rest_id": "2088316788874658085",
+                              "source": "<a href=\"http://twitter.com/download/android\" rel=\"nofollow\">Twitter for Android</a>",
+                              "unmention_data": {},
+                              "views": {
+                                "count": "150",
+                                "state": "EnabledWithCount"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  ],
+                  "metadata": {
+                    "conversationMetadata": {
+                      "allTweetIds": ["2088316788874658085"],
+                      "enableDeduplication": true
+                    }
+                  }
+                },
+                "entryId": "conversationthread-2088316788874658085",
+                "sortIndex": "2088929116056190676"
+              },
+              {
+                "content": {
+                  "__typename": "TimelineTimelineModule",
+                  "clientEventInfo": {
+                    "component": "tweet",
+                    "details": {
+                      "conversationDetails": {
+                        "conversationSection": "HighQuality"
+                      },
+                      "timelinesDetails": {
+                        "controllerData": "DAACDAAEDAABCgABAAAAAAAAAAEKAAIAAAAAAAAAAAoAAwAAAaAKBN5LAAAAAA=="
+                      }
+                    }
+                  },
+                  "displayType": "VerticalConversation",
+                  "entryType": "TimelineTimelineModule",
+                  "items": [
+                    {
+                      "entryId": "conversationthread-2088509182848974967-tweet-2088509182848974967",
+                      "item": {
+                        "clientEventInfo": {
+                          "component": "tweet",
+                          "details": {
+                            "conversationDetails": {
+                              "conversationSection": "HighQuality"
+                            },
+                            "timelinesDetails": {
+                              "controllerData": "DAACDAAEDAABCgABAAAAAAAAAAEKAAIAAAAAAAAAAAoAAwAAAaAKBN5LAAAAAA=="
+                            }
+                          },
+                          "element": "tweet"
+                        },
+                        "itemContent": {
+                          "__typename": "TimelineTweet",
+                          "itemType": "TimelineTweet",
+                          "tweetDisplayType": "Tweet",
+                          "tweet_results": {
+                            "result": {
+                              "__typename": "Tweet",
+                              "core": {
+                                "user_results": {
+                                  "result": {
+                                    "__typename": "User",
+                                    "affiliates_highlighted_label": {},
+                                    "avatar": {
+                                      "image_url": "https://pbs.twimg.com/profile_images/2015284245300760576/582mWH-3_normal.jpg"
+                                    },
+                                    "core": {
+                                      "created_at": "Sat Jan 16 04:56:34 +0000 2021",
+                                      "name": "lol",
+                                      "screen_name": "vbeanis"
+                                    },
+                                    "dm_permissions": {
+                                      "can_dm": false
+                                    },
+                                    "follow_request_sent": false,
+                                    "has_graduated_access": true,
+                                    "id": "VXNlcjoxMzUwMzA1ODcyOTY3MTM1MjMy",
+                                    "is_blue_verified": false,
+                                    "legacy": {
+                                      "default_profile": true,
+                                      "default_profile_image": false,
+                                      "description": "",
+                                      "entities": {
+                                        "description": {}
+                                      },
+                                      "fast_followers_count": 0,
+                                      "favourites_count": 3,
+                                      "follow_request_sent": false,
+                                      "followers_count": 0,
+                                      "friends_count": 1,
+                                      "has_custom_timelines": false,
+                                      "is_translator": false,
+                                      "listed_count": 0,
+                                      "media_count": 1,
+                                      "needs_phone_verification": false,
+                                      "normal_followers_count": 0,
+                                      "notifications": false,
+                                      "possibly_sensitive": false,
+                                      "profile_banner_url": "",
+                                      "profile_interstitial_type": "",
+                                      "statuses_count": 1,
+                                      "time_zone": "",
+                                      "translator_type": "none",
+                                      "url": "",
+                                      "utc_offset": 0,
+                                      "want_retweets": false,
+                                      "withheld_description": "",
+                                      "withheld_scope": ""
+                                    },
+                                    "location": {
+                                      "location": ""
+                                    },
+                                    "media_permissions": {
+                                      "can_media_tag": true
+                                    },
+                                    "parody_commentary_fan_label": "None",
+                                    "privacy": {
+                                      "protected": false
+                                    },
+                                    "profile_bio": {
+                                      "description": ""
+                                    },
+                                    "profile_image_shape": "Circle",
+                                    "relationship_perspectives": {
+                                      "blocked_by": false,
+                                      "blocking": false,
+                                      "followed_by": false,
+                                      "following": false,
+                                      "muting": false
+                                    },
+                                    "rest_id": "1350305872967135232",
+                                    "super_follow_eligible": false,
+                                    "super_followed_by": false,
+                                    "super_following": false,
+                                    "verification": {
+                                      "verified": false
+                                    }
+                                  }
+                                }
+                              },
+                              "edit_control": {
+                                "edit_tweet_ids": ["2088509182848974967"],
+                                "editable_until_msecs": "1786777966000",
+                                "edits_remaining": "5",
+                                "is_edit_eligible": false
+                              },
+                              "grok_analysis_button": true,
+                              "grok_annotations": {},
+                              "has_birdwatch_notes": false,
+                              "is_translatable": false,
+                              "legacy": {
+                                "bookmark_count": 0,
+                                "bookmarked": false,
+                                "conversation_id_str": "2087720798702498234",
+                                "created_at": "Sat Aug 15 06:12:46 +0000 2026",
+                                "display_text_range": [15, 38],
+                                "entities": {
+                                  "media": [
+                                    {
+                                      "display_url": "pic.x.com/bfpK3Qex2X",
+                                      "expanded_url": "https://x.com/vbeanis/status/2088509182848974967/photo/1",
+                                      "ext_media_availability": {
+                                        "status": "Available"
+                                      },
+                                      "features": {
+                                        "large": {
+                                          "faces": []
+                                        },
+                                        "medium": {
+                                          "faces": []
+                                        },
+                                        "orig": {
+                                          "faces": []
+                                        },
+                                        "small": {
+                                          "faces": []
+                                        }
+                                      },
+                                      "id_str": "2088509179158056960",
+                                      "indices": [39, 62],
+                                      "media_key": "3_2088509179158056960",
+                                      "media_results": {
+                                        "result": {
+                                          "media_key": "3_2088509179158056960"
+                                        }
+                                      },
+                                      "media_url_https": "https://pbs.twimg.com/media/HPvgCHXb0AAIvr5.jpg",
+                                      "original_info": {
+                                        "focus_rects": [
+                                          {
+                                            "h": 660,
+                                            "w": 1179,
+                                            "x": 0,
+                                            "y": 506
+                                          },
+                                          {
+                                            "h": 1166,
+                                            "w": 1166,
+                                            "x": 0,
+                                            "y": 0
+                                          },
+                                          {
+                                            "h": 1166,
+                                            "w": 1023,
+                                            "x": 0,
+                                            "y": 0
+                                          },
+                                          {
+                                            "h": 1166,
+                                            "w": 583,
+                                            "x": 151,
+                                            "y": 0
+                                          },
+                                          {
+                                            "h": 1166,
+                                            "w": 1179,
+                                            "x": 0,
+                                            "y": 0
+                                          }
+                                        ],
+                                        "height": 1166,
+                                        "width": 1179
+                                      },
+                                      "sizes": {
+                                        "large": {
+                                          "h": 1166,
+                                          "resize": "fit",
+                                          "w": 1179
+                                        },
+                                        "medium": {
+                                          "h": 1166,
+                                          "resize": "fit",
+                                          "w": 1179
+                                        },
+                                        "small": {
+                                          "h": 673,
+                                          "resize": "fit",
+                                          "w": 680
+                                        },
+                                        "thumb": {
+                                          "h": 150,
+                                          "resize": "crop",
+                                          "w": 150
+                                        }
+                                      },
+                                      "type": "photo",
+                                      "url": "https://t.co/bfpK3Qex2X"
+                                    }
+                                  ],
+                                  "user_mentions": [
+                                    {
+                                      "id_str": "1072404907230060544",
+                                      "indices": [0, 14],
+                                      "name": "Genshin Impact",
+                                      "screen_name": "GenshinImpact"
+                                    }
+                                  ]
+                                },
+                                "extended_entities": {
+                                  "media": [
+                                    {
+                                      "display_url": "pic.x.com/bfpK3Qex2X",
+                                      "expanded_url": "https://x.com/vbeanis/status/2088509182848974967/photo/1",
+                                      "ext_media_availability": {
+                                        "status": "Available"
+                                      },
+                                      "features": {
+                                        "large": {
+                                          "faces": []
+                                        },
+                                        "medium": {
+                                          "faces": []
+                                        },
+                                        "orig": {
+                                          "faces": []
+                                        },
+                                        "small": {
+                                          "faces": []
+                                        }
+                                      },
+                                      "id_str": "2088509179158056960",
+                                      "indices": [39, 62],
+                                      "media_key": "3_2088509179158056960",
+                                      "media_results": {
+                                        "result": {
+                                          "media_key": "3_2088509179158056960"
+                                        }
+                                      },
+                                      "media_url_https": "https://pbs.twimg.com/media/HPvgCHXb0AAIvr5.jpg",
+                                      "original_info": {
+                                        "focus_rects": [
+                                          {
+                                            "h": 660,
+                                            "w": 1179,
+                                            "x": 0,
+                                            "y": 506
+                                          },
+                                          {
+                                            "h": 1166,
+                                            "w": 1166,
+                                            "x": 0,
+                                            "y": 0
+                                          },
+                                          {
+                                            "h": 1166,
+                                            "w": 1023,
+                                            "x": 0,
+                                            "y": 0
+                                          },
+                                          {
+                                            "h": 1166,
+                                            "w": 583,
+                                            "x": 151,
+                                            "y": 0
+                                          },
+                                          {
+                                            "h": 1166,
+                                            "w": 1179,
+                                            "x": 0,
+                                            "y": 0
+                                          }
+                                        ],
+                                        "height": 1166,
+                                        "width": 1179
+                                      },
+                                      "sizes": {
+                                        "large": {
+                                          "h": 1166,
+                                          "resize": "fit",
+                                          "w": 1179
+                                        },
+                                        "medium": {
+                                          "h": 1166,
+                                          "resize": "fit",
+                                          "w": 1179
+                                        },
+                                        "small": {
+                                          "h": 673,
+                                          "resize": "fit",
+                                          "w": 680
+                                        },
+                                        "thumb": {
+                                          "h": 150,
+                                          "resize": "crop",
+                                          "w": 150
+                                        }
+                                      },
+                                      "type": "photo",
+                                      "url": "https://t.co/bfpK3Qex2X"
+                                    }
+                                  ]
+                                },
+                                "favorite_count": 0,
+                                "favorited": false,
+                                "full_text": "@GenshinImpact UID 600008344\nserver NA https://t.co/bfpK3Qex2X",
+                                "id_str": "2088509182848974967",
+                                "in_reply_to_screen_name": "GenshinImpact",
+                                "in_reply_to_status_id_str": "2087720798702498234",
+                                "in_reply_to_user_id_str": "1072404907230060544",
+                                "is_quote_status": false,
+                                "lang": "tl",
+                                "possibly_sensitive": false,
+                                "possibly_sensitive_editable": true,
+                                "quote_count": 0,
+                                "reply_count": 0,
+                                "retweet_count": 0,
+                                "retweeted": false,
+                                "user_id_str": "1350305872967135232"
+                              },
+                              "quick_promote_eligibility": {
+                                "eligibility": "IneligibleNotVerified"
+                              },
+                              "rest_id": "2088509182848974967",
+                              "source": "<a href=\"http://twitter.com/download/iphone\" rel=\"nofollow\">Twitter for iPhone</a>",
+                              "unmention_data": {},
+                              "views": {
+                                "count": "696",
+                                "state": "EnabledWithCount"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  ],
+                  "metadata": {
+                    "conversationMetadata": {
+                      "allTweetIds": ["2088509182848974967"],
+                      "enableDeduplication": true
+                    }
+                  }
+                },
+                "entryId": "conversationthread-2088509182848974967",
+                "sortIndex": "2088929116056190666"
+              },
+              {
+                "content": {
+                  "__typename": "TimelineTimelineModule",
+                  "clientEventInfo": {
+                    "component": "tweet",
+                    "details": {
+                      "conversationDetails": {
+                        "conversationSection": "HighQuality"
+                      },
+                      "timelinesDetails": {
+                        "controllerData": "DAACDAAEDAABCgABAAAAAAAAAAEKAAIAAAAAAAAAAAoAAwAAAaAKBN5LAAAAAA=="
+                      }
+                    }
+                  },
+                  "displayType": "VerticalConversation",
+                  "entryType": "TimelineTimelineModule",
+                  "items": [
+                    {
+                      "entryId": "conversationthread-2088371654921486382-tweet-2088371654921486382",
+                      "item": {
+                        "clientEventInfo": {
+                          "component": "tweet",
+                          "details": {
+                            "conversationDetails": {
+                              "conversationSection": "HighQuality"
+                            },
+                            "timelinesDetails": {
+                              "controllerData": "DAACDAAEDAABCgABAAAAAAAAAAEKAAIAAAAAAAAAAAoAAwAAAaAKBN5LAAAAAA=="
+                            }
+                          },
+                          "element": "tweet"
+                        },
+                        "itemContent": {
+                          "__typename": "TimelineTweet",
+                          "itemType": "TimelineTweet",
+                          "tweetDisplayType": "Tweet",
+                          "tweet_results": {
+                            "result": {
+                              "__typename": "Tweet",
+                              "core": {
+                                "user_results": {
+                                  "result": {
+                                    "__typename": "User",
+                                    "affiliates_highlighted_label": {},
+                                    "avatar": {
+                                      "image_url": "https://pbs.twimg.com/profile_images/1705994434897178624/lqHbz6Qu_normal.jpg"
+                                    },
+                                    "core": {
+                                      "created_at": "Sat Oct 16 16:10:18 +0000 2021",
+                                      "name": "DeviledEggs",
+                                      "screen_name": "DeviledEggs4372"
+                                    },
+                                    "dm_permissions": {
+                                      "can_dm": true
+                                    },
+                                    "follow_request_sent": false,
+                                    "has_graduated_access": true,
+                                    "id": "VXNlcjoxNDQ5NDA3Mjg1NDk1ODMyNTgw",
+                                    "is_blue_verified": false,
+                                    "legacy": {
+                                      "default_profile": true,
+                                      "default_profile_image": false,
+                                      "description": "Simply Perishing / BD: 3/13/2002🎉",
+                                      "entities": {
+                                        "description": {}
+                                      },
+                                      "fast_followers_count": 0,
+                                      "favourites_count": 93479,
+                                      "follow_request_sent": false,
+                                      "followers_count": 22,
+                                      "friends_count": 970,
+                                      "has_custom_timelines": true,
+                                      "is_translator": false,
+                                      "listed_count": 0,
+                                      "media_count": 2,
+                                      "needs_phone_verification": false,
+                                      "normal_followers_count": 22,
+                                      "notifications": false,
+                                      "possibly_sensitive": false,
+                                      "profile_banner_url": "https://pbs.twimg.com/profile_banners/1449407285495832580/1695575755",
+                                      "profile_interstitial_type": "",
+                                      "statuses_count": 145,
+                                      "time_zone": "",
+                                      "translator_type": "none",
+                                      "url": "",
+                                      "utc_offset": 0,
+                                      "want_retweets": false,
+                                      "withheld_description": "",
+                                      "withheld_scope": ""
+                                    },
+                                    "location": {
+                                      "location": ""
+                                    },
+                                    "media_permissions": {
+                                      "can_media_tag": true
+                                    },
+                                    "parody_commentary_fan_label": "None",
+                                    "privacy": {
+                                      "protected": false
+                                    },
+                                    "profile_bio": {
+                                      "description": "Simply Perishing / BD: 3/13/2002🎉"
+                                    },
+                                    "profile_image_shape": "Circle",
+                                    "relationship_perspectives": {
+                                      "blocked_by": false,
+                                      "blocking": false,
+                                      "followed_by": false,
+                                      "following": false,
+                                      "muting": false
+                                    },
+                                    "rest_id": "1449407285495832580",
+                                    "super_follow_eligible": false,
+                                    "super_followed_by": false,
+                                    "super_following": false,
+                                    "verification": {
+                                      "verified": false
+                                    }
+                                  }
+                                }
+                              },
+                              "edit_control": {
+                                "edit_tweet_ids": ["2088371654921486382"],
+                                "editable_until_msecs": "1786745177000",
+                                "edits_remaining": "5",
+                                "is_edit_eligible": false
+                              },
+                              "grok_analysis_button": true,
+                              "grok_annotations": {},
+                              "has_birdwatch_notes": false,
+                              "is_translatable": false,
+                              "legacy": {
+                                "bookmark_count": 0,
+                                "bookmarked": false,
+                                "conversation_id_str": "2087720798702498234",
+                                "created_at": "Fri Aug 14 21:06:17 +0000 2026",
+                                "display_text_range": [15, 45],
+                                "entities": {
+                                  "media": [
+                                    {
+                                      "allow_download_status": {
+                                        "allow_download": true
+                                      },
+                                      "display_url": "pic.x.com/cKRtwoQx9a",
+                                      "expanded_url": "https://x.com/DeviledEggs4372/status/2088371654921486382/photo/1",
+                                      "ext_media_availability": {
+                                        "status": "Available"
+                                      },
+                                      "features": {
+                                        "large": {
+                                          "faces": [
+                                            {
+                                              "h": 157,
+                                              "w": 157,
+                                              "x": 789,
+                                              "y": 372
+                                            }
+                                          ]
+                                        },
+                                        "medium": {
+                                          "faces": [
+                                            {
+                                              "h": 157,
+                                              "w": 157,
+                                              "x": 789,
+                                              "y": 372
+                                            }
+                                          ]
+                                        },
+                                        "orig": {
+                                          "faces": [
+                                            {
+                                              "h": 157,
+                                              "w": 157,
+                                              "x": 789,
+                                              "y": 372
+                                            }
+                                          ]
+                                        },
+                                        "small": {
+                                          "faces": [
+                                            {
+                                              "h": 91,
+                                              "w": 91,
+                                              "x": 458,
+                                              "y": 216
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "id_str": "2088371651599622144",
+                                      "indices": [46, 69],
+                                      "media_key": "3_2088371651599622144",
+                                      "media_results": {
+                                        "result": {
+                                          "media_key": "3_2088371651599622144"
+                                        }
+                                      },
+                                      "media_url_https": "https://pbs.twimg.com/media/HPti89SXYAAlqGF.jpg",
+                                      "original_info": {
+                                        "focus_rects": [
+                                          {
+                                            "h": 655,
+                                            "w": 1170,
+                                            "x": 0,
+                                            "y": 0
+                                          },
+                                          {
+                                            "h": 1078,
+                                            "w": 1078,
+                                            "x": 0,
+                                            "y": 0
+                                          },
+                                          {
+                                            "h": 1078,
+                                            "w": 946,
+                                            "x": 0,
+                                            "y": 0
+                                          },
+                                          {
+                                            "h": 1078,
+                                            "w": 539,
+                                            "x": 169,
+                                            "y": 0
+                                          },
+                                          {
+                                            "h": 1078,
+                                            "w": 1170,
+                                            "x": 0,
+                                            "y": 0
+                                          }
+                                        ],
+                                        "height": 1078,
+                                        "width": 1170
+                                      },
+                                      "sizes": {
+                                        "large": {
+                                          "h": 1078,
+                                          "resize": "fit",
+                                          "w": 1170
+                                        },
+                                        "medium": {
+                                          "h": 1078,
+                                          "resize": "fit",
+                                          "w": 1170
+                                        },
+                                        "small": {
+                                          "h": 627,
+                                          "resize": "fit",
+                                          "w": 680
+                                        },
+                                        "thumb": {
+                                          "h": 150,
+                                          "resize": "crop",
+                                          "w": 150
+                                        }
+                                      },
+                                      "type": "photo",
+                                      "url": "https://t.co/cKRtwoQx9a"
+                                    }
+                                  ],
+                                  "user_mentions": [
+                                    {
+                                      "id_str": "1072404907230060544",
+                                      "indices": [0, 14],
+                                      "name": "Genshin Impact",
+                                      "screen_name": "GenshinImpact"
+                                    }
+                                  ]
+                                },
+                                "extended_entities": {
+                                  "media": [
+                                    {
+                                      "allow_download_status": {
+                                        "allow_download": true
+                                      },
+                                      "display_url": "pic.x.com/cKRtwoQx9a",
+                                      "expanded_url": "https://x.com/DeviledEggs4372/status/2088371654921486382/photo/1",
+                                      "ext_media_availability": {
+                                        "status": "Available"
+                                      },
+                                      "features": {
+                                        "large": {
+                                          "faces": [
+                                            {
+                                              "h": 157,
+                                              "w": 157,
+                                              "x": 789,
+                                              "y": 372
+                                            }
+                                          ]
+                                        },
+                                        "medium": {
+                                          "faces": [
+                                            {
+                                              "h": 157,
+                                              "w": 157,
+                                              "x": 789,
+                                              "y": 372
+                                            }
+                                          ]
+                                        },
+                                        "orig": {
+                                          "faces": [
+                                            {
+                                              "h": 157,
+                                              "w": 157,
+                                              "x": 789,
+                                              "y": 372
+                                            }
+                                          ]
+                                        },
+                                        "small": {
+                                          "faces": [
+                                            {
+                                              "h": 91,
+                                              "w": 91,
+                                              "x": 458,
+                                              "y": 216
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "id_str": "2088371651599622144",
+                                      "indices": [46, 69],
+                                      "media_key": "3_2088371651599622144",
+                                      "media_results": {
+                                        "result": {
+                                          "media_key": "3_2088371651599622144"
+                                        }
+                                      },
+                                      "media_url_https": "https://pbs.twimg.com/media/HPti89SXYAAlqGF.jpg",
+                                      "original_info": {
+                                        "focus_rects": [
+                                          {
+                                            "h": 655,
+                                            "w": 1170,
+                                            "x": 0,
+                                            "y": 0
+                                          },
+                                          {
+                                            "h": 1078,
+                                            "w": 1078,
+                                            "x": 0,
+                                            "y": 0
+                                          },
+                                          {
+                                            "h": 1078,
+                                            "w": 946,
+                                            "x": 0,
+                                            "y": 0
+                                          },
+                                          {
+                                            "h": 1078,
+                                            "w": 539,
+                                            "x": 169,
+                                            "y": 0
+                                          },
+                                          {
+                                            "h": 1078,
+                                            "w": 1170,
+                                            "x": 0,
+                                            "y": 0
+                                          }
+                                        ],
+                                        "height": 1078,
+                                        "width": 1170
+                                      },
+                                      "sizes": {
+                                        "large": {
+                                          "h": 1078,
+                                          "resize": "fit",
+                                          "w": 1170
+                                        },
+                                        "medium": {
+                                          "h": 1078,
+                                          "resize": "fit",
+                                          "w": 1170
+                                        },
+                                        "small": {
+                                          "h": 627,
+                                          "resize": "fit",
+                                          "w": 680
+                                        },
+                                        "thumb": {
+                                          "h": 150,
+                                          "resize": "crop",
+                                          "w": 150
+                                        }
+                                      },
+                                      "type": "photo",
+                                      "url": "https://t.co/cKRtwoQx9a"
+                                    }
+                                  ]
+                                },
+                                "favorite_count": 0,
+                                "favorited": false,
+                                "full_text": "@GenshinImpact Server: America\nUID: 617829701 https://t.co/cKRtwoQx9a",
+                                "id_str": "2088371654921486382",
+                                "in_reply_to_screen_name": "GenshinImpact",
+                                "in_reply_to_status_id_str": "2087720798702498234",
+                                "in_reply_to_user_id_str": "1072404907230060544",
+                                "is_quote_status": false,
+                                "lang": "ca",
+                                "possibly_sensitive": false,
+                                "possibly_sensitive_editable": true,
+                                "quote_count": 0,
+                                "reply_count": 0,
+                                "retweet_count": 0,
+                                "retweeted": false,
+                                "user_id_str": "1449407285495832580"
+                              },
+                              "quick_promote_eligibility": {
+                                "eligibility": "IneligibleNotVerified"
+                              },
+                              "rest_id": "2088371654921486382",
+                              "source": "<a href=\"http://twitter.com/download/iphone\" rel=\"nofollow\">Twitter for iPhone</a>",
+                              "unmention_data": {},
+                              "views": {
+                                "count": "685",
+                                "state": "EnabledWithCount"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  ],
+                  "metadata": {
+                    "conversationMetadata": {
+                      "allTweetIds": ["2088371654921486382"],
+                      "enableDeduplication": true
+                    }
+                  }
+                },
+                "entryId": "conversationthread-2088371654921486382",
+                "sortIndex": "2088929116056190656"
+              },
+              {
+                "content": {
+                  "__typename": "TimelineTimelineModule",
+                  "clientEventInfo": {
+                    "component": "tweet",
+                    "details": {
+                      "conversationDetails": {
+                        "conversationSection": "HighQuality"
+                      },
+                      "timelinesDetails": {
+                        "controllerData": "DAACDAAEDAABCgABAAAAAAAAAAEKAAIAAAAAAAAAAAoAAwAAAaAKBN5LAAAAAA=="
+                      }
+                    }
+                  },
+                  "displayType": "VerticalConversation",
+                  "entryType": "TimelineTimelineModule",
+                  "items": [
+                    {
+                      "entryId": "conversationthread-2088038290435764252-tweet-2088038290435764252",
+                      "item": {
+                        "clientEventInfo": {
+                          "component": "tweet",
+                          "details": {
+                            "conversationDetails": {
+                              "conversationSection": "HighQuality"
+                            },
+                            "timelinesDetails": {
+                              "controllerData": "DAACDAAEDAABCgABAAAAAAAAAAEKAAIAAAAAAAAAAAoAAwAAAaAKBN5LAAAAAA=="
+                            }
+                          },
+                          "element": "tweet"
+                        },
+                        "itemContent": {
+                          "__typename": "TimelineTweet",
+                          "itemType": "TimelineTweet",
+                          "tweetDisplayType": "Tweet",
+                          "tweet_results": {
+                            "result": {
+                              "__typename": "Tweet",
+                              "core": {
+                                "user_results": {
+                                  "result": {
+                                    "__typename": "User",
+                                    "affiliates_highlighted_label": {},
+                                    "avatar": {
+                                      "image_url": "https://pbs.twimg.com/profile_images/1859084389461696514/vq9HQsU9_normal.jpg"
+                                    },
+                                    "core": {
+                                      "created_at": "Thu Oct 14 01:46:52 +0000 2021",
+                                      "name": "DigitalCyber640",
+                                      "screen_name": "DigitalCyber660"
+                                    },
+                                    "dm_permissions": {
+                                      "can_dm": false
+                                    },
+                                    "follow_request_sent": false,
+                                    "has_graduated_access": true,
+                                    "id": "VXNlcjoxNDQ4NDY1MTk4Mzk5MDMzMzQ3",
+                                    "is_blue_verified": false,
+                                    "legacy": {
+                                      "default_profile": true,
+                                      "default_profile_image": false,
+                                      "description": "",
+                                      "entities": {
+                                        "description": {}
+                                      },
+                                      "fast_followers_count": 0,
+                                      "favourites_count": 14,
+                                      "follow_request_sent": false,
+                                      "followers_count": 6,
+                                      "friends_count": 66,
+                                      "has_custom_timelines": false,
+                                      "is_translator": false,
+                                      "listed_count": 0,
+                                      "media_count": 3,
+                                      "needs_phone_verification": false,
+                                      "normal_followers_count": 6,
+                                      "notifications": false,
+                                      "possibly_sensitive": false,
+                                      "profile_banner_url": "",
+                                      "profile_interstitial_type": "",
+                                      "statuses_count": 46,
+                                      "time_zone": "",
+                                      "translator_type": "none",
+                                      "url": "",
+                                      "utc_offset": 0,
+                                      "want_retweets": false,
+                                      "withheld_description": "",
+                                      "withheld_scope": ""
+                                    },
+                                    "location": {
+                                      "location": ""
+                                    },
+                                    "media_permissions": {
+                                      "can_media_tag": false
+                                    },
+                                    "parody_commentary_fan_label": "None",
+                                    "privacy": {
+                                      "protected": false
+                                    },
+                                    "profile_bio": {
+                                      "description": ""
+                                    },
+                                    "profile_image_shape": "Circle",
+                                    "relationship_perspectives": {
+                                      "blocked_by": false,
+                                      "blocking": false,
+                                      "followed_by": false,
+                                      "following": false,
+                                      "muting": false
+                                    },
+                                    "rest_id": "1448465198399033347",
+                                    "super_follow_eligible": false,
+                                    "super_followed_by": false,
+                                    "super_following": false,
+                                    "verification": {
+                                      "verified": false
+                                    }
+                                  }
+                                }
+                              },
+                              "edit_control": {
+                                "edit_tweet_ids": ["2088038290435764252"],
+                                "editable_until_msecs": "1786665696000",
+                                "edits_remaining": "5",
+                                "is_edit_eligible": false
+                              },
+                              "grok_analysis_button": true,
+                              "grok_annotations": {},
+                              "has_birdwatch_notes": false,
+                              "is_translatable": false,
+                              "legacy": {
+                                "bookmark_count": 0,
+                                "bookmarked": false,
+                                "conversation_id_str": "2087720798702498234",
+                                "created_at": "Thu Aug 13 23:01:36 +0000 2026",
+                                "display_text_range": [15, 37],
+                                "entities": {
+                                  "media": [
+                                    {
+                                      "display_url": "pic.x.com/7fgNKaoO6q",
+                                      "expanded_url": "https://x.com/DigitalCyber660/status/2088038290435764252/photo/1",
+                                      "ext_media_availability": {
+                                        "status": "Available"
+                                      },
+                                      "features": {
+                                        "large": {
+                                          "faces": []
+                                        },
+                                        "medium": {
+                                          "faces": []
+                                        },
+                                        "orig": {
+                                          "faces": []
+                                        },
+                                        "small": {
+                                          "faces": []
+                                        }
+                                      },
+                                      "id_str": "2088038286417600512",
+                                      "indices": [38, 61],
+                                      "media_key": "3_2088038286417600512",
+                                      "media_results": {
+                                        "result": {
+                                          "media_key": "3_2088038286417600512"
+                                        }
+                                      },
+                                      "media_url_https": "https://pbs.twimg.com/media/HPozwjNWIAA5Cag.jpg",
+                                      "original_info": {
+                                        "focus_rects": [
+                                          {
+                                            "h": 722,
+                                            "w": 1290,
+                                            "x": 0,
+                                            "y": 641
+                                          },
+                                          {
+                                            "h": 1290,
+                                            "w": 1290,
+                                            "x": 0,
+                                            "y": 73
+                                          },
+                                          {
+                                            "h": 1363,
+                                            "w": 1196,
+                                            "x": 0,
+                                            "y": 0
+                                          },
+                                          {
+                                            "h": 1363,
+                                            "w": 682,
+                                            "x": 101,
+                                            "y": 0
+                                          },
+                                          {
+                                            "h": 1363,
+                                            "w": 1290,
+                                            "x": 0,
+                                            "y": 0
+                                          }
+                                        ],
+                                        "height": 1363,
+                                        "width": 1290
+                                      },
+                                      "sizes": {
+                                        "large": {
+                                          "h": 1363,
+                                          "resize": "fit",
+                                          "w": 1290
+                                        },
+                                        "medium": {
+                                          "h": 1200,
+                                          "resize": "fit",
+                                          "w": 1136
+                                        },
+                                        "small": {
+                                          "h": 680,
+                                          "resize": "fit",
+                                          "w": 644
+                                        },
+                                        "thumb": {
+                                          "h": 150,
+                                          "resize": "crop",
+                                          "w": 150
+                                        }
+                                      },
+                                      "type": "photo",
+                                      "url": "https://t.co/7fgNKaoO6q"
+                                    }
+                                  ],
+                                  "user_mentions": [
+                                    {
+                                      "id_str": "1072404907230060544",
+                                      "indices": [0, 14],
+                                      "name": "Genshin Impact",
+                                      "screen_name": "GenshinImpact"
+                                    }
+                                  ]
+                                },
+                                "extended_entities": {
+                                  "media": [
+                                    {
+                                      "display_url": "pic.x.com/7fgNKaoO6q",
+                                      "expanded_url": "https://x.com/DigitalCyber660/status/2088038290435764252/photo/1",
+                                      "ext_media_availability": {
+                                        "status": "Available"
+                                      },
+                                      "features": {
+                                        "large": {
+                                          "faces": []
+                                        },
+                                        "medium": {
+                                          "faces": []
+                                        },
+                                        "orig": {
+                                          "faces": []
+                                        },
+                                        "small": {
+                                          "faces": []
+                                        }
+                                      },
+                                      "id_str": "2088038286417600512",
+                                      "indices": [38, 61],
+                                      "media_key": "3_2088038286417600512",
+                                      "media_results": {
+                                        "result": {
+                                          "media_key": "3_2088038286417600512"
+                                        }
+                                      },
+                                      "media_url_https": "https://pbs.twimg.com/media/HPozwjNWIAA5Cag.jpg",
+                                      "original_info": {
+                                        "focus_rects": [
+                                          {
+                                            "h": 722,
+                                            "w": 1290,
+                                            "x": 0,
+                                            "y": 641
+                                          },
+                                          {
+                                            "h": 1290,
+                                            "w": 1290,
+                                            "x": 0,
+                                            "y": 73
+                                          },
+                                          {
+                                            "h": 1363,
+                                            "w": 1196,
+                                            "x": 0,
+                                            "y": 0
+                                          },
+                                          {
+                                            "h": 1363,
+                                            "w": 682,
+                                            "x": 101,
+                                            "y": 0
+                                          },
+                                          {
+                                            "h": 1363,
+                                            "w": 1290,
+                                            "x": 0,
+                                            "y": 0
+                                          }
+                                        ],
+                                        "height": 1363,
+                                        "width": 1290
+                                      },
+                                      "sizes": {
+                                        "large": {
+                                          "h": 1363,
+                                          "resize": "fit",
+                                          "w": 1290
+                                        },
+                                        "medium": {
+                                          "h": 1200,
+                                          "resize": "fit",
+                                          "w": 1136
+                                        },
+                                        "small": {
+                                          "h": 680,
+                                          "resize": "fit",
+                                          "w": 644
+                                        },
+                                        "thumb": {
+                                          "h": 150,
+                                          "resize": "crop",
+                                          "w": 150
+                                        }
+                                      },
+                                      "type": "photo",
+                                      "url": "https://t.co/7fgNKaoO6q"
+                                    }
+                                  ]
+                                },
+                                "favorite_count": 2,
+                                "favorited": false,
+                                "full_text": "@GenshinImpact America\nUID: 682126011 https://t.co/7fgNKaoO6q",
+                                "id_str": "2088038290435764252",
+                                "in_reply_to_screen_name": "GenshinImpact",
+                                "in_reply_to_status_id_str": "2087720798702498234",
+                                "in_reply_to_user_id_str": "1072404907230060544",
+                                "is_quote_status": false,
+                                "lang": "nl",
+                                "possibly_sensitive": false,
+                                "possibly_sensitive_editable": true,
+                                "quote_count": 0,
+                                "reply_count": 0,
+                                "retweet_count": 0,
+                                "retweeted": false,
+                                "user_id_str": "1448465198399033347"
+                              },
+                              "quick_promote_eligibility": {
+                                "eligibility": "IneligibleNotVerified"
+                              },
+                              "rest_id": "2088038290435764252",
+                              "source": "<a href=\"http://twitter.com/download/iphone\" rel=\"nofollow\">Twitter for iPhone</a>",
+                              "unmention_data": {},
+                              "views": {
+                                "count": "910",
+                                "state": "EnabledWithCount"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  ],
+                  "metadata": {
+                    "conversationMetadata": {
+                      "allTweetIds": ["2088038290435764252"],
+                      "enableDeduplication": true
+                    }
+                  }
+                },
+                "entryId": "conversationthread-2088038290435764252",
+                "sortIndex": "2088929116056190646"
+              },
+              {
+                "content": {
+                  "__typename": "TimelineTimelineModule",
+                  "clientEventInfo": {
+                    "component": "tweet",
+                    "details": {
+                      "conversationDetails": {
+                        "conversationSection": "HighQuality"
+                      },
+                      "timelinesDetails": {
+                        "controllerData": "DAACDAAEDAABCgABAAAAAAAAAAEKAAIAAAAAAAAAAAoAAwAAAaAKBN5LAAAAAA=="
+                      }
+                    }
+                  },
+                  "displayType": "VerticalConversation",
+                  "entryType": "TimelineTimelineModule",
+                  "items": [
+                    {
+                      "entryId": "conversationthread-2088891477866975636-tweet-2088891477866975636",
+                      "item": {
+                        "clientEventInfo": {
+                          "component": "tweet",
+                          "details": {
+                            "conversationDetails": {
+                              "conversationSection": "HighQuality"
+                            },
+                            "timelinesDetails": {
+                              "controllerData": "DAACDAAEDAABCgABAAAAAAAAAAEKAAIAAAAAAAAAAAoAAwAAAaAKBN5LAAAAAA=="
+                            }
+                          },
+                          "element": "tweet"
+                        },
+                        "itemContent": {
+                          "__typename": "TimelineTweet",
+                          "itemType": "TimelineTweet",
+                          "tweetDisplayType": "Tweet",
+                          "tweet_results": {
+                            "result": {
+                              "__typename": "Tweet",
+                              "core": {
+                                "user_results": {
+                                  "result": {
+                                    "__typename": "User",
+                                    "affiliates_highlighted_label": {},
+                                    "avatar": {
+                                      "image_url": "https://pbs.twimg.com/profile_images/2076382238925811712/0OojsidY_normal.jpg"
+                                    },
+                                    "core": {
+                                      "created_at": "Sun Jul 12 19:04:04 +0000 2026",
+                                      "name": "总而言之你很可爱",
+                                      "screen_name": "shiziyaoyaole"
+                                    },
+                                    "dm_permissions": {
+                                      "can_dm": false
+                                    },
+                                    "follow_request_sent": false,
+                                    "has_graduated_access": true,
+                                    "id": "VXNlcjoyMDc2MzgxNTM3NjU1MDM3OTUy",
+                                    "is_blue_verified": false,
+                                    "legacy": {
+                                      "default_profile": true,
+                                      "default_profile_image": false,
+                                      "description": "🍁☂️   🤕🎩    💜💚\n\n（🚫🔁）",
+                                      "entities": {
+                                        "description": {}
+                                      },
+                                      "fast_followers_count": 0,
+                                      "favourites_count": 301,
+                                      "follow_request_sent": false,
+                                      "followers_count": 1,
+                                      "friends_count": 29,
+                                      "has_custom_timelines": false,
+                                      "is_translator": false,
+                                      "listed_count": 0,
+                                      "media_count": 5,
+                                      "needs_phone_verification": false,
+                                      "normal_followers_count": 1,
+                                      "notifications": false,
+                                      "possibly_sensitive": false,
+                                      "profile_banner_url": "",
+                                      "profile_interstitial_type": "",
+                                      "statuses_count": 22,
+                                      "time_zone": "",
+                                      "translator_type": "none",
+                                      "url": "",
+                                      "utc_offset": 0,
+                                      "want_retweets": false,
+                                      "withheld_description": "",
+                                      "withheld_scope": ""
+                                    },
+                                    "location": {
+                                      "location": ""
+                                    },
+                                    "media_permissions": {
+                                      "can_media_tag": true
+                                    },
+                                    "parody_commentary_fan_label": "None",
+                                    "privacy": {
+                                      "protected": false
+                                    },
+                                    "profile_bio": {
+                                      "description": "🍁☂️   🤕🎩    💜💚\n\n（🚫🔁）"
+                                    },
+                                    "profile_description_language": "art",
+                                    "profile_image_shape": "Circle",
+                                    "relationship_perspectives": {
+                                      "blocked_by": false,
+                                      "blocking": false,
+                                      "followed_by": false,
+                                      "following": false,
+                                      "muting": false
+                                    },
+                                    "rest_id": "2076381537655037952",
+                                    "super_follow_eligible": false,
+                                    "super_followed_by": false,
+                                    "super_following": false,
+                                    "verification": {
+                                      "verified": false
+                                    }
+                                  }
+                                }
+                              },
+                              "edit_control": {
+                                "edit_tweet_ids": ["2088891477866975636"],
+                                "editable_until_msecs": "1786869112000",
+                                "edits_remaining": "5",
+                                "is_edit_eligible": false
+                              },
+                              "grok_analysis_button": true,
+                              "grok_annotations": {},
+                              "has_birdwatch_notes": false,
+                              "is_translatable": false,
+                              "legacy": {
+                                "bookmark_count": 0,
+                                "bookmarked": false,
+                                "conversation_id_str": "2087720798702498234",
+                                "created_at": "Sun Aug 16 07:31:52 +0000 2026",
+                                "display_text_range": [15, 40],
+                                "entities": {
+                                  "media": [
+                                    {
+                                      "display_url": "pic.x.com/FLR4s9qPyJ",
+                                      "expanded_url": "https://x.com/shiziyaoyaole/status/2088891477866975636/photo/1",
+                                      "ext_media_availability": {
+                                        "status": "Available"
+                                      },
+                                      "features": {
+                                        "large": {
+                                          "faces": []
+                                        },
+                                        "medium": {
+                                          "faces": []
+                                        },
+                                        "orig": {
+                                          "faces": []
+                                        },
+                                        "small": {
+                                          "faces": []
+                                        }
+                                      },
+                                      "id_str": "2088891469109309440",
+                                      "indices": [41, 64],
+                                      "media_key": "3_2088891469109309440",
+                                      "media_results": {
+                                        "result": {
+                                          "media_key": "3_2088891469109309440"
+                                        }
+                                      },
+                                      "media_url_https": "https://pbs.twimg.com/media/HP07uUaasAAD201.jpg",
+                                      "original_info": {
+                                        "focus_rects": [
+                                          {
+                                            "h": 528,
+                                            "w": 942,
+                                            "x": 0,
+                                            "y": 1016
+                                          },
+                                          {
+                                            "h": 942,
+                                            "w": 942,
+                                            "x": 0,
+                                            "y": 809
+                                          },
+                                          {
+                                            "h": 1074,
+                                            "w": 942,
+                                            "x": 0,
+                                            "y": 743
+                                          },
+                                          {
+                                            "h": 1884,
+                                            "w": 942,
+                                            "x": 0,
+                                            "y": 164
+                                          },
+                                          {
+                                            "h": 2048,
+                                            "w": 942,
+                                            "x": 0,
+                                            "y": 0
+                                          }
+                                        ],
+                                        "height": 2048,
+                                        "width": 942
+                                      },
+                                      "sizes": {
+                                        "large": {
+                                          "h": 2048,
+                                          "resize": "fit",
+                                          "w": 942
+                                        },
+                                        "medium": {
+                                          "h": 1200,
+                                          "resize": "fit",
+                                          "w": 552
+                                        },
+                                        "small": {
+                                          "h": 680,
+                                          "resize": "fit",
+                                          "w": 313
+                                        },
+                                        "thumb": {
+                                          "h": 150,
+                                          "resize": "crop",
+                                          "w": 150
+                                        }
+                                      },
+                                      "type": "photo",
+                                      "url": "https://t.co/FLR4s9qPyJ"
+                                    }
+                                  ],
+                                  "user_mentions": [
+                                    {
+                                      "id_str": "1072404907230060544",
+                                      "indices": [0, 14],
+                                      "name": "Genshin Impact",
+                                      "screen_name": "GenshinImpact"
+                                    }
+                                  ]
+                                },
+                                "extended_entities": {
+                                  "media": [
+                                    {
+                                      "display_url": "pic.x.com/FLR4s9qPyJ",
+                                      "expanded_url": "https://x.com/shiziyaoyaole/status/2088891477866975636/photo/1",
+                                      "ext_media_availability": {
+                                        "status": "Available"
+                                      },
+                                      "features": {
+                                        "large": {
+                                          "faces": []
+                                        },
+                                        "medium": {
+                                          "faces": []
+                                        },
+                                        "orig": {
+                                          "faces": []
+                                        },
+                                        "small": {
+                                          "faces": []
+                                        }
+                                      },
+                                      "id_str": "2088891469109309440",
+                                      "indices": [41, 64],
+                                      "media_key": "3_2088891469109309440",
+                                      "media_results": {
+                                        "result": {
+                                          "media_key": "3_2088891469109309440"
+                                        }
+                                      },
+                                      "media_url_https": "https://pbs.twimg.com/media/HP07uUaasAAD201.jpg",
+                                      "original_info": {
+                                        "focus_rects": [
+                                          {
+                                            "h": 528,
+                                            "w": 942,
+                                            "x": 0,
+                                            "y": 1016
+                                          },
+                                          {
+                                            "h": 942,
+                                            "w": 942,
+                                            "x": 0,
+                                            "y": 809
+                                          },
+                                          {
+                                            "h": 1074,
+                                            "w": 942,
+                                            "x": 0,
+                                            "y": 743
+                                          },
+                                          {
+                                            "h": 1884,
+                                            "w": 942,
+                                            "x": 0,
+                                            "y": 164
+                                          },
+                                          {
+                                            "h": 2048,
+                                            "w": 942,
+                                            "x": 0,
+                                            "y": 0
+                                          }
+                                        ],
+                                        "height": 2048,
+                                        "width": 942
+                                      },
+                                      "sizes": {
+                                        "large": {
+                                          "h": 2048,
+                                          "resize": "fit",
+                                          "w": 942
+                                        },
+                                        "medium": {
+                                          "h": 1200,
+                                          "resize": "fit",
+                                          "w": 552
+                                        },
+                                        "small": {
+                                          "h": 680,
+                                          "resize": "fit",
+                                          "w": 313
+                                        },
+                                        "thumb": {
+                                          "h": 150,
+                                          "resize": "crop",
+                                          "w": 150
+                                        }
+                                      },
+                                      "type": "photo",
+                                      "url": "https://t.co/FLR4s9qPyJ"
+                                    }
+                                  ]
+                                },
+                                "favorite_count": 0,
+                                "favorited": false,
+                                "full_text": "@GenshinImpact UID275374894\nChina server https://t.co/FLR4s9qPyJ",
+                                "id_str": "2088891477866975636",
+                                "in_reply_to_screen_name": "GenshinImpact",
+                                "in_reply_to_status_id_str": "2087720798702498234",
+                                "in_reply_to_user_id_str": "1072404907230060544",
+                                "is_quote_status": false,
+                                "lang": "tl",
+                                "possibly_sensitive": false,
+                                "possibly_sensitive_editable": true,
+                                "quote_count": 0,
+                                "reply_count": 0,
+                                "retweet_count": 0,
+                                "retweeted": false,
+                                "user_id_str": "2076381537655037952"
+                              },
+                              "quick_promote_eligibility": {
+                                "eligibility": "IneligibleNotVerified"
+                              },
+                              "rest_id": "2088891477866975636",
+                              "source": "<a href=\"http://twitter.com/download/iphone\" rel=\"nofollow\">Twitter for iPhone</a>",
+                              "unmention_data": {},
+                              "views": {
+                                "count": "134",
+                                "state": "EnabledWithCount"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  ],
+                  "metadata": {
+                    "conversationMetadata": {
+                      "allTweetIds": ["2088891477866975636"],
+                      "enableDeduplication": true
+                    }
+                  }
+                },
+                "entryId": "conversationthread-2088891477866975636",
+                "sortIndex": "2088929116056190636"
+              },
+              {
+                "content": {
+                  "__typename": "TimelineTimelineModule",
+                  "clientEventInfo": {
+                    "component": "tweet",
+                    "details": {
+                      "conversationDetails": {
+                        "conversationSection": "HighQuality"
+                      },
+                      "timelinesDetails": {
+                        "controllerData": "DAACDAAEDAABCgABAAAAAAAAAAEKAAIAAAAAAAAAAAoAAwAAAaAKBN5LAAAAAA=="
+                      }
+                    }
+                  },
+                  "displayType": "VerticalConversation",
+                  "entryType": "TimelineTimelineModule",
+                  "items": [
+                    {
+                      "entryId": "conversationthread-2088845155126362586-tweet-2088845155126362586",
+                      "item": {
+                        "clientEventInfo": {
+                          "component": "tweet",
+                          "details": {
+                            "conversationDetails": {
+                              "conversationSection": "HighQuality"
+                            },
+                            "timelinesDetails": {
+                              "controllerData": "DAACDAAEDAABCgABAAAAAAAAAAEKAAIAAAAAAAAAAAoAAwAAAaAKBN5LAAAAAA=="
+                            }
+                          },
+                          "element": "tweet"
+                        },
+                        "itemContent": {
+                          "__typename": "TimelineTweet",
+                          "itemType": "TimelineTweet",
+                          "tweetDisplayType": "Tweet",
+                          "tweet_results": {
+                            "result": {
+                              "__typename": "Tweet",
+                              "core": {
+                                "user_results": {
+                                  "result": {
+                                    "__typename": "User",
+                                    "affiliates_highlighted_label": {},
+                                    "avatar": {
+                                      "image_url": "https://pbs.twimg.com/profile_images/2048662269467541504/WyUqCqad_normal.jpg"
+                                    },
+                                    "core": {
+                                      "created_at": "Mon May 16 23:39:16 +0000 2022",
+                                      "name": "EKO 🍉",
+                                      "screen_name": "EKOing_"
+                                    },
+                                    "dm_permissions": {
+                                      "can_dm": false
+                                    },
+                                    "follow_request_sent": false,
+                                    "has_graduated_access": true,
+                                    "id": "VXNlcjoxNTI2MzQ2NTM4MTU0MTk2OTky",
+                                    "is_blue_verified": false,
+                                    "legacy": {
+                                      "default_profile": true,
+                                      "default_profile_image": false,
+                                      "description": "19 // any pronouns // i draw when my education allows me to (=´∀｀)",
+                                      "entities": {
+                                        "description": {}
+                                      },
+                                      "fast_followers_count": 0,
+                                      "favourites_count": 18228,
+                                      "follow_request_sent": false,
+                                      "followers_count": 9,
+                                      "friends_count": 79,
+                                      "has_custom_timelines": false,
+                                      "is_translator": false,
+                                      "listed_count": 0,
+                                      "media_count": 69,
+                                      "needs_phone_verification": false,
+                                      "normal_followers_count": 9,
+                                      "notifications": false,
+                                      "possibly_sensitive": false,
+                                      "profile_banner_url": "https://pbs.twimg.com/profile_banners/1526346538154196992/1707238877",
+                                      "profile_interstitial_type": "",
+                                      "statuses_count": 657,
+                                      "time_zone": "",
+                                      "translator_type": "none",
+                                      "url": "",
+                                      "utc_offset": 0,
+                                      "want_retweets": false,
+                                      "withheld_description": "",
+                                      "withheld_scope": ""
+                                    },
+                                    "location": {
+                                      "location": ""
+                                    },
+                                    "media_permissions": {
+                                      "can_media_tag": false
+                                    },
+                                    "parody_commentary_fan_label": "None",
+                                    "privacy": {
+                                      "protected": false
+                                    },
+                                    "profile_bio": {
+                                      "description": "19 // any pronouns // i draw when my education allows me to (=´∀｀)"
+                                    },
+                                    "profile_description_language": "en",
+                                    "profile_image_shape": "Circle",
+                                    "relationship_perspectives": {
+                                      "blocked_by": false,
+                                      "blocking": false,
+                                      "followed_by": false,
+                                      "following": false,
+                                      "muting": false
+                                    },
+                                    "rest_id": "1526346538154196992",
+                                    "super_follow_eligible": false,
+                                    "super_followed_by": false,
+                                    "super_following": false,
+                                    "verification": {
+                                      "verified": false
+                                    }
+                                  }
+                                }
+                              },
+                              "edit_control": {
+                                "edit_tweet_ids": ["2088845155126362586"],
+                                "editable_until_msecs": "1786858068000",
+                                "edits_remaining": "5",
+                                "is_edit_eligible": false
+                              },
+                              "grok_analysis_button": true,
+                              "grok_annotations": {},
+                              "has_birdwatch_notes": false,
+                              "is_translatable": false,
+                              "legacy": {
+                                "bookmark_count": 0,
+                                "bookmarked": false,
+                                "conversation_id_str": "2087720798702498234",
+                                "created_at": "Sun Aug 16 04:27:48 +0000 2026",
+                                "display_text_range": [15, 45],
+                                "entities": {
+                                  "media": [
+                                    {
+                                      "display_url": "pic.x.com/3gva7qCun8",
+                                      "expanded_url": "https://x.com/EKOing_/status/2088845155126362586/photo/1",
+                                      "ext_media_availability": {
+                                        "status": "Available"
+                                      },
+                                      "features": {
+                                        "large": {
+                                          "faces": []
+                                        },
+                                        "medium": {
+                                          "faces": []
+                                        },
+                                        "orig": {
+                                          "faces": []
+                                        },
+                                        "small": {
+                                          "faces": []
+                                        }
+                                      },
+                                      "id_str": "2088845151615713280",
+                                      "indices": [46, 69],
+                                      "media_key": "3_2088845151615713280",
+                                      "media_results": {
+                                        "result": {
+                                          "media_key": "3_2088845151615713280"
+                                        }
+                                      },
+                                      "media_url_https": "https://pbs.twimg.com/media/HP0RmSTaAAA928e.jpg",
+                                      "original_info": {
+                                        "focus_rects": [
+                                          {
+                                            "h": 660,
+                                            "w": 1179,
+                                            "x": 0,
+                                            "y": 566
+                                          },
+                                          {
+                                            "h": 1179,
+                                            "w": 1179,
+                                            "x": 0,
+                                            "y": 47
+                                          },
+                                          {
+                                            "h": 1226,
+                                            "w": 1075,
+                                            "x": 0,
+                                            "y": 0
+                                          },
+                                          {
+                                            "h": 1226,
+                                            "w": 613,
+                                            "x": 153,
+                                            "y": 0
+                                          },
+                                          {
+                                            "h": 1226,
+                                            "w": 1179,
+                                            "x": 0,
+                                            "y": 0
+                                          }
+                                        ],
+                                        "height": 1226,
+                                        "width": 1179
+                                      },
+                                      "sizes": {
+                                        "large": {
+                                          "h": 1226,
+                                          "resize": "fit",
+                                          "w": 1179
+                                        },
+                                        "medium": {
+                                          "h": 1200,
+                                          "resize": "fit",
+                                          "w": 1154
+                                        },
+                                        "small": {
+                                          "h": 680,
+                                          "resize": "fit",
+                                          "w": 654
+                                        },
+                                        "thumb": {
+                                          "h": 150,
+                                          "resize": "crop",
+                                          "w": 150
+                                        }
+                                      },
+                                      "type": "photo",
+                                      "url": "https://t.co/3gva7qCun8"
+                                    }
+                                  ],
+                                  "user_mentions": [
+                                    {
+                                      "id_str": "1072404907230060544",
+                                      "indices": [0, 14],
+                                      "name": "Genshin Impact",
+                                      "screen_name": "GenshinImpact"
+                                    }
+                                  ]
+                                },
+                                "extended_entities": {
+                                  "media": [
+                                    {
+                                      "display_url": "pic.x.com/3gva7qCun8",
+                                      "expanded_url": "https://x.com/EKOing_/status/2088845155126362586/photo/1",
+                                      "ext_media_availability": {
+                                        "status": "Available"
+                                      },
+                                      "features": {
+                                        "large": {
+                                          "faces": []
+                                        },
+                                        "medium": {
+                                          "faces": []
+                                        },
+                                        "orig": {
+                                          "faces": []
+                                        },
+                                        "small": {
+                                          "faces": []
+                                        }
+                                      },
+                                      "id_str": "2088845151615713280",
+                                      "indices": [46, 69],
+                                      "media_key": "3_2088845151615713280",
+                                      "media_results": {
+                                        "result": {
+                                          "media_key": "3_2088845151615713280"
+                                        }
+                                      },
+                                      "media_url_https": "https://pbs.twimg.com/media/HP0RmSTaAAA928e.jpg",
+                                      "original_info": {
+                                        "focus_rects": [
+                                          {
+                                            "h": 660,
+                                            "w": 1179,
+                                            "x": 0,
+                                            "y": 566
+                                          },
+                                          {
+                                            "h": 1179,
+                                            "w": 1179,
+                                            "x": 0,
+                                            "y": 47
+                                          },
+                                          {
+                                            "h": 1226,
+                                            "w": 1075,
+                                            "x": 0,
+                                            "y": 0
+                                          },
+                                          {
+                                            "h": 1226,
+                                            "w": 613,
+                                            "x": 153,
+                                            "y": 0
+                                          },
+                                          {
+                                            "h": 1226,
+                                            "w": 1179,
+                                            "x": 0,
+                                            "y": 0
+                                          }
+                                        ],
+                                        "height": 1226,
+                                        "width": 1179
+                                      },
+                                      "sizes": {
+                                        "large": {
+                                          "h": 1226,
+                                          "resize": "fit",
+                                          "w": 1179
+                                        },
+                                        "medium": {
+                                          "h": 1200,
+                                          "resize": "fit",
+                                          "w": 1154
+                                        },
+                                        "small": {
+                                          "h": 680,
+                                          "resize": "fit",
+                                          "w": 654
+                                        },
+                                        "thumb": {
+                                          "h": 150,
+                                          "resize": "crop",
+                                          "w": 150
+                                        }
+                                      },
+                                      "type": "photo",
+                                      "url": "https://t.co/3gva7qCun8"
+                                    }
+                                  ]
+                                },
+                                "favorite_count": 0,
+                                "favorited": false,
+                                "full_text": "@GenshinImpact UID: 621905131\nServer: America https://t.co/3gva7qCun8",
+                                "id_str": "2088845155126362586",
+                                "in_reply_to_screen_name": "GenshinImpact",
+                                "in_reply_to_status_id_str": "2087720798702498234",
+                                "in_reply_to_user_id_str": "1072404907230060544",
+                                "is_quote_status": false,
+                                "lang": "pt",
+                                "possibly_sensitive": false,
+                                "possibly_sensitive_editable": true,
+                                "quote_count": 0,
+                                "reply_count": 0,
+                                "retweet_count": 0,
+                                "retweeted": false,
+                                "user_id_str": "1526346538154196992"
+                              },
+                              "quick_promote_eligibility": {
+                                "eligibility": "IneligibleNotVerified"
+                              },
+                              "rest_id": "2088845155126362586",
+                              "source": "<a href=\"http://twitter.com/download/iphone\" rel=\"nofollow\">Twitter for iPhone</a>",
+                              "unmention_data": {},
+                              "views": {
+                                "count": "120",
+                                "state": "EnabledWithCount"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  ],
+                  "metadata": {
+                    "conversationMetadata": {
+                      "allTweetIds": ["2088845155126362586"],
+                      "enableDeduplication": true
+                    }
+                  }
+                },
+                "entryId": "conversationthread-2088845155126362586",
+                "sortIndex": "2088929116056190626"
+              },
+              {
+                "content": {
+                  "__typename": "TimelineTimelineModule",
+                  "clientEventInfo": {
+                    "component": "tweet",
+                    "details": {
+                      "conversationDetails": {
+                        "conversationSection": "HighQuality"
+                      },
+                      "timelinesDetails": {
+                        "controllerData": "DAACDAAEDAABCgABAAAAAAAAAAEKAAIAAAAAAAAAAAoAAwAAAaAKBN5LAAAAAA=="
+                      }
+                    }
+                  },
+                  "displayType": "VerticalConversation",
+                  "entryType": "TimelineTimelineModule",
+                  "items": [
+                    {
+                      "entryId": "conversationthread-2088203233244459497-tweet-2088203233244459497",
+                      "item": {
+                        "clientEventInfo": {
+                          "component": "tweet",
+                          "details": {
+                            "conversationDetails": {
+                              "conversationSection": "HighQuality"
+                            },
+                            "timelinesDetails": {
+                              "controllerData": "DAACDAAEDAABCgABAAAAAAAAAAEKAAIAAAAAAAAAAAoAAwAAAaAKBN5LAAAAAA=="
+                            }
+                          },
+                          "element": "tweet"
+                        },
+                        "itemContent": {
+                          "__typename": "TimelineTweet",
+                          "itemType": "TimelineTweet",
+                          "tweetDisplayType": "Tweet",
+                          "tweet_results": {
+                            "result": {
+                              "__typename": "Tweet",
+                              "core": {
+                                "user_results": {
+                                  "result": {
+                                    "__typename": "User",
+                                    "affiliates_highlighted_label": {},
+                                    "avatar": {
+                                      "image_url": "https://pbs.twimg.com/profile_images/2075154775096901632/0LLc8ShP_normal.jpg"
+                                    },
+                                    "core": {
+                                      "created_at": "Fri Jun 05 19:57:53 +0000 2020",
+                                      "name": "ami",
+                                      "screen_name": "leeknowbites"
+                                    },
+                                    "dm_permissions": {
+                                      "can_dm": false
+                                    },
+                                    "follow_request_sent": false,
+                                    "has_graduated_access": true,
+                                    "id": "VXNlcjoxMjY4OTk1NDUxMjIwNjI3NDU3",
+                                    "is_blue_verified": false,
+                                    "legacy": {
+                                      "default_profile": true,
+                                      "default_profile_image": false,
+                                      "description": "leeknowuist #minsung",
+                                      "entities": {
+                                        "description": {}
+                                      },
+                                      "fast_followers_count": 0,
+                                      "favourites_count": 19816,
+                                      "follow_request_sent": false,
+                                      "followers_count": 160,
+                                      "friends_count": 936,
+                                      "has_custom_timelines": false,
+                                      "is_translator": false,
+                                      "listed_count": 1,
+                                      "media_count": 3,
+                                      "needs_phone_verification": false,
+                                      "normal_followers_count": 160,
+                                      "notifications": false,
+                                      "possibly_sensitive": false,
+                                      "profile_banner_url": "https://pbs.twimg.com/profile_banners/1268995451220627457/1776813296",
+                                      "profile_interstitial_type": "",
+                                      "statuses_count": 3471,
+                                      "time_zone": "",
+                                      "translator_type": "none",
+                                      "url": "",
+                                      "utc_offset": 0,
+                                      "want_retweets": false,
+                                      "withheld_description": "",
+                                      "withheld_scope": ""
+                                    },
+                                    "location": {
+                                      "location": "૮⁔•⤙•⁔ა"
+                                    },
+                                    "media_permissions": {
+                                      "can_media_tag": false
+                                    },
+                                    "parody_commentary_fan_label": "None",
+                                    "privacy": {
+                                      "protected": false
+                                    },
+                                    "profile_bio": {
+                                      "description": "leeknowuist #minsung"
+                                    },
+                                    "profile_image_shape": "Circle",
+                                    "relationship_perspectives": {
+                                      "blocked_by": false,
+                                      "blocking": false,
+                                      "followed_by": false,
+                                      "following": false,
+                                      "muting": false
+                                    },
+                                    "rest_id": "1268995451220627457",
+                                    "super_follow_eligible": false,
+                                    "super_followed_by": false,
+                                    "super_following": false,
+                                    "verification": {
+                                      "verified": false
+                                    }
+                                  }
+                                }
+                              },
+                              "edit_control": {
+                                "edit_tweet_ids": ["2088203233244459497"],
+                                "editable_until_msecs": "1786705022000",
+                                "edits_remaining": "5",
+                                "is_edit_eligible": false
+                              },
+                              "grok_analysis_button": true,
+                              "grok_annotations": {},
+                              "has_birdwatch_notes": false,
+                              "is_translatable": false,
+                              "legacy": {
+                                "bookmark_count": 0,
+                                "bookmarked": false,
+                                "conversation_id_str": "2087720798702498234",
+                                "created_at": "Fri Aug 14 09:57:02 +0000 2026",
+                                "display_text_range": [15, 38],
+                                "entities": {
+                                  "media": [
+                                    {
+                                      "allow_download_status": {
+                                        "allow_download": true
+                                      },
+                                      "display_url": "pic.x.com/TVF2OWDtve",
+                                      "expanded_url": "https://x.com/leeknowbites/status/2088203233244459497/photo/1",
+                                      "ext_media_availability": {
+                                        "status": "Available"
+                                      },
+                                      "features": {
+                                        "large": {
+                                          "faces": []
+                                        },
+                                        "medium": {
+                                          "faces": []
+                                        },
+                                        "orig": {
+                                          "faces": []
+                                        },
+                                        "small": {
+                                          "faces": []
+                                        }
+                                      },
+                                      "id_str": "2088203229440131072",
+                                      "indices": [39, 62],
+                                      "media_key": "3_2088203229440131072",
+                                      "media_results": {
+                                        "result": {
+                                          "media_key": "3_2088203229440131072"
+                                        }
+                                      },
+                                      "media_url_https": "https://pbs.twimg.com/media/HPrJxf2aQAANleg.jpg",
+                                      "original_info": {
+                                        "focus_rects": [
+                                          {
+                                            "h": 605,
+                                            "w": 1080,
+                                            "x": 0,
+                                            "y": 475
+                                          },
+                                          {
+                                            "h": 1080,
+                                            "w": 1080,
+                                            "x": 0,
+                                            "y": 0
+                                          },
+                                          {
+                                            "h": 1080,
+                                            "w": 947,
+                                            "x": 133,
+                                            "y": 0
+                                          },
+                                          {
+                                            "h": 1080,
+                                            "w": 540,
+                                            "x": 459,
+                                            "y": 0
+                                          },
+                                          {
+                                            "h": 1080,
+                                            "w": 1080,
+                                            "x": 0,
+                                            "y": 0
+                                          }
+                                        ],
+                                        "height": 1080,
+                                        "width": 1080
+                                      },
+                                      "sizes": {
+                                        "large": {
+                                          "h": 1080,
+                                          "resize": "fit",
+                                          "w": 1080
+                                        },
+                                        "medium": {
+                                          "h": 1080,
+                                          "resize": "fit",
+                                          "w": 1080
+                                        },
+                                        "small": {
+                                          "h": 680,
+                                          "resize": "fit",
+                                          "w": 680
+                                        },
+                                        "thumb": {
+                                          "h": 150,
+                                          "resize": "crop",
+                                          "w": 150
+                                        }
+                                      },
+                                      "type": "photo",
+                                      "url": "https://t.co/TVF2OWDtve"
+                                    }
+                                  ],
+                                  "user_mentions": [
+                                    {
+                                      "id_str": "1072404907230060544",
+                                      "indices": [0, 14],
+                                      "name": "Genshin Impact",
+                                      "screen_name": "GenshinImpact"
+                                    }
+                                  ]
+                                },
+                                "extended_entities": {
+                                  "media": [
+                                    {
+                                      "allow_download_status": {
+                                        "allow_download": true
+                                      },
+                                      "display_url": "pic.x.com/TVF2OWDtve",
+                                      "expanded_url": "https://x.com/leeknowbites/status/2088203233244459497/photo/1",
+                                      "ext_media_availability": {
+                                        "status": "Available"
+                                      },
+                                      "features": {
+                                        "large": {
+                                          "faces": []
+                                        },
+                                        "medium": {
+                                          "faces": []
+                                        },
+                                        "orig": {
+                                          "faces": []
+                                        },
+                                        "small": {
+                                          "faces": []
+                                        }
+                                      },
+                                      "id_str": "2088203229440131072",
+                                      "indices": [39, 62],
+                                      "media_key": "3_2088203229440131072",
+                                      "media_results": {
+                                        "result": {
+                                          "media_key": "3_2088203229440131072"
+                                        }
+                                      },
+                                      "media_url_https": "https://pbs.twimg.com/media/HPrJxf2aQAANleg.jpg",
+                                      "original_info": {
+                                        "focus_rects": [
+                                          {
+                                            "h": 605,
+                                            "w": 1080,
+                                            "x": 0,
+                                            "y": 475
+                                          },
+                                          {
+                                            "h": 1080,
+                                            "w": 1080,
+                                            "x": 0,
+                                            "y": 0
+                                          },
+                                          {
+                                            "h": 1080,
+                                            "w": 947,
+                                            "x": 133,
+                                            "y": 0
+                                          },
+                                          {
+                                            "h": 1080,
+                                            "w": 540,
+                                            "x": 459,
+                                            "y": 0
+                                          },
+                                          {
+                                            "h": 1080,
+                                            "w": 1080,
+                                            "x": 0,
+                                            "y": 0
+                                          }
+                                        ],
+                                        "height": 1080,
+                                        "width": 1080
+                                      },
+                                      "sizes": {
+                                        "large": {
+                                          "h": 1080,
+                                          "resize": "fit",
+                                          "w": 1080
+                                        },
+                                        "medium": {
+                                          "h": 1080,
+                                          "resize": "fit",
+                                          "w": 1080
+                                        },
+                                        "small": {
+                                          "h": 680,
+                                          "resize": "fit",
+                                          "w": 680
+                                        },
+                                        "thumb": {
+                                          "h": 150,
+                                          "resize": "crop",
+                                          "w": 150
+                                        }
+                                      },
+                                      "type": "photo",
+                                      "url": "https://t.co/TVF2OWDtve"
+                                    }
+                                  ]
+                                },
+                                "favorite_count": 0,
+                                "favorited": false,
+                                "full_text": "@GenshinImpact America\nUID : 606544455 https://t.co/TVF2OWDtve",
+                                "id_str": "2088203233244459497",
+                                "in_reply_to_screen_name": "GenshinImpact",
+                                "in_reply_to_status_id_str": "2087720798702498234",
+                                "in_reply_to_user_id_str": "1072404907230060544",
+                                "is_quote_status": false,
+                                "lang": "nl",
+                                "possibly_sensitive": false,
+                                "possibly_sensitive_editable": true,
+                                "quote_count": 0,
+                                "reply_count": 0,
+                                "retweet_count": 0,
+                                "retweeted": false,
+                                "user_id_str": "1268995451220627457"
+                              },
+                              "quick_promote_eligibility": {
+                                "eligibility": "IneligibleNotVerified"
+                              },
+                              "rest_id": "2088203233244459497",
+                              "source": "<a href=\"http://twitter.com/download/iphone\" rel=\"nofollow\">Twitter for iPhone</a>",
+                              "unmention_data": {},
+                              "views": {
+                                "count": "220",
+                                "state": "EnabledWithCount"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  ],
+                  "metadata": {
+                    "conversationMetadata": {
+                      "allTweetIds": ["2088203233244459497"],
+                      "enableDeduplication": true
+                    }
+                  }
+                },
+                "entryId": "conversationthread-2088203233244459497",
+                "sortIndex": "2088929116056190616"
+              },
+              {
+                "content": {
+                  "__typename": "TimelineTimelineCursor",
+                  "cursorType": "Bottom",
+                  "entryType": "TimelineTimelineCursor",
+                  "value": "DAAKCgABHP1d9qN__pULAAIAAAGoRW1QQzZ3QUFBZlEvZ0dKTjB2R3AvQUFBQUNVYytvNjM4OVpnRkJ6NmYzb0ZtZ0dDSFBvcVpaUmJZTVFjL1Z5dm5sc1J3eHo3dlFLWm1pQ2FIUHV4K2lJVzRiOGMvUzMwWVZwd0R4ejhubVhWbHBGaUhQeWFSaTZhb0FrYyszbUlVSmJ3cHh6NnljYmdXN0hwSFAwdFFmL2JzZE1jKzNCR3hkdHdIQno3WXZTYWx3QXVIUDBEcDA5V1FUUWMrbUZyREZwaG1SejlOendMMjVFc0hQMVpuS0tiMFU0Yyt6RU9HMXZCSlJ6NlVBSTZWaEhoSFB5cHVzaVhJUWNjL05vWEhScXdMUno5Tzd0UW1oR1VIUHlQQ1YxWFVLa2MrbHRyWkJjQVNCejdjQVRHbGhIaUhQenhubDdYWVhNYysrQUpVZHJBZHh6OVJRaUwyckZ4SFBwaDk4cVhzRkljL05QbGVaZlIvUno2TThNaTFuQWNIUGtUQVZUYmNib2MvQThLVFZjZ3l4ejgrVzlYRzlET0hQMFJtZllhUWRvYy9SN2haQmJRbUE9PQgAAwAAAAILAAQAAAAGQm90dG9tAAA"
+                },
+                "entryId": "cursor-bottom-2088929116056190615",
+                "sortIndex": "2088929116056190615"
+              }
+            ],
+            "type": "TimelineAddEntries"
+          },
+          {
+            "direction": "Top",
+            "type": "TimelineTerminateTimeline"
+          }
+        ],
+        "metadata": {
+          "scribeConfig": {
+            "page": "ranked_replies"
+          }
+        }
+      }
+    }
+  },
+  "message": "Request Success"
+}

--- a/src/nonebot_plugin_parser_lite/parsers/x/__init__.py
+++ b/src/nonebot_plugin_parser_lite/parsers/x/__init__.py
@@ -14,18 +14,81 @@ from ..base import (
     PlatformEnum,
     handle,
 )
-from .model import TweetEntry
+from .model import TweetCard, TweetEntry
+from .util import parse_link_card
+
+
+def _get_timeline_tweet_result(entry: dict) -> dict | None:
+    """
+    从单个 entry 中提取 tweet_results.result
+    (Tweet 或 TweetWithVisibilityResults)
+    """
+    content = entry.get("content")
+    if not isinstance(content, dict):
+        return None
+
+    if (
+        content.get("__typename") != "TimelineTimelineItem"
+        or content.get("itemContent", {}).get("__typename") != "TimelineTweet"
+    ):
+        return None
+
+    tweet_results = content["itemContent"].get("tweet_results") or {}
+    result = tweet_results.get("result") or {}
+    typename = result.get("__typename")
+    if typename not in {"Tweet", "TweetWithVisibilityResults"}:
+        return None
+    return tweet_results
+
+
+def _get_rest_id(result: dict) -> str | None:
+    """兼容 Tweet / TweetWithVisibilityResults，取出真实 tweet 的 rest_id."""
+    typename = result.get("__typename")
+    if typename == "Tweet":
+        return result.get("rest_id")
+    if typename == "TweetWithVisibilityResults":
+        inner = result.get("tweet") or {}
+        return inner.get("rest_id")
+    return None
 
 
 class XParser(BaseParser):
     platform: ClassVar[Platform] = Platform(name=PlatformEnum.X, display_name="X")
 
+    def __init__(self):
+        super().__init__()
+        self.headers.update(
+            {"Host": "easycomment.ai", "Content-Type": "application/json"}
+        )
+
+    def _get_link_card(self, card: TweetCard | None) -> ContentItem | None:
+        """将 X 的 unified_card 或传统 binding_values 转换为链接卡片"""
+        if link_card := parse_link_card(card):
+            return self.create_link(
+                url=link_card.url,
+                title=link_card.title,
+                site_name=link_card.site_name,
+                description=link_card.description,
+                preview_url=link_card.preview_url,
+                cache_key=f"x:link:{link_card.url}",
+            )
+        return None
+
     def collect_data(self, raw: TweetEntry, is_repost: bool = False) -> ParseResult:
         tweet = raw.result.as_tweet
         legacy = tweet.legacy
 
-        content: list[ContentItem] = [legacy.text]
+        content: list[ContentItem] = [tweet.text]
         content.extend(legacy.medias)
+        if article_cover := tweet.article_cover_url:
+            content.append(
+                self.create_image(
+                    url=article_cover,
+                    cache_key=f"x:article-cover:{tweet.rest_id}",
+                )
+            )
+        if link_card := self._get_link_card(tweet.card):
+            content.append(link_card)
 
         user = tweet.core.user_results.result
 
@@ -54,39 +117,6 @@ class XParser(BaseParser):
             repost=repost,
         )
 
-    def _get_timeline_tweet_result(self, entry: dict) -> dict | None:
-        """
-        从单个 entry 中提取 tweet_results.result
-        (Tweet 或 TweetWithVisibilityResults)
-        """
-        content = entry.get("content")
-        if not isinstance(content, dict):
-            return None
-
-        if (
-            content.get("__typename") != "TimelineTimelineItem"
-            or content.get("itemContent", {}).get("__typename") != "TimelineTweet"
-        ):
-            return None
-
-        tweet_results = content["itemContent"].get("tweet_results") or {}
-        result = tweet_results.get("result") or {}
-        typename = result.get("__typename")
-        if typename not in {"Tweet", "TweetWithVisibilityResults"}:
-            return None
-        return tweet_results
-
-    @staticmethod
-    def _get_rest_id(result: dict) -> str | None:
-        """兼容 Tweet / TweetWithVisibilityResults，取出真实 tweet 的 rest_id."""
-        typename = result.get("__typename")
-        if typename == "Tweet":
-            return result.get("rest_id")
-        if typename == "TweetWithVisibilityResults":
-            inner = result.get("tweet") or {}
-            return inner.get("rest_id")
-        return None
-
     @handle("twitter.com", r"twitter.com/[0-9-a-zA-Z_]{1,20}/status/([0-9]+)")
     @handle("x.com", r"x.com/[0-9-a-zA-Z_]{1,20}/status/([0-9]+)")
     async def _parse(self, searched: MatchWithParams) -> ParseResult:
@@ -95,8 +125,7 @@ class XParser(BaseParser):
         response = await DOWNLOADER.client.post(
             "https://easycomment.ai/api/twitter/v1/free/get-tweet-detail",
             json={"pid": tweet_id},
-            headers=self.headers
-            | {"Host": "easycomment.ai", "Content-Type": "application/json"},
+            headers=self.headers,
             use_curl_cffi=True,
         )
         try:
@@ -127,12 +156,12 @@ class XParser(BaseParser):
         root_entry: dict | None = None
 
         for entry in entries:
-            tweet_results = self._get_timeline_tweet_result(entry)
+            tweet_results = _get_timeline_tweet_result(entry)
             if not tweet_results:
                 continue
 
             result = tweet_results.get("result") or {}
-            rest_id = self._get_rest_id(result)
+            rest_id = _get_rest_id(result)
             if not rest_id:
                 continue
 

--- a/src/nonebot_plugin_parser_lite/parsers/x/model.py
+++ b/src/nonebot_plugin_parser_lite/parsers/x/model.py
@@ -46,6 +46,8 @@ class UnifiedComponentData(Struct):
     destination: str | None = None
     title: UnifiedText | None = None
     subtitle: UnifiedText | None = None
+    description: str | UnifiedText | None = None
+    summary: str | UnifiedText | None = None
 
 
 class UnifiedComponent(Struct):
@@ -72,6 +74,7 @@ class UnifiedMediaEntity(Struct):
 
 
 class UnifiedCard(Struct):
+    # X unified_card JSON uses string component IDs (for example, "media_1").
     components: list[str] = field(default_factory=list)
     component_objects: dict[str, UnifiedComponent] = field(default_factory=dict)
     destination_objects: dict[str, UnifiedDestination] = field(default_factory=dict)

--- a/src/nonebot_plugin_parser_lite/parsers/x/model.py
+++ b/src/nonebot_plugin_parser_lite/parsers/x/model.py
@@ -13,6 +13,71 @@ class Views(Struct):
     """浏览数"""
 
 
+class CardImage(Struct):
+    url: str = ""
+
+
+class CardValue(Struct):
+    string_value: str | None = None
+    image_value: CardImage | None = None
+
+
+class CardBindingValue(Struct):
+    key: str = ""
+    value: CardValue = field(default_factory=CardValue)
+
+
+class CardLegacy(Struct):
+    name: str = ""
+    url: str = ""
+    binding_values: list[CardBindingValue] = field(default_factory=list)
+
+
+class TweetCard(Struct):
+    legacy: CardLegacy | None = None
+
+
+class UnifiedText(Struct):
+    content: str = ""
+
+
+class UnifiedComponentData(Struct):
+    id: str | None = None
+    destination: str | None = None
+    title: UnifiedText | None = None
+    subtitle: UnifiedText | None = None
+
+
+class UnifiedComponent(Struct):
+    type: str = ""
+    data: UnifiedComponentData = field(default_factory=UnifiedComponentData)
+
+
+class UnifiedUrlData(Struct):
+    url: str = ""
+    vanity: str | None = None
+
+
+class UnifiedDestinationData(Struct):
+    url_data: UnifiedUrlData | None = None
+
+
+class UnifiedDestination(Struct):
+    type: str = ""
+    data: UnifiedDestinationData = field(default_factory=UnifiedDestinationData)
+
+
+class UnifiedMediaEntity(Struct):
+    media_url_https: str = ""
+
+
+class UnifiedCard(Struct):
+    components: list[str] = field(default_factory=list)
+    component_objects: dict[str, UnifiedComponent] = field(default_factory=dict)
+    destination_objects: dict[str, UnifiedDestination] = field(default_factory=dict)
+    media_entities: dict[str, UnifiedMediaEntity] = field(default_factory=dict)
+
+
 class VideoVariant(Struct):
     content_type: str
     """视频编码类型，如 'video/mp4' 或 'application/x-mpegURL'"""
@@ -160,6 +225,41 @@ class TweetCore(Struct):
     user_results: UserResult
 
 
+class NoteTweetResult(Struct):
+    text: str = ""
+
+
+class NoteTweetResults(Struct):
+    result: NoteTweetResult | None = None
+
+
+class NoteTweet(Struct):
+    note_tweet_results: NoteTweetResults | None = None
+
+
+class ArticleMediaInfo(Struct):
+    original_img_url: str = ""
+
+
+class ArticleCoverMedia(Struct):
+    media_info: ArticleMediaInfo | None = None
+
+
+class ArticleResult(Struct):
+    title: str = ""
+    preview_text: str = ""
+    rest_id: str = ""
+    cover_media: ArticleCoverMedia | None = None
+
+
+class ArticleResults(Struct):
+    result: ArticleResult | None = None
+
+
+class Article(Struct):
+    article_results: ArticleResults | None = None
+
+
 class Tweet(Struct):
     core: TweetCore
     legacy: TweetLegacy
@@ -167,10 +267,57 @@ class Tweet(Struct):
     views: Views
     rest_id: str
     """推文id"""
+    card: TweetCard | None = None
+    """推文链接卡片"""
+    note_tweet: NoteTweet | None = None
+    """长文本推文结构"""
+    article: Article | None = None
+    """X Article 结构，按普通正文处理"""
     quoted_status_result: TweetEntry | None = None
     """被引用推文(转发时说话了)"""
     retweeted_status_result: TweetEntry | None = None
     """被转发推文(直接转发啥都没说,正文RT @开头)"""
+
+    @property
+    def text(self) -> str:
+        """完整正文，优先使用 note_tweet / Article 内容"""
+        note_results = self.note_tweet.note_tweet_results if self.note_tweet else None
+        note_result = note_results.result if note_results else None
+        if note_result and note_result.text:
+            return note_result.text
+
+        if article_result := self._article_result:
+            if parts := [
+                value
+                for value in (
+                    article_result.title,
+                    article_result.preview_text,
+                )
+                if value
+            ]:
+                article_text = "\n\n".join(parts)
+                return (
+                    f"{self.legacy.text}\n\n{article_text}"
+                    if self.legacy.text
+                    else article_text
+                )
+
+        return self.legacy.text
+
+    @property
+    def _article_result(self) -> ArticleResult | None:
+        article_results = self.article.article_results if self.article else None
+        return article_results.result if article_results else None
+
+    @property
+    def article_cover_url(self) -> str | None:
+        """Article 封面"""
+        result = self._article_result
+        cover_media = result.cover_media if result else None
+        media_info = cover_media.media_info if cover_media else None
+        if media_info and media_info.original_img_url:
+            return media_info.original_img_url
+        return None
 
 
 class TweetData(Struct):
@@ -182,6 +329,9 @@ class TweetData(Struct):
     legacy: TweetLegacy | None = None
     views: Views | None = None
     rest_id: str | None = None
+    card: TweetCard | None = None
+    note_tweet: NoteTweet | None = None
+    article: Article | None = None
     quoted_status_result: TweetEntry | None = None
     retweeted_status_result: TweetEntry | None = None
 
@@ -199,6 +349,9 @@ class TweetData(Struct):
             legacy=self.legacy,
             views=self.views,
             rest_id=self.rest_id,
+            card=self.card,
+            note_tweet=self.note_tweet,
+            article=self.article,
             quoted_status_result=self.quoted_status_result,
             retweeted_status_result=self.retweeted_status_result,
         )

--- a/src/nonebot_plugin_parser_lite/parsers/x/util.py
+++ b/src/nonebot_plugin_parser_lite/parsers/x/util.py
@@ -1,0 +1,118 @@
+from dataclasses import dataclass
+
+from msgspec import DecodeError
+from msgspec.json import decode
+
+from .model import CardValue, TweetCard, UnifiedCard
+
+
+@dataclass(frozen=True, slots=True)
+class LinkCardData:
+    url: str
+    title: str
+    site_name: str | None = None
+    description: str | None = None
+    preview_url: str | None = None
+
+
+def _binding_values(card: TweetCard) -> dict[str, CardValue]:
+    if card.legacy is None:
+        return {}
+    return {item.key: item.value for item in card.legacy.binding_values if item.key}
+
+
+def _decode_unified(card: TweetCard) -> UnifiedCard | None:
+    for key, value in _binding_values(card).items():
+        if key != "unified_card" or value.string_value is None:
+            continue
+        raw = value.string_value
+        if not raw:
+            return None
+        try:
+            return decode(raw, type=UnifiedCard)
+        except (DecodeError, TypeError):
+            return None
+    return None
+
+
+def _unified_data(card: UnifiedCard) -> LinkCardData | None:
+    url_data = next(
+        (
+            destination.data.url_data
+            for destination in card.destination_objects.values()
+            if destination.type == "browser" and destination.data.url_data
+        ),
+        None,
+    )
+    if not url_data or not url_data.url:
+        return None
+
+    title = site_name = preview_url = None
+    for component_name in card.components:
+        component = card.component_objects.get(component_name)
+        if component is None:
+            continue
+        data = component.data
+        if component.type == "details":
+            title = data.title.content if data.title and data.title.content else title
+            site_name = (
+                data.subtitle.content
+                if data.subtitle and data.subtitle.content
+                else site_name
+            )
+        elif component.type == "media" and data.id:
+            media = card.media_entities.get(data.id)
+            if media and media.media_url_https:
+                preview_url = media.media_url_https
+
+    return LinkCardData(
+        url=url_data.url,
+        title=title or site_name or url_data.url,
+        site_name=site_name or url_data.vanity,
+        preview_url=preview_url,
+    )
+
+
+def _legacy_data(card: TweetCard) -> LinkCardData | None:
+    if card.legacy is None:
+        return None
+    values = _binding_values(card)
+
+    def string_value(key: str) -> str | None:
+        value = values.get(key)
+        text = value.string_value if value else None
+        return text if isinstance(text, str) and text else None
+
+    def image_url(*keys: str) -> str | None:
+        for key in keys:
+            value = values.get(key)
+            image = value.image_value if value else None
+            url = image.url if image else None
+            if isinstance(url, str) and url:
+                return url
+        return None
+
+    url = string_value("card_url") or card.legacy.url
+    if not url:
+        return None
+    return LinkCardData(
+        url=url,
+        title=string_value("title") or url,
+        site_name=string_value("vanity_url") or string_value("domain"),
+        description=string_value("description"),
+        preview_url=image_url(
+            "thumbnail_image_large",
+            "thumbnail_image",
+            "player_image_large",
+            "player_image",
+            "photo_image_full_size_large",
+            "photo_image_full_size",
+        ),
+    )
+
+
+def parse_link_card(card: TweetCard | None) -> LinkCardData | None:
+    if card is None:
+        return None
+    unified = _decode_unified(card)
+    return _unified_data(unified) if unified is not None else _legacy_data(card)

--- a/src/nonebot_plugin_parser_lite/parsers/x/util.py
+++ b/src/nonebot_plugin_parser_lite/parsers/x/util.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 from msgspec import DecodeError
 from msgspec.json import decode
 
-from .model import CardValue, TweetCard, UnifiedCard
+from .model import CardValue, TweetCard, UnifiedCard, UnifiedText
 
 
 @dataclass(frozen=True, slots=True)
@@ -22,16 +22,18 @@ def _binding_values(card: TweetCard) -> dict[str, CardValue]:
 
 
 def _decode_unified(card: TweetCard) -> UnifiedCard | None:
-    for key, value in _binding_values(card).items():
-        if key != "unified_card" or value.string_value is None:
+    if card.legacy is None:
+        return None
+    for binding in card.legacy.binding_values:
+        if binding.key != "unified_card" or binding.value.string_value is None:
             continue
-        raw = value.string_value
+        raw = binding.value.string_value
         if not raw:
-            return None
+            continue
         try:
             return decode(raw, type=UnifiedCard)
         except (DecodeError, TypeError):
-            return None
+            continue
     return None
 
 
@@ -47,18 +49,25 @@ def _unified_data(card: UnifiedCard) -> LinkCardData | None:
     if not url_data or not url_data.url:
         return None
 
-    title = site_name = preview_url = None
+    title = site_name = description = preview_url = None
+
+    def text_content(value: str | UnifiedText | None) -> str | None:
+        if isinstance(value, UnifiedText):
+            return value.content or None
+        return value or None
+
     for component_name in card.components:
         component = card.component_objects.get(component_name)
         if component is None:
             continue
         data = component.data
         if component.type == "details":
-            title = data.title.content if data.title and data.title.content else title
-            site_name = (
-                data.subtitle.content
-                if data.subtitle and data.subtitle.content
-                else site_name
+            title = text_content(data.title) or title
+            site_name = text_content(data.subtitle) or site_name
+            description = (
+                text_content(data.description)
+                or text_content(data.summary)
+                or description
             )
         elif component.type == "media" and data.id:
             media = card.media_entities.get(data.id)
@@ -69,6 +78,7 @@ def _unified_data(card: UnifiedCard) -> LinkCardData | None:
         url=url_data.url,
         title=title or site_name or url_data.url,
         site_name=site_name or url_data.vanity,
+        description=description,
         preview_url=preview_url,
     )
 


### PR DESCRIPTION
## Summary by Sourcery

扩展 X 推文解析，以支持富链接卡片和文章式内容，并将推文结果提取工具进行集中管理。

新功能：
- 从推文的卡片结构中解析并暴露 X 链接卡片数据，并将其转换为链接内容项。
- 支持长文本推文和 X Articles，通过优先使用 note 或 article 内容而不是传统文本，并在可用时附加文章封面图像。

增强点：
- 将推文结果提取辅助函数重构为模块级函数，并在 X 解析器中复用它们。
- 在 X 解析器的构造函数中初始化共享 HTTP 头信息，而不是在每次请求时进行合并。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Extend X tweet parsing to support rich link cards and article-style content, and centralize tweet result extraction utilities.

New Features:
- Parse and expose X link card data from tweet card structures and convert them into link content items.
- Support long-text tweets and X Articles by preferring note or article content over legacy text and attaching article cover images where available.

Enhancements:
- Refactor tweet result extraction helpers into module-level functions and reuse them in the X parser.
- Initialize shared HTTP headers in the X parser constructor instead of per-request merging.

</details>