### PR TITLE
fix(douyin-music): 修复错误将作品原声提取的问题

### DIFF
--- a/src/nonebot_plugin_parser_lite/parsers/douyin/aweme.py
+++ b/src/nonebot_plugin_parser_lite/parsers/douyin/aweme.py
@@ -64,6 +64,7 @@ class Music(Struct):
     mid: str
     play_url: MusicPlayUrl
     extra: str
+    is_original_sound: bool
 
 
 class ShareInfo(Struct):
@@ -94,20 +95,21 @@ class Aweme(Struct):
         aweme_cache_key = f"douyin:{self.aweme_id}"
         music_url: str | None = None
         if music := self.music:
-            if music.play_url.uri == "":
-                extra = ujson.loads(music.extra)
-                music_url = extra.get("original_song_url")
-            else:
-                music_url = music.play_url.uri
-            if music_url:
-                content.append(
-                    Creator.audio(
-                        url_or_task=music_url,
-                        duration=music.duration,
-                        cache_key=f"douyin:{music.mid}",
-                        ext_headers={"Referer": "https://www.douyin.com/"},
+            if not music.is_original_sound:
+                if music.play_url.uri == "":
+                    extra = ujson.loads(music.extra)
+                    music_url = extra.get("original_song_url")
+                else:
+                    music_url = music.play_url.uri
+                if music_url:
+                    content.append(
+                        Creator.audio(
+                            url_or_task=music_url,
+                            duration=music.duration,
+                            cache_key=f"douyin:{music.mid}",
+                            ext_headers={"Referer": "https://www.douyin.com/"},
+                        )
                     )
-                )
         if self.images:
             for image in self.images:
                 image_cache_key = (


### PR DESCRIPTION
- 新增 `is_original_sound` 字段用于标识抖音视频的作品原声音乐状态
- 修改音频URL获取逻辑，仅当非作品原声时才尝试获取音频链接
- 避免对作品原声进行不必要的音频提取操作

## Summary by Sourcery

防止为原声抖音视频提取音频，并添加元数据以追踪原声状态。

新功能：
- 在抖音音乐元数据中添加 `is_original_sound` 标记，用于指示是否为原声。

错误修复：
- 当抖音视频的音乐被标记为原声时，跳过音频 URL 解析和提取，以避免错误的音频处理。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Guard against extracting audio for original-sound Douyin videos and add metadata to track original sound status.

New Features:
- Add is_original_sound flag to Douyin music metadata to indicate original-sound status.

Bug Fixes:
- Skip audio URL resolution and extraction when a Douyin video's music is marked as original sound to avoid incorrect audio handling.

</details>