### PR TITLE
fix(render-text): 修复可发送文本被多次追加作者前缀的问题

### DIFF
--- a/src/nonebot_plugin_parser_lite/render/__init__.py
+++ b/src/nonebot_plugin_parser_lite/render/__init__.py
@@ -120,22 +120,26 @@ class _ForwardText:
 
     author_name: str
     parts: list[_ForwardTextPart]
+    include_author: bool = True
     text_length: int = field(init=False)
 
     def __post_init__(self) -> None:
-        self.text_length = (
-            len(self.author_name) + 1 + sum(len(part.text) for part in self.parts)
-        )
+        prefix_length = len(self.author_name) + 1 if self.include_author else 0
+        self.text_length = prefix_length + sum(len(part.text) for part in self.parts)
+
+    @property
+    def prefix(self) -> str:
+        return f"{self.author_name}：" if self.include_author else ""
 
     @property
     def text(self) -> str:
-        return f"{self.author_name}：{''.join(part.text for part in self.parts)}"
+        return f"{self.prefix}{''.join(part.text for part in self.parts)}"
 
     def split(self, max_len: int) -> list[str]:
         if max_len <= 0 or self.text_length <= max_len:
             return [self.text]
 
-        prefix = f"{self.author_name}："
+        prefix = self.prefix
         chunks: list[str] = []
         current = prefix
 
@@ -404,11 +408,19 @@ class Renderer:
             author_name = pr.author.name
             nodes: list[ForwardNodeInner | _ForwardText] = []
             text_buffer: list[_ForwardTextPart] = []
+            author_prefix_pending = True
 
             async def flush_text() -> None:
-                nonlocal text_buffer
+                nonlocal author_prefix_pending, text_buffer
                 if text_buffer:
-                    nodes.append(_ForwardText(author_name, text_buffer))
+                    nodes.append(
+                        _ForwardText(
+                            author_name,
+                            text_buffer,
+                            include_author=author_prefix_pending,
+                        )
+                    )
+                    author_prefix_pending = False
                     text_buffer = []
 
             def append_text(text: str) -> None:
@@ -484,6 +496,9 @@ class Renderer:
                     await flush_text()
                     await append_media(item)
                 elif isinstance(item, LinkContent):
+                    await flush_text()
+                    if preview := await item.get_preview_path():
+                        nodes.append(await UniHelper.img_seg(file=preview))
                     append_text(item.url)
                 elif isinstance(item, QuoteContent):
                     quote_parts = [part for part in (item.title, item.text) if part]

--- a/src/nonebot_plugin_parser_lite/render/__init__.py
+++ b/src/nonebot_plugin_parser_lite/render/__init__.py
@@ -124,8 +124,7 @@ class _ForwardText:
     text_length: int = field(init=False)
 
     def __post_init__(self) -> None:
-        prefix_length = len(self.author_name) + 1 if self.include_author else 0
-        self.text_length = prefix_length + sum(len(part.text) for part in self.parts)
+        self.text_length = len(self.prefix) + sum(len(part.text) for part in self.parts)
 
     @property
     def prefix(self) -> str:


### PR DESCRIPTION
新增 include_author 参数来控制是否显示消息发送者姓名前缀， 优化了 ForwardText 类的文本长度计算逻辑并添加了 prefix 属性。

## Summary by Sourcery

防止在渲染转发文本消息时出现重复的作者前缀，并改进对链接预览和文本长度计算的处理。

Bug 修复：
- 确保在可发送的转发文本消息中，作者名前缀只添加一次。

增强功能：
- 为 `ForwardText` 新增 `include_author` 标志和 `prefix` 属性，用于在渲染时控制和复用作者前缀。
- 优化 `ForwardText` 的文本长度计算，以便将可选的作者前缀纳入考虑。
- 在渲染链接内容之前刷新缓冲文本，并在可用时为链接附加图片预览。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Prevent duplicate author prefixes in rendered forward text messages and improve handling of link previews and text length calculation.

Bug Fixes:
- Ensure the author name prefix is only added once to sendable forward text messages.

Enhancements:
- Add an include_author flag and prefix property to ForwardText to control and reuse the author prefix when rendering.
- Refine ForwardText text length computation to account for optional author prefixes.
- Flush buffered text before rendering link content and attach image previews for links when available.

</details>