### PR TITLE
feat(tieba): 贴吧表情使用官方cdn以修复部分表情不显示的问题

### DIFF
--- a/src/nonebot_plugin_parser_lite/parsers/tieba/utils.py
+++ b/src/nonebot_plugin_parser_lite/parsers/tieba/utils.py
@@ -117,7 +117,7 @@ def build_content(posts: Posts) -> list[ContentItem]:
         elif isinstance(part, FragEmoji):
             contents.append(
                 Creator.sticker(
-                    url=STICKER_CDN.format(platform="tieba", name=part.id),
+                    url=f"https://gsp0.baidu.com/5aAHeD3nKhI2p27j8IqW0jdnxx1xbK/tb/editor/images/client/{part.id}.png",
                     size="small",
                     desc=part.desc,
                 )


### PR DESCRIPTION
更新贴吧表情CDN链接为百度贴吧编辑器图片地址， 替换原有的STICKER_CDN格式化链接以确保部分表情能够正常显示

## 由 Sourcery 提供的摘要

使用百度贴吧官方 CDN 提升贴吧表情的显示兼容性。

Bug 修复：
- 修复贴吧部分表情无法正常显示的问题。

改进：
- 改用百度贴吧官方编辑器图片 CDN 加载表情资源。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

使用百度贴吧官方 CDN 提升贴吧表情的显示兼容性。

Bug Fixes:
- 修复贴吧部分表情无法正常显示的问题。

Enhancements:
- 改用百度贴吧官方编辑器图片 CDN 加载表情资源。

</details>