### PR TITLE
fix(douyin/cover): 修复抖音视频封面显示不正确

### DIFF
--- a/src/nonebot_plugin_parser_lite/parsers/douyin/aweme.py
+++ b/src/nonebot_plugin_parser_lite/parsers/douyin/aweme.py
@@ -40,6 +40,7 @@ class Video(Struct):
     duration: int
     """视频时长(/1000)"""
     play_addr: Addr
+    cover_original_scale: UrlList | None = None
 
     @property
     def url(self) -> str:
@@ -138,7 +139,9 @@ class Aweme(Struct):
             content.append(
                 Creator.video(
                     url_or_task=video.play_addr.url,
-                    cover_url=video.cover.url_list[-1],
+                    cover_url=video.cover_original_scale.url_list[-1]
+                    if video.cover_original_scale
+                    else video.cover.url_list[-1],
                     duration=video.duration // 1000,
                     cache_key=aweme_cache_key,
                     ext_headers={"Referer": "https://www.douyin.com/"},


### PR DESCRIPTION
新增 cover_original_scale 字段用于获取抖音视频的原始尺寸封面， 当原始封面可用时优先使用，否则回退到默认封面

## 由 Sourcery 提供的总结

Bug 修复：
- 修复抖音视频封面显示不正确的问题，优先使用原始尺寸封面并在不可用时回退到默认封面。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- 修复抖音视频封面显示不正确的问题，优先使用原始尺寸封面并在不可用时回退到默认封面。

</details>