### PR TITLE
feat(render): 现在不再会提前初始化 cover_path 字段

### DIFF
--- a/src/nonebot_plugin_parser_lite/render/__init__.py
+++ b/src/nonebot_plugin_parser_lite/render/__init__.py
@@ -603,7 +603,6 @@ class Renderer:
             "extra": result.extra,
             "platform": result.platform,
             "content": result.content,
-            "cover_path": await safe_src(result, "get_cover_path"),
             "stats": result.stats,
             "comments": result.comments[: pconfig.max_comments],
             "author": result.author,

--- a/src/nonebot_plugin_parser_lite/render/templates/music.html.jinja
+++ b/src/nonebot_plugin_parser_lite/render/templates/music.html.jinja
@@ -15,7 +15,7 @@
             {% endif %}
             <div class="mb-6 flex items-start gap-5 pr-[100px] max-[600px]:pr-20">
                 {% if result.cover_path %}
-                    <img src="{{ result.cover_path }}"
+                    <img src="{{ result | safe_src('get_cover_path') }}"
                          alt="专辑封面"
                          class="h-[150px] w-[150px] shrink-0 rounded-lg object-cover max-[600px]:h-[120px] max-[600px]:w-[120px]" />
                 {% endif %}

--- a/src/nonebot_plugin_parser_lite/render/templates/music.html.jinja
+++ b/src/nonebot_plugin_parser_lite/render/templates/music.html.jinja
@@ -14,8 +14,9 @@
                      class="absolute top-6 right-6 h-20 w-20 max-[600px]:h-[60px] max-[600px]:w-[60px]" />
             {% endif %}
             <div class="mb-6 flex items-start gap-5 pr-[100px] max-[600px]:pr-20">
-                {% if result.cover_path %}
-                    <img src="{{ result | safe_src('get_cover_path') }}"
+                {% set cover_src = result | safe_src('get_cover_path', return_none_on_fail=True) %}
+                {% if cover_src %}
+                    <img src="{{ cover_src }}"
                          alt="专辑封面"
                          class="h-[150px] w-[150px] shrink-0 rounded-lg object-cover max-[600px]:h-[120px] max-[600px]:w-[120px]" />
                 {% endif %}


### PR DESCRIPTION
移除了Renderer类中的cover_path字段，改为在模板中使用safe_src过滤器 来获取封面路径，提高安全性并优化代码结构

BREAKING CHANGE: cover_path字段不再包含在渲染结果中

## Summary by Sourcery

在渲染结果中停止包含预先计算的 `cover_path`，并在模板中使用 `safe_src` 直接解析音乐封面 URL。

New Features:
- 在模板中通过 `safe_src` 过滤器解析音乐封面图片 URL，而不是使用单独的 `cover_path` 字段。

Enhancements:
- 通过从已解析的渲染数据中移除 `cover_path` 字段来简化解析结果的载荷。

Chores:
- 引入一个破坏性变更：渲染结果中不再包含 `cover_path`，使用方应改为使用基于 `safe_src` 的解析方式。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Stop including precomputed cover_path in render results and resolve music cover URLs directly in the template using safe_src.

New Features:
- Resolve music cover image URL in the template via the safe_src filter instead of a dedicated cover_path field.

Enhancements:
- Simplify parse result payload by removing the cover_path field from resolved render data.

Chores:
- Introduce a breaking change where cover_path is no longer present in rendered results and consumers should use safe_src-based resolution instead.

</details>