### PR TITLE
feat(download): 强制 identity 编码并增强断点续传健壮性

### DIFF
--- a/src/nonebot_plugin_parser_lite/download/__init__.py
+++ b/src/nonebot_plugin_parser_lite/download/__init__.py
@@ -42,6 +42,17 @@ _CONTENT_TYPE_SUFFIX_OVERRIDES = {
 }
 
 
+def _with_identity_encoding(headers: dict[str, str]) -> dict[str, str]:
+    """让文件长度、Content-Length 与 Range 使用同一字节坐标系。"""
+    result = {
+        key: value
+        for key, value in headers.items()
+        if key.lower() != "accept-encoding"
+    }
+    result["Accept-Encoding"] = "identity"
+    return result
+
+
 def _resolve_suffix(
     url: str,
     content_type: str | None,
@@ -92,7 +103,7 @@ class StreamDownloader:
         :return: UniResponse 对象
         :raise HTTPStatusError: HEAD 与 GET 均非 2xx 时抛出
         """
-        headers = {**self.headers, **(ext_headers or {})}
+        headers = _with_identity_encoding({**self.headers, **(ext_headers or {})})
         resp = await self.client.head(
             url=url,
             headers=headers,
@@ -161,7 +172,7 @@ class StreamDownloader:
         base_path = cache_dir / cache_name
         partial_path = cache_dir / f"{cache_name}.part"
 
-        headers = {**self.headers, **(ext_headers or {})}
+        headers = _with_identity_encoding({**self.headers, **(ext_headers or {})})
         download_key = str(base_path)
         active_download = self._active_downloads.get(download_key)
         if active_download is not None:
@@ -244,19 +255,27 @@ class StreamDownloader:
         ) from last_error
 
     def __validate_response(self, response: UniResponse, downloaded: int):
+        if downloaded > 0 and response.status_code == 416:
+            raise RetryableDownloadError(
+                "断点位置无效，重新完整下载", keep_part=False
+            )
         response.raise_for_status()
         if downloaded > 0:
             if response.status_code != 206:
                 raise RetryableDownloadError("服务器不支持断点续传", keep_part=False)
-            if content_range := response.headers.get("content-range"):
-                if match := _RE_RANGE_PATTERN.match(content_range):
-                    server_start = int(match[1])
+            content_range = response.headers.get("content-range")
+            match = _RE_RANGE_PATTERN.fullmatch(content_range or "")
+            if match is None:
+                raise RetryableDownloadError(
+                    "服务器未返回有效的 Content-Range", keep_part=False
+                )
 
-                    if server_start != downloaded:
-                        raise DownloadException(
-                            f"Content-Range 错误: 请求 {downloaded}, "
-                            f"返回 {server_start}"
-                        )
+            server_start = int(match[1])
+            if server_start != downloaded:
+                raise RetryableDownloadError(
+                    f"Content-Range 错误: 请求 {downloaded}, 返回 {server_start}",
+                    keep_part=False,
+                )
 
     def __make_range_headers(
         self, headers: dict[str, str], downloaded: int
@@ -282,7 +301,23 @@ class StreamDownloader:
             use_curl_cffi=use_curl_cffi,
         ) as response:
             self.__validate_response(response, downloaded)
-            content_length = response.headers.get("content-length")
+            content_encoding = (
+                response.headers.get("content-encoding") or ""
+            ).strip().lower()
+            transfer_encoded = content_encoding not in ("", "identity")
+
+            if downloaded > 0 and transfer_encoded:
+                raise RetryableDownloadError(
+                    f"压缩响应 {content_encoding!r} 无法安全断点续传",
+                    keep_part=False,
+                )
+
+            # 编码响应的 Content-Length 是压缩传输体大小，而 aiter_bytes()
+            # 返回解码后的文件内容，不能用前者校验后者。正常情况下
+            # Accept-Encoding: identity 会避免进入此兼容分支。
+            content_length = (
+                None if transfer_encoded else response.headers.get("content-length")
+            )
             content_type = response.headers.get("content-type")
 
             total_size = (
@@ -347,10 +382,11 @@ class StreamDownloader:
             if total_size is not None and final_size != total_size:
                 size_diff = abs(final_size - total_size)
                 if size_diff > self._SIZE_MISMATCH_TOLERANCE_BYTES:
-                    raise DownloadException(
+                    raise RetryableDownloadError(
                         f"文件大小不匹配: {final_size}/{total_size} "
                         f"(差值: {size_diff} bytes, 超过允许的 "
-                        f"{self._SIZE_MISMATCH_TOLERANCE_BYTES} bytes)"
+                        f"{self._SIZE_MISMATCH_TOLERANCE_BYTES} bytes)",
+                        keep_part=final_size < total_size,
                     )
             return content_type
 

--- a/src/nonebot_plugin_parser_lite/download/__init__.py
+++ b/src/nonebot_plugin_parser_lite/download/__init__.py
@@ -53,6 +53,15 @@ def _with_identity_encoding(headers: dict[str, str]) -> dict[str, str]:
     return result
 
 
+def _parse_content_encodings(value: str | None) -> tuple[str, ...]:
+    """解析 Content-Encoding 编码链，忽略空标记并统一大小写。"""
+    return tuple(
+        encoding
+        for token in (value or "").split(",")
+        if (encoding := token.strip().lower())
+    )
+
+
 def _resolve_suffix(
     url: str,
     content_type: str | None,
@@ -301,14 +310,16 @@ class StreamDownloader:
             use_curl_cffi=use_curl_cffi,
         ) as response:
             self.__validate_response(response, downloaded)
-            content_encoding = (
-                response.headers.get("content-encoding") or ""
-            ).strip().lower()
-            transfer_encoded = content_encoding not in ("", "identity")
+            content_encodings = _parse_content_encodings(
+                response.headers.get("content-encoding")
+            )
+            transfer_encoded = any(
+                encoding != "identity" for encoding in content_encodings
+            )
 
             if downloaded > 0 and transfer_encoded:
                 raise RetryableDownloadError(
-                    f"压缩响应 {content_encoding!r} 无法安全断点续传",
+                    f"压缩响应 {', '.join(content_encodings)!r} 无法安全断点续传",
                     keep_part=False,
                 )
 

--- a/src/nonebot_plugin_parser_lite/download/client.py
+++ b/src/nonebot_plugin_parser_lite/download/client.py
@@ -136,7 +136,7 @@ class UniResponse:
         except DecodingError as e:
             # Content-Encoding 解码失败后，本地文件与远端 Range 的字节坐标
             # 不再具备可比性，不能保留断点继续追加。
-            raise RetryableDownloadError(e.__repr__(), keep_part=False) from e
+            raise RetryableDownloadError(str(e), keep_part=False) from e
         except (TransportError, RequestException) as e:
             raise RetryableDownloadError(e.__repr__()) from e
 

--- a/src/nonebot_plugin_parser_lite/download/client.py
+++ b/src/nonebot_plugin_parser_lite/download/client.py
@@ -8,7 +8,7 @@ from typing import Any, Literal
 from curl_cffi import AsyncSession
 from curl_cffi import Response as CurlResponse
 from curl_cffi.requests.exceptions import RequestException
-from httpx import AsyncClient, Timeout, TransportError, codes
+from httpx import AsyncClient, DecodingError, Timeout, TransportError, codes
 from httpx import Response as HttpxResponse
 
 from ..exception import ParseException
@@ -133,6 +133,10 @@ class UniResponse:
             else:
                 async for chunk in self._raw.aiter_content():
                     yield chunk
+        except DecodingError as e:
+            # Content-Encoding 解码失败后，本地文件与远端 Range 的字节坐标
+            # 不再具备可比性，不能保留断点继续追加。
+            raise RetryableDownloadError(e.__repr__(), keep_part=False) from e
         except (TransportError, RequestException) as e:
             raise RetryableDownloadError(e.__repr__()) from e
 

--- a/tests/test_downloader_content_encoding.py
+++ b/tests/test_downloader_content_encoding.py
@@ -1,0 +1,358 @@
+from contextlib import asynccontextmanager
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+import sys
+from types import ModuleType, SimpleNamespace
+
+from httpx import DecodingError, Request, Timeout
+import pytest
+
+ROOT = Path(__file__).parents[1]
+SOURCE = ROOT / "src/nonebot_plugin_parser_lite"
+TEST_PACKAGE = "_parser_lite_downloader_test"
+
+
+class AsyncPathStub:
+    """只供下载器单元测试使用，避免依赖 anyio 的工作线程。"""
+
+    def __init__(self, path):
+        self._path = Path(path)
+
+    def __fspath__(self):
+        return str(self._path)
+
+    def __str__(self):
+        return str(self._path)
+
+    def __truediv__(self, child):
+        return type(self)(self._path / child)
+
+    @property
+    def parent(self):
+        return type(self)(self._path.parent)
+
+    @property
+    def name(self):
+        return self._path.name
+
+    async def exists(self):
+        return self._path.exists()
+
+    async def mkdir(self, *, parents=False, exist_ok=False):
+        self._path.mkdir(parents=parents, exist_ok=exist_ok)
+
+    async def rename(self, target):
+        self._path.rename(Path(target))
+
+    async def stat(self):
+        return self._path.stat()
+
+    async def unlink(self, *, missing_ok=False):
+        self._path.unlink(missing_ok=missing_ok)
+
+    async def read_bytes(self):
+        return self._path.read_bytes()
+
+    def with_suffix(self, suffix):
+        return type(self)(self._path.with_suffix(suffix))
+
+
+class AsyncFileStub:
+    """aiofiles.open 的同步测试替身。"""
+
+    def __init__(self, path, mode):
+        self._file = open(Path(path), mode)
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, traceback):
+        self._file.close()
+
+    async def write(self, data):
+        return self._file.write(data)
+
+
+def _module(name: str, **attrs):
+    module = ModuleType(name)
+    for key, value in attrs.items():
+        setattr(module, key, value)
+    sys.modules[name] = module
+    return module
+
+
+def _load_module(name: str, path: Path):
+    spec = spec_from_file_location(name, path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def downloader_modules(tmp_path):
+    for name in list(sys.modules):
+        if name == TEST_PACKAGE or name.startswith(f"{TEST_PACKAGE}."):
+            sys.modules.pop(name)
+
+    package = _module(TEST_PACKAGE)
+    package.__path__ = [str(SOURCE)]
+
+    class ParseException(Exception):
+        pass
+
+    class DownloadException(ParseException):
+        pass
+
+    class SizeLimitException(DownloadException):
+        pass
+
+    class ZeroSizeException(DownloadException):
+        pass
+
+    _module(
+        f"{TEST_PACKAGE}.exception",
+        ParseException=ParseException,
+        DownloadException=DownloadException,
+        SizeLimitException=SizeLimitException,
+        ZeroSizeException=ZeroSizeException,
+    )
+
+    pconfig = SimpleNamespace(
+        max_retries=2,
+        cache_dir=AsyncPathStub(tmp_path),
+        max_size=10,
+    )
+    _module(f"{TEST_PACKAGE}.config", pconfig=pconfig)
+    _module(
+        f"{TEST_PACKAGE}.constants",
+        COMMON_HEADER={"User-Agent": "downloader-test"},
+        DOWNLOAD_TIMEOUT=Timeout(1.0),
+    )
+
+    utils = _module(f"{TEST_PACKAGE}.utils")
+    utils.__path__ = []
+
+    class CacheManager:
+        MEDIA = "media"
+
+        @classmethod
+        async def ensure_dir(cls, cache_type):
+            path = pconfig.cache_dir / cache_type
+            await path.mkdir(parents=True, exist_ok=True)
+            return path
+
+        @classmethod
+        async def get_cached_file(cls, _base_path):
+            return None
+
+        @classmethod
+        async def set_cached_file(cls, _base_path, _file_path):
+            return None
+
+    async def safe_unlink(path):
+        await path.unlink(missing_ok=True)
+
+    _module(f"{TEST_PACKAGE}.utils.cache", CacheManager=CacheManager)
+    _module(
+        f"{TEST_PACKAGE}.utils.common",
+        compose_cache_key=lambda *parts: ":".join(str(part) for part in parts),
+        generate_file_name=lambda _url, cache_key=None: cache_key or "download",
+        safe_unlink=safe_unlink,
+    )
+    _module(f"{TEST_PACKAGE}.utils.ffmpeg", FFmpeg=object)
+
+    download_name = f"{TEST_PACKAGE}.download"
+    download_path = SOURCE / "download"
+    download_spec = spec_from_file_location(
+        download_name,
+        download_path / "__init__.py",
+        submodule_search_locations=[str(download_path)],
+    )
+    assert download_spec is not None
+    assert download_spec.loader is not None
+    download = module_from_spec(download_spec)
+    sys.modules[download_name] = download
+
+    client = _load_module(f"{download_name}.client", download_path / "client.py")
+    _load_module(f"{download_name}.task", download_path / "task.py")
+    download_spec.loader.exec_module(download)
+    download.aiofiles = SimpleNamespace(open=AsyncFileStub)
+
+    yield download, client, CacheManager
+
+    for name in list(sys.modules):
+        if name == TEST_PACKAGE or name.startswith(f"{TEST_PACKAGE}."):
+            sys.modules.pop(name)
+
+
+class FakeResponse:
+    def __init__(self, status_code, *, headers=None, chunks=()):
+        self.status_code = status_code
+        self.headers = {key.lower(): value for key, value in (headers or {}).items()}
+        self._chunks = list(chunks)
+
+    def raise_for_status(self):
+        if not 200 <= self.status_code < 300:
+            raise RuntimeError(f"HTTP {self.status_code}")
+
+    async def aiter_bytes(self, _chunk_size=None):
+        for chunk in self._chunks:
+            yield chunk
+
+
+class FakeClient:
+    def __init__(self, responses):
+        self.responses = list(responses)
+        self.requests = []
+
+    @asynccontextmanager
+    async def stream(self, method, url, *, headers, use_curl_cffi=False):
+        self.requests.append(
+            {
+                "method": method,
+                "url": url,
+                "headers": dict(headers),
+                "use_curl_cffi": use_curl_cffi,
+            }
+        )
+        yield self.responses.pop(0)
+
+
+def _new_downloader(download, client):
+    downloader = object.__new__(download.StreamDownloader)
+    downloader.headers = {
+        "User-Agent": "downloader-test",
+        "accept-encoding": "gzip, deflate, br",
+    }
+    downloader.client = client
+    downloader._active_downloads = {}
+    return downloader
+
+
+async def _download_image(downloader, cache_manager):
+    return await downloader.streamd(
+        url="https://cdn.example/image.webp",
+        cache_key="image",
+        default_suffix=".webp",
+        cache_type=cache_manager.MEDIA,
+    )
+
+
+@pytest.mark.asyncio
+async def test_file_download_forces_identity_encoding(downloader_modules):
+    download, _, cache_manager = downloader_modules
+    client = FakeClient(
+        [FakeResponse(200, headers={"Content-Length": "4"}, chunks=[b"webp"])]
+    )
+    downloader = _new_downloader(download, client)
+
+    path = await _download_image(downloader, cache_manager)
+
+    assert await path.read_bytes() == b"webp"
+    assert client.requests[0]["headers"]["Accept-Encoding"] == "identity"
+    assert "accept-encoding" not in client.requests[0]["headers"]
+
+
+@pytest.mark.asyncio
+async def test_legacy_part_416_is_removed_and_restarted(
+    downloader_modules, tmp_path
+):
+    download, _, cache_manager = downloader_modules
+    media_dir = tmp_path / cache_manager.MEDIA
+    media_dir.mkdir()
+    (media_dir / "image.part").write_bytes(b"stale-decoded-data")
+    client = FakeClient(
+        [
+            FakeResponse(416),
+            FakeResponse(200, headers={"Content-Length": "5"}, chunks=[b"fresh"]),
+        ]
+    )
+    downloader = _new_downloader(download, client)
+
+    path = await _download_image(downloader, cache_manager)
+
+    assert await path.read_bytes() == b"fresh"
+    assert client.requests[0]["headers"]["Range"] == "bytes=18-"
+    assert "Range" not in client.requests[1]["headers"]
+    assert not (media_dir / "image.part").exists()
+
+
+@pytest.mark.asyncio
+async def test_short_identity_response_resumes_with_matching_range(
+    downloader_modules,
+):
+    download, _, cache_manager = downloader_modules
+    prefix = b"a" * 512
+    remainder = b"b" * 1536
+    client = FakeClient(
+        [
+            FakeResponse(
+                200,
+                headers={"Content-Length": "2048"},
+                chunks=[prefix],
+            ),
+            FakeResponse(
+                206,
+                headers={
+                    "Content-Length": "1536",
+                    "Content-Range": "bytes 512-2047/2048",
+                },
+                chunks=[remainder],
+            ),
+        ]
+    )
+    downloader = _new_downloader(download, client)
+
+    path = await _download_image(downloader, cache_manager)
+
+    assert await path.read_bytes() == prefix + remainder
+    assert client.requests[1]["headers"]["Range"] == "bytes=512-"
+
+
+@pytest.mark.asyncio
+async def test_unexpected_encoded_response_does_not_compare_decoded_length(
+    downloader_modules,
+):
+    download, _, cache_manager = downloader_modules
+    client = FakeClient(
+        [
+            FakeResponse(
+                200,
+                headers={
+                    "Content-Encoding": "gzip",
+                    "Content-Length": "124406",
+                },
+                chunks=[b"decoded-webp"],
+            )
+        ]
+    )
+    downloader = _new_downloader(download, client)
+
+    path = await _download_image(downloader, cache_manager)
+
+    assert await path.read_bytes() == b"decoded-webp"
+
+
+@pytest.mark.asyncio
+async def test_decoding_error_discards_partial_file(downloader_modules, monkeypatch):
+    _, client_module, _ = downloader_modules
+
+    class BrokenHttpxResponse:
+        async def aiter_bytes(self, _chunk_size=None):
+            raise DecodingError(
+                "invalid gzip stream",
+                request=Request("GET", "https://cdn.example/image.webp"),
+            )
+            yield b""  # pragma: no cover
+
+    monkeypatch.setattr(client_module, "HttpxResponse", BrokenHttpxResponse)
+    response = client_module.UniResponse(BrokenHttpxResponse())
+
+    with pytest.raises(client_module.RetryableDownloadError) as exc_info:
+        async for _ in response.aiter_bytes():
+            pass
+
+    assert exc_info.value.keep_part is False

--- a/tests/test_downloader_content_encoding.py
+++ b/tests/test_downloader_content_encoding.py
@@ -280,6 +280,53 @@ async def test_legacy_part_416_is_removed_and_restarted(
     assert not (media_dir / "image.part").exists()
 
 
+@pytest.mark.parametrize(
+    "content_range",
+    [
+        None,
+        "not-a-content-range",
+        "bytes 2-7/10",
+    ],
+    ids=["missing", "malformed", "mismatched-start"],
+)
+@pytest.mark.asyncio
+async def test_invalid_content_range_removes_part_and_restarts_cleanly(
+    downloader_modules, tmp_path, content_range
+):
+    download, _, cache_manager = downloader_modules
+    media_dir = tmp_path / cache_manager.MEDIA
+    media_dir.mkdir()
+    part_path = media_dir / "image.part"
+    part_path.write_bytes(b"partial-data")
+
+    resume_headers = {
+        "Content-Length": "20",
+        "Content-Encoding": "identity",
+    }
+    if content_range is not None:
+        resume_headers["Content-Range"] = content_range
+
+    client = FakeClient(
+        [
+            FakeResponse(
+                206,
+                headers=resume_headers,
+                chunks=[b"must-not-be-appended"],
+            ),
+            FakeResponse(200, headers={"Content-Length": "5"}, chunks=[b"fresh"]),
+        ]
+    )
+    downloader = _new_downloader(download, client)
+
+    path = await _download_image(downloader, cache_manager)
+
+    assert await path.read_bytes() == b"fresh"
+    assert client.requests[0]["headers"]["Range"] == "bytes=12-"
+    assert "Range" not in client.requests[1]["headers"]
+    assert len(client.requests) == 2
+    assert not part_path.exists()
+
+
 @pytest.mark.asyncio
 async def test_short_identity_response_resumes_with_matching_range(
     downloader_modules,
@@ -322,7 +369,7 @@ async def test_unexpected_encoded_response_does_not_compare_decoded_length(
             FakeResponse(
                 200,
                 headers={
-                    "Content-Encoding": "gzip",
+                    "Content-Encoding": "gzip, br",
                     "Content-Length": "124406",
                 },
                 chunks=[b"decoded-webp"],


### PR DESCRIPTION
文件 HEAD 与流式下载统一请求 Accept-Encoding: identity，确保本地文件、Content-Length 与 Range 使用同一字节坐标系。
遗留或无效断点遇到 HTTP 416、无效 Content-Range、压缩响应续传时，安全删除对应 .part 后完整重试。
将 httpx.DecodingError 转换为不可保留断点的可重试下载错误，避免继续追加损坏数据。
超过现有 1 KiB 容差的大小不匹配进入重试；文件较短时保留可安全续传的 identity 断点，文件异常偏大时丢弃断点。
保留 1.3.4 最新缓存键、动态后缀解析和小范围大小容差行为。
新增 identity、416 恢复、合法续传、服务端意外 gzip、解码失败共 5 个回归场景。

## Summary by Sourcery

使可续传下载在处理压缩或无效的 HTTP 响应时更加稳健，同时保持本地文件和范围偏移量在一致的字节坐标体系中。

Bug Fixes（错误修复）:
- 将 HEAD 和流式下载请求统一为使用 identity 编码，使文件大小和范围偏移量基于相同的字节表示。
- 在遇到过期或无效的部分下载、HTTP 416 响应、格式错误的范围元数据、意外的编码响应以及解码失败时安全恢复，通过丢弃不可用的部分文件并重试来保证稳定性。
- 根据既有的容差策略处理下载大小不匹配的情况，同时仅保留仍然安全可续传的部分文件。

Enhancements（增强）:
- 在保持兼容的缓存键、动态后缀和大小容差行为的同时，加强对可续传下载的校验和验证。

Tests（测试）:
- 新增回归测试覆盖 identity 编码、HTTP 416 恢复、有效和无效的范围续传、意外的 gzip 响应以及解码失败场景。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make resumable downloads robust against compressed or invalid HTTP responses while keeping local files and range offsets in a consistent byte coordinate system.

Bug Fixes:
- Align HEAD and streaming download requests on identity encoding so file sizes and range offsets use the same byte representation.
- Recover safely from stale or invalid partial downloads, HTTP 416 responses, malformed range metadata, unexpected encoded responses, and decoding failures by discarding unusable partial files and retrying.
- Handle download size mismatches according to the existing tolerance while preserving only partial files that remain safe to resume.

Enhancements:
- Preserve compatible cache-key, dynamic suffix, and size-tolerance behavior while strengthening resumable-download validation.

Tests:
- Add regression coverage for identity encoding, HTTP 416 recovery, valid and invalid range resumption, unexpected gzip responses, and decoding failures.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

使可续传下载在处理压缩或无效的 HTTP 响应时更加稳健，同时保持本地文件和范围偏移量在一致的字节坐标体系中。

Bug Fixes（错误修复）:
- 将 HEAD 和流式下载请求统一为使用 identity 编码，使文件大小和范围偏移量基于相同的字节表示。
- 在遇到过期或无效的部分下载、HTTP 416 响应、格式错误的范围元数据、意外的编码响应以及解码失败时安全恢复，通过丢弃不可用的部分文件并重试来保证稳定性。
- 根据既有的容差策略处理下载大小不匹配的情况，同时仅保留仍然安全可续传的部分文件。

Enhancements（增强）:
- 在保持兼容的缓存键、动态后缀和大小容差行为的同时，加强对可续传下载的校验和验证。

Tests（测试）:
- 新增回归测试覆盖 identity 编码、HTTP 416 恢复、有效和无效的范围续传、意外的 gzip 响应以及解码失败场景。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make resumable downloads robust against compressed or invalid HTTP responses while keeping local files and range offsets in a consistent byte coordinate system.

Bug Fixes:
- Align HEAD and streaming download requests on identity encoding so file sizes and range offsets use the same byte representation.
- Recover safely from stale or invalid partial downloads, HTTP 416 responses, malformed range metadata, unexpected encoded responses, and decoding failures by discarding unusable partial files and retrying.
- Handle download size mismatches according to the existing tolerance while preserving only partial files that remain safe to resume.

Enhancements:
- Preserve compatible cache-key, dynamic suffix, and size-tolerance behavior while strengthening resumable-download validation.

Tests:
- Add regression coverage for identity encoding, HTTP 416 recovery, valid and invalid range resumption, unexpected gzip responses, and decoding failures.

</details>

</details>